### PR TITLE
fix: document corrected `@zendeskgarden` package scope

### DIFF
--- a/packages/arrows/CHANGELOG.md
+++ b/packages/arrows/CHANGELOG.md
@@ -9,7 +9,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Features
 
-* add css-menus package to monorepo ([#10](https://github.com/zendeskgarden/css-components/issues/10)) ([6f48111](https://github.com/zendeskgarden/css-components/commit/6f48111))
 * **variables, arrows:** prepare for [@zendeskgarden](https://github.com/zendeskgarden) npm publish ([#44](https://github.com/zendeskgarden/css-components/issues/44)) ([ffe72ce](https://github.com/zendeskgarden/css-components/commit/ffe72ce))
 
 

--- a/packages/arrows/README.md
+++ b/packages/arrows/README.md
@@ -5,7 +5,7 @@ This package contains styling and positioning classes for `.c-arrow`.
 ## Installation
 
 ```sh
-npm install --save-dev @zendesk/garden-css-arrows
+npm install --save-dev @zendeskgarden/css-arrows
 ```
 
 ## Usage
@@ -13,7 +13,7 @@ npm install --save-dev @zendesk/garden-css-arrows
 Once installed, arrow CSS can be accessed via `postcss-import`.
 
 ```css
-@import '@zendesk/garden-css-arrows';
+@import '@zendeskgarden/css-arrows';
 ```
 
 Arrow CSS classes are used on a parent element (typically menus or

--- a/packages/avatars/README.md
+++ b/packages/avatars/README.md
@@ -5,7 +5,7 @@ This component contains basic `.c-avatar` component styling.
 ## Installation
 
 ```sh
-npm install --save-dev @zendesk/garden-css-avatars
+npm install --save-dev @zendeskgarden/css-avatars
 ```
 
 ## Usage
@@ -13,7 +13,7 @@ npm install --save-dev @zendesk/garden-css-avatars
 Once installed, avatar CSS can be accessed via `postcss-import`.
 
 ```css
-@import '@zendesk/garden-css-avatars';
+@import '@zendeskgarden/css-avatars';
 ```
 
 Use avatar CSS to style user and system images.

--- a/packages/bedrock/README.md
+++ b/packages/bedrock/README.md
@@ -6,7 +6,7 @@ This package provides a mostly reasonable CSS reset layered on top of
 ## Installation
 
 ```sh
-npm install --save-dev @zendesk/garden-css-bedrock
+npm install --save-dev @zendeskgarden/css-bedrock
 ```
 
 ## Usage
@@ -14,7 +14,7 @@ npm install --save-dev @zendesk/garden-css-bedrock
 Once installed, bedrock CSS can be accessed via `postcss-import`.
 
 ```css
-@import '@zendesk/garden-css-bedrock';
+@import '@zendeskgarden/css-bedrock';
 ```
 
 The distribution for Bedrock CSS contains global styling rules to help

--- a/packages/buttons/README.md
+++ b/packages/buttons/README.md
@@ -5,7 +5,7 @@ This package contains basic `.c-btn` component styling.
 ## Installation
 
 ```sh
-npm install --save-dev @zendesk/garden-css-buttons
+npm install --save-dev @zendeskgarden/css-buttons
 ```
 
 ## Usage
@@ -13,7 +13,7 @@ npm install --save-dev @zendesk/garden-css-buttons
 Once installed, button CSS can be accessed via `postcss-import`.
 
 ```css
-@import '@zendesk/garden-css-buttons';
+@import '@zendeskgarden/css-buttons';
 ```
 
 Button CSS is intended to enhance the following HTML.

--- a/packages/callouts/README.md
+++ b/packages/callouts/README.md
@@ -5,7 +5,7 @@ This package contains styling for a selection of callout containers.
 ## Installation
 
 ```sh
-npm install --save-dev @zendesk/garden-css-callouts
+npm install --save-dev @zendeskgarden/css-callouts
 ```
 
 ## Usage
@@ -13,7 +13,7 @@ npm install --save-dev @zendesk/garden-css-callouts
 Once installed, callout CSS can be accessed via `postcss-import`.
 
 ```css
-@import '@zendesk/garden-css-callouts';
+@import '@zendeskgarden/css-callouts';
 ```
 
 Callout CSS is intended to provide styling for the following HTML.

--- a/packages/chrome/README.md
+++ b/packages/chrome/README.md
@@ -6,7 +6,7 @@ product page navigation, headers, and layout.
 ## Installation
 
 ```sh
-npm install --save-dev @zendesk/garden-css-chrome
+npm install --save-dev @zendeskgarden/css-chrome
 ```
 
 ## Usage
@@ -14,7 +14,7 @@ npm install --save-dev @zendesk/garden-css-chrome
 Once installed, chrome CSS can be accessed via `postcss-import`.
 
 ```css
-@import '@zendesk/garden-css-chrome';
+@import '@zendeskgarden/css-chrome';
 ```
 
 Component CSS provides styling for the following basic page structure

--- a/packages/forms/README.md
+++ b/packages/forms/README.md
@@ -6,7 +6,7 @@ used throughout Zendesk products.
 ## Installation
 
 ```sh
-npm install --save-dev @zendesk/garden-css-forms
+npm install --save-dev @zendeskgarden/css-forms
 ```
 
 ## Usage
@@ -14,7 +14,7 @@ npm install --save-dev @zendesk/garden-css-forms
 Once installed, form CSS can be accessed via `postcss-import`.
 
 ```css
-@import '@zendesk/garden-css-forms';
+@import '@zendeskgarden/css-forms';
 ```
 
 ### Checkbox

--- a/packages/menus/README.md
+++ b/packages/menus/README.md
@@ -8,7 +8,7 @@ to apply an arrow indicator along the menu's border.
 ## Installation
 
 ```sh
-npm install --save-dev @zendesk/garden-css-menus
+npm install --save-dev @zendeskgarden/css-menus
 ```
 
 ## Usage
@@ -16,7 +16,7 @@ npm install --save-dev @zendesk/garden-css-menus
 Once installed, menu CSS can be accessed via `postcss-import`.
 
 ```css
-@import '@zendesk/garden-css-menus';
+@import '@zendeskgarden/css-menus';
 ```
 
 Menu CSS provides styling for the following basic structure ([W3

--- a/packages/modals/README.md
+++ b/packages/modals/README.md
@@ -6,7 +6,7 @@ backdrop layouts needed to present a modal dialog treatment.
 ## Installation
 
 ```sh
-npm install --save-dev @zendesk/garden-css-modals
+npm install --save-dev @zendeskgarden/css-modals
 ```
 
 ## Usage
@@ -14,7 +14,7 @@ npm install --save-dev @zendesk/garden-css-modals
 Once installed, modal CSS can be accessed via `postcss-import`.
 
 ```css
-@import '@zendesk/garden-css-modals';
+@import '@zendeskgarden/css-modals';
 ```
 
 Canonical markup for a dialog is structured as follows.

--- a/packages/pagination/README.md
+++ b/packages/pagination/README.md
@@ -5,7 +5,7 @@ This package provides component styling for page navigation.
 ## Installation
 
 ```sh
-npm install --save-dev @zendesk/garden-css-pagination
+npm install --save-dev @zendeskgarden/css-pagination
 ```
 
 ## Usage
@@ -13,7 +13,7 @@ npm install --save-dev @zendesk/garden-css-pagination
 Once installed, pagination CSS can be accessed via `postcss-import`.
 
 ```css
-@import '@zendesk/garden-css-pagination';
+@import '@zendeskgarden/css-pagination';
 ```
 
 Pagination CSS classes are used to style the following canonical markup.

--- a/packages/tables/README.md
+++ b/packages/tables/README.md
@@ -6,7 +6,7 @@ to tables, rows, and columns.
 ## Installation
 
 ```sh
-npm install --save-dev @zendesk/garden-css-tables
+npm install --save-dev @zendeskgarden/css-tables
 ```
 
 ## Usage
@@ -14,7 +14,7 @@ npm install --save-dev @zendesk/garden-css-tables
 Once installed, table CSS can be accessed via `postcss-import`.
 
 ```css
-@import '@zendesk/garden-css-tables';
+@import '@zendeskgarden/css-tables';
 ```
 
 Component CSS provides styling for the following basic table structure.

--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -5,7 +5,7 @@ This package provides styling for tab components.
 ## Installation
 
 ```sh
-npm install --save-dev @zendesk/garden-css-tabs
+npm install --save-dev @zendeskgarden/css-tabs
 ```
 
 ## Usage
@@ -13,7 +13,7 @@ npm install --save-dev @zendesk/garden-css-tabs
 Once installed, tabs CSS can be accessed via `postcss-import`.
 
 ```css
-@import '@zendesk/garden-css-tabs';
+@import '@zendeskgarden/css-tabs';
 ```
 
 Tab CSS classes are intended to support the following component

--- a/packages/tags/README.md
+++ b/packages/tags/README.md
@@ -6,7 +6,7 @@ badges, pills, and labels.
 ## Installation
 
 ```sh
-npm install --save-dev @zendesk/garden-css-tags
+npm install --save-dev @zendeskgarden/css-tags
 ```
 
 ## Usage
@@ -14,7 +14,7 @@ npm install --save-dev @zendesk/garden-css-tags
 Once installed, tag CSS can be accessed via `postcss-import`.
 
 ```css
-@import '@zendesk/garden-css-tags';
+@import '@zendeskgarden/css-tags';
 ```
 
 Tag CSS is intended to enhance the following HTML.

--- a/packages/tooltips/README.md
+++ b/packages/tooltips/README.md
@@ -5,7 +5,7 @@ This package contains styling for various `.c-tooltip` treatments.
 ## Installation
 
 ```sh
-npm install --save-dev @zendesk/garden-css-tooltips
+npm install --save-dev @zendeskgarden/css-tooltips
 ```
 
 ## Usage
@@ -13,7 +13,7 @@ npm install --save-dev @zendesk/garden-css-tooltips
 Once installed, tooltip CSS can be accessed via `postcss-import`.
 
 ```css
-@import '@zendesk/garden-css-tooltips';
+@import '@zendeskgarden/css-tooltips';
 ```
 
 Tooltip CSS is intended to enhance the following HTML.

--- a/packages/utilities/README.md
+++ b/packages/utilities/README.md
@@ -6,7 +6,7 @@ classes.
 ## Installation
 
 ```sh
-npm install --save-dev @zendesk/garden-css-utilities
+npm install --save-dev @zendeskgarden/css-utilities
 ```
 
 ## Usage
@@ -14,7 +14,7 @@ npm install --save-dev @zendesk/garden-css-utilities
 Once installed, utilities CSS can be accessed via `postcss-import`.
 
 ```css
-@import '@zendesk/garden-css-utilities';
+@import '@zendeskgarden/css-utilities';
 ```
 
 Utilities include CSS property overrides for:

--- a/packages/variables/README.md
+++ b/packages/variables/README.md
@@ -12,7 +12,7 @@ CSS component framework.
 ## Installation
 
 ```sh
-npm install --save-dev @zendesk/garden-css-variables
+npm install --save-dev @zendeskgarden/css-variables
 ```
 
 ## Usage
@@ -20,7 +20,7 @@ npm install --save-dev @zendesk/garden-css-variables
 Once installed, variables can be referenced via `postcss-import`.
 
 ```css
-@import '@zendesk/garden-css-variables';
+@import '@zendeskgarden/css-variables';
 ```
 
 The package contains corresponding JSON, JS, and Sass variables for use


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

All package README files are still pointing to outdated `@zendesk/garden-css-[package]` names.
