### PR TITLE
fix(avatars): remove default figure margin

### DIFF
--- a/packages/avatars/src/_base.css
+++ b/packages/avatars/src/_base.css
@@ -11,9 +11,12 @@
   --zd-avatar__img-transition: all .3s;
 }
 
+/* 1. Reset for <figure> element. */
+
 .c-avatar {
   display: inline-block;
   transition: var(--zd-avatar-transition);
+  margin: 0; /* [1] */
   border: var(--zd-avatar-border);
   border-radius: var(--zd-avatar-border-radius);
   width: var(--zd-avatar-size);


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "fix(buttons):
     increase specificity for disabled state". the title informs the
     semantic version bump if this PR is merged. -->

- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

By default the `<figure>` element has a large default margin. This change allows normal visualization even when not using the resets provided by bedrock.

## Detail

Added a `margin: 0` to the base avatar class.

<!-- closes GITHUB_ISSUE -->

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :black_circle: renders as expected in "dark" mode
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
