### PR TITLE
fix(forms): prevent `-webkit` pseudo selectors from invalidating rulesets

### DIFF
--- a/packages/forms/src/_text/_base.css
+++ b/packages/forms/src/_text/_base.css
@@ -106,10 +106,13 @@
 
 .c-txt.is-rtl,
 .c-txt__input.is-rtl,
-.c-txt__input.is-rtl::-webkit-datetime-edit,
 .c-txt__label.is-rtl,
 .c-txt__hint.is-rtl,
 .c-txt__message.is-rtl {
+  direction: rtl;
+}
+
+.c-txt__input.is-rtl::-webkit-datetime-edit {
   direction: rtl;
 }
 

--- a/packages/forms/src/_text/_select.css
+++ b/packages/forms/src/_text/_select.css
@@ -26,7 +26,8 @@
 
 /* 1. Select reset.
  * 2. Button reset.
- * 3. Calendar picker reset. */
+ * 3. Calendar picker reset (standalone ruleset prevents non-Chrome parsing
+ *    errors). */
 
 .c-txt__input--select {
   appearance: none; /* [1] */
@@ -35,11 +36,11 @@
   text-align: left; /* [2] */
 }
 
-.c-txt__input--select:not(select)::before,
-.c-txt__input--select::-webkit-calendar-picker-indicator {
+.c-txt__input--select:not(select)::before {
   position: absolute;
   top: 0;
   right: 0;
+  cursor: pointer;
   width: var(--zd-txt__input--select__chevron-width);
   height: var(--zd-txt__input-height);
   content: '';
@@ -69,9 +70,16 @@ select.c-txt__input--select:-moz-focusring {
 }
 
 .c-txt__input--select::-webkit-calendar-picker-indicator {
-  background-color: transparent; /* [2] */
-  padding: 0; /* [2] */
-  color: transparent; /* [2] */
+  position: absolute; /* [3] */
+  top: 0; /* [3] */
+  right: 0; /* [3] */
+  background-color: transparent; /* [3] */
+  cursor: pointer; /* [3] */
+  padding: 0; /* [3] */
+  width: var(--zd-txt__input--select__chevron-width); /* [3] */
+  height: var(--zd-txt__input-height); /* [3] */
+  color: transparent; /* [3] */
+  content: ''; /* [3] */
 }
 
 .c-txt__input--select:--txt-hovered:not(select)::before,
@@ -99,10 +107,14 @@ select.c-txt__input--select[disabled] {
   text-align: right;
 }
 
-.is-rtl.c-txt__input--select:not(select)::before,
-.is-rtl.c-txt__input--select::-webkit-calendar-picker-indicator {
+.is-rtl.c-txt__input--select:not(select)::before {
   right: auto;
   left: 0;
+}
+
+.is-rtl.c-txt__input--select::-webkit-calendar-picker-indicator {
+  right: auto; /* [3] */
+  left: 0; /* [3] */
 }
 
 .is-rtl.c-txt__input--select:not(select)::before,


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

When a webkit pseudo (i.e. `::-webkit-datetime-edit`) is listed with other selectors, the entire ruleset is invalidated for non-Chrome browsers.

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
