### PR TITLE
chore: fix demo page React links

### DIFF
--- a/demo/buttons/index.html
+++ b/demo/buttons/index.html
@@ -56,8 +56,8 @@
     <div class="c-main__body">
       <p class="u-mb">Use the <code class="c-code">.c-btn</code> component for
         consistent button styling. See the Garden React
-        <a href="//zendeskgarden.github.io/react-components/#!/Button"><code class="c-code">&lt;Button&gt;</code></a>
-        component for enhanced keyboard and event behavior.</p>
+        <a href="//zendeskgarden.github.io/react-components/buttons/">buttons</a>
+        package for enhanced keyboard and event behavior.</p>
       <h2 class="u-gamma u-mb-sm">Types</h2>
       <ul class="u-mb">
         <li class="u-mb-sm"><button class="c-btn">.c-btn</button></li>
@@ -132,7 +132,7 @@
         the <code class="c-code">.c-btn__icon</code> class. The following
         examples demonstrate the icon sized as default, small, and large.
         (See the corresponding Garden React
-        <a href="//zendeskgarden.github.io/react-components/#!/IconButton"><code class="c-code">&lt;IconButton&gt;</code></a>
+        <a href="//zendeskgarden.github.io/react-components/buttons/#!/IconButton"><code class="c-code">&lt;IconButton&gt;</code></a>
         component.)
       </p>
       <div class="l-grid u-mb">
@@ -191,7 +191,7 @@
         layout class can be used as a container for grouped buttons. Use
         <code class="c-code">.is-selected</code>
         to indicate item selection. (See the corresponding Garden React
-        <a href="//zendeskgarden.github.io/react-components/#!/ButtonGroup"><code class="c-code">&lt;ButtonGroup&gt;</code></a>
+        <a href="//zendeskgarden.github.io/react-components/buttons/#!/ButtonGroup"><code class="c-code">&lt;ButtonGroup&gt;</code></a>
         component.)
       </p>
       <div class="l-btn-group u-mb" role="tablist">
@@ -206,7 +206,7 @@
         <code class="c-code">.is-rotated</code> to the
         <code class="c-code">.c-btn__icon</code> element. (See the corresponding
         Garden React
-        <a href="//zendeskgarden.github.io/react-components/#!/SplitButton"><code class="c-code">&lt;SplitButton&gt;</code></a>
+        <a href="//zendeskgarden.github.io/react-components/buttons/#!/SplitButton"><code class="c-code">&lt;SplitButton&gt;</code></a>
         component.)
       </p>
       <div class="l-btn-group u-mb-lg">

--- a/demo/forms/dropdown/index.html
+++ b/demo/forms/dropdown/index.html
@@ -101,10 +101,10 @@
         <a href="../../menus/">
           <code class="c-code">.c-menu</code>
         </a>
-        component to present dropdown options. Consult the
-        associated Select React Component for complete
-        functionality, including option selection and
-        keyboard navigation.</p>
+        component to present dropdown options. Consult the associated
+        <a href="//zendeskgarden.github.io/react-components/select/"><code class="c-code">&lt;Select&gt;</code></a>
+        React Component for complete functionality, including option selection
+        and keyboard navigation.</p>
       <form class="l-wrapper--370 u-mb-lg">
         <fieldset class="u-mb-lg u-position-relative">
           <div class="c-txt">

--- a/demo/tabs/index.html
+++ b/demo/tabs/index.html
@@ -57,7 +57,7 @@
       <p class="u-mb-lg">Use the
         <code class="c-code">.c-tab</code>
         components for consistent tab styling. See the Garden React
-        <a href="//zendeskgarden.github.io/react-components/#!/Tabs"><code class="c-code">&lt;Tabs&gt;</code></a>
+        <a href="//zendeskgarden.github.io/react-components/tabs/"><code class="c-code">&lt;Tabs&gt;</code></a>
         component for enhanced keyboard and event behavior along with support for dynamic panel content.</p>
       <h2 class="u-gamma u-mb">Default Layout
         <code class="c-code">.c-tab<span class="js-rtl-display u-display-none">.is-rtl</span></code>


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Update to point to the new `react-components`.

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [ ] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [ ] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
