### PR TITLE
fix(chrome): allow subnav items to be used with buttons

### DIFF
--- a/packages/chrome/src/_subnav.css
+++ b/packages/chrome/src/_subnav.css
@@ -91,6 +91,10 @@
   margin-top: 0;
 }
 
+.c-chrome__subnav__item:active:--chrome-focused {
+  box-shadow: none;
+}
+
 .c-chrome__subnav__item__text {
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "fix(buttons):
     increase specificity for disabled state". the title informs the
     semantic version bump if this PR is merged. -->

- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Currently we only allow the `subnav_item` class to be used with `<a>` tags. This PR adds the necessary resets to also allow `<button>` usage. Similar to commit https://github.com/zendeskgarden/css-components/commit/d1f4f0518f4920b488b076378ef7fe2d56d24cf2

## Detail

Previous:
<img width="349" alt="screen shot 2018-04-01 at 1 25 24 pm" src="https://user-images.githubusercontent.com/4030377/38177116-2ab28172-35b0-11e8-93ac-2e243c40428c.png">

Now:
<img width="259" alt="screen shot 2018-04-01 at 1 24 59 pm" src="https://user-images.githubusercontent.com/4030377/38177118-2dbb0272-35b0-11e8-82c6-d8deca3d5686.png">

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :black_circle: renders as expected in "dark" mode
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
