### PR TITLE
fix: remove save-dev from bedrock install instructions

### DIFF
--- a/packages/.template/README.md
+++ b/packages/.template/README.md
@@ -5,7 +5,7 @@ This package contains ...
 ## Installation
 
 ```sh
-npm install --save-dev @zendeskgarden/css-{{component}}
+npm install @zendeskgarden/css-{{component}}
 ```
 
 ## Usage

--- a/packages/arrows/README.md
+++ b/packages/arrows/README.md
@@ -5,7 +5,7 @@ This package contains styling and positioning classes for `.c-arrow`.
 ## Installation
 
 ```sh
-npm install --save-dev @zendeskgarden/css-arrows
+npm install @zendeskgarden/css-arrows
 ```
 
 ## Usage

--- a/packages/avatars/README.md
+++ b/packages/avatars/README.md
@@ -5,7 +5,7 @@ This component contains basic `.c-avatar` component styling.
 ## Installation
 
 ```sh
-npm install --save-dev @zendeskgarden/css-avatars
+npm install @zendeskgarden/css-avatars
 ```
 
 ## Usage

--- a/packages/bedrock/README.md
+++ b/packages/bedrock/README.md
@@ -6,7 +6,7 @@ This package provides a mostly reasonable CSS reset layered on top of
 ## Installation
 
 ```sh
-npm install --save-dev @zendeskgarden/css-bedrock
+npm install --save @zendeskgarden/css-bedrock
 ```
 
 ## Usage

--- a/packages/bedrock/README.md
+++ b/packages/bedrock/README.md
@@ -6,7 +6,7 @@ This package provides a mostly reasonable CSS reset layered on top of
 ## Installation
 
 ```sh
-npm install --save @zendeskgarden/css-bedrock
+npm install @zendeskgarden/css-bedrock
 ```
 
 ## Usage

--- a/packages/buttons/README.md
+++ b/packages/buttons/README.md
@@ -5,7 +5,7 @@ This package contains basic `.c-btn` component styling.
 ## Installation
 
 ```sh
-npm install --save-dev @zendeskgarden/css-buttons
+npm install @zendeskgarden/css-buttons
 ```
 
 ## Usage

--- a/packages/callouts/README.md
+++ b/packages/callouts/README.md
@@ -5,7 +5,7 @@ This package contains styling for a selection of callout containers.
 ## Installation
 
 ```sh
-npm install --save-dev @zendeskgarden/css-callouts
+npm install @zendeskgarden/css-callouts
 ```
 
 ## Usage

--- a/packages/chrome/README.md
+++ b/packages/chrome/README.md
@@ -6,7 +6,7 @@ product page navigation, headers, and layout.
 ## Installation
 
 ```sh
-npm install --save-dev @zendeskgarden/css-chrome
+npm install @zendeskgarden/css-chrome
 ```
 
 ## Usage

--- a/packages/forms/README.md
+++ b/packages/forms/README.md
@@ -6,7 +6,7 @@ used throughout Zendesk products.
 ## Installation
 
 ```sh
-npm install --save-dev @zendeskgarden/css-forms
+npm install @zendeskgarden/css-forms
 ```
 
 ## Usage

--- a/packages/menus/README.md
+++ b/packages/menus/README.md
@@ -8,7 +8,7 @@ to apply an arrow indicator along the menu's border.
 ## Installation
 
 ```sh
-npm install --save-dev @zendeskgarden/css-menus
+npm install @zendeskgarden/css-menus
 ```
 
 ## Usage

--- a/packages/modals/README.md
+++ b/packages/modals/README.md
@@ -6,7 +6,7 @@ backdrop layouts needed to present a modal dialog treatment.
 ## Installation
 
 ```sh
-npm install --save-dev @zendeskgarden/css-modals
+npm install @zendeskgarden/css-modals
 ```
 
 ## Usage

--- a/packages/pagination/README.md
+++ b/packages/pagination/README.md
@@ -5,7 +5,7 @@ This package provides component styling for page navigation.
 ## Installation
 
 ```sh
-npm install --save-dev @zendeskgarden/css-pagination
+npm install @zendeskgarden/css-pagination
 ```
 
 ## Usage

--- a/packages/tables/README.md
+++ b/packages/tables/README.md
@@ -6,7 +6,7 @@ to tables, rows, and columns.
 ## Installation
 
 ```sh
-npm install --save-dev @zendeskgarden/css-tables
+npm install @zendeskgarden/css-tables
 ```
 
 ## Usage

--- a/packages/tabs/README.md
+++ b/packages/tabs/README.md
@@ -5,7 +5,7 @@ This package provides styling for tab components.
 ## Installation
 
 ```sh
-npm install --save-dev @zendeskgarden/css-tabs
+npm install @zendeskgarden/css-tabs
 ```
 
 ## Usage

--- a/packages/tags/README.md
+++ b/packages/tags/README.md
@@ -6,7 +6,7 @@ badges, pills, and labels.
 ## Installation
 
 ```sh
-npm install --save-dev @zendeskgarden/css-tags
+npm install @zendeskgarden/css-tags
 ```
 
 ## Usage

--- a/packages/tooltips/README.md
+++ b/packages/tooltips/README.md
@@ -5,7 +5,7 @@ This package contains styling for various `.c-tooltip` treatments.
 ## Installation
 
 ```sh
-npm install --save-dev @zendeskgarden/css-tooltips
+npm install @zendeskgarden/css-tooltips
 ```
 
 ## Usage

--- a/packages/utilities/README.md
+++ b/packages/utilities/README.md
@@ -6,7 +6,7 @@ classes.
 ## Installation
 
 ```sh
-npm install --save-dev @zendeskgarden/css-utilities
+npm install @zendeskgarden/css-utilities
 ```
 
 ## Usage

--- a/packages/variables/README.md
+++ b/packages/variables/README.md
@@ -12,7 +12,7 @@ CSS component framework.
 ## Installation
 
 ```sh
-npm install --save-dev @zendeskgarden/css-variables
+npm install @zendeskgarden/css-variables
 ```
 
 ## Usage


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "fix(buttons):
     increase specificity for disabled state". the title informs the
     semantic version bump if this PR is merged. -->

- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

removes the `--save-dev` flag from the bed-rock install `README.md` file. 

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

* [ ] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [ ] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [ ] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [ ] :black_circle: renders as expected in "dark" mode
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
