### PR TITLE
fix: correct Modal placement in Firefox

### DIFF
--- a/packages/modals/src/_backdrop.css
+++ b/packages/modals/src/_backdrop.css
@@ -10,7 +10,8 @@
   --zd-backdrop--center__dialog-max-height: calc(100vh - (2 * var(--zd-dialog-margin)));
 }
 
-/* 1. Fix for Firefox dialog .is-open animation. */
+/* 1. Fix for Firefox dialog .is-open animation.
+ * 2. IE11 centering hack. */
 
 .l-backdrop {
   display: flex;
@@ -54,6 +55,14 @@
 .l-backdrop--center .c-dialog {
   margin: 0;
 }
+
+/* stylelint-disable selector-type-no-unknown, selector-no-vendor-prefix */
+_:-ms-input-placeholder, .l-backdrop--center .c-dialog {
+  right: 50%; /* [2] */
+  bottom: 50%; /* [2] */
+  transform: translate(50%, 50%); /* [2] */
+}
+/* stylelint-enable selector-type-no-unknown, selector-no-vendor-prefix */
 
 @custom-media --zd-dialog-viewport-small-height (height < 400px);
 @custom-media --zd-dialog-viewport-small-width (width < 700px);


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "fix(buttons):
     increase specificity for disabled state". the title informs the
     semantic version bump if this PR is merged. -->

- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

When using flexbox within an absolutely positioned container you can get some weirdness with Firefox.

## Detail

This PR makes the dialog `position: fixed;` as well as removing the now unnecessary IE11 transform fix.

Relating to https://github.com/zendeskgarden/react-components/pull/509

I have checked provided examples as well as supported browsers, but please take a closer look. 

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :black_circle: renders as expected in "dark" mode
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :nail_care: provides `custom.css` example for modifying the
  primary accent color
