### PR TITLE
fix(tags): correct base-4 element margins and remove styling for color tags

### DIFF
--- a/demo/tags/index.html
+++ b/demo/tags/index.html
@@ -63,7 +63,9 @@
         <p class="u-mb">The
           <code class="c-code">.c-tag</code>
           component exposes a variety of styling options needed to support
-          badges, pills, and tags.</p>
+          badges, pills, and tags. See the Garden React
+          <a href="https://garden.zendesk.com/react-components/tags/">tags</a>
+          package for enhanced keyboard and event behavior.</p>
         <div class="c-tag"><span dir="ltr">.c-tag</span></div>
       </section>
 
@@ -157,6 +159,34 @@
               <span dir="ltr">button.c-tag .c-tag__remove</span>
               <span class="c-tag__remove"></span>
             </button>
+          </div>
+        </div>
+        <div class="l-grid u-mb">
+          <div class="l-grid__item u-1/3">
+            <div class="c-tag c-tag--sm" tabindex="0">
+              <span dir="ltr">.c-tag.c-tag--sm .c-tag__remove</span>
+              <button class="c-tag__remove" tabindex="-1"></button>
+            </div>
+          </div
+          ><div class="l-grid__item u-1/3">
+            <div class="c-tag c-tag--sm c-tag--pill" tabindex="0">
+              <span dir="ltr">.c-tag.c-tag--sm.c-tag--pill .c-tag__remove</span>
+              <button class="c-tag__remove" tabindex="-1"></button>
+            </div>
+          </div>
+        </div>
+        <div class="l-grid u-mb">
+          <div class="l-grid__item u-1/3">
+            <div class="c-tag c-tag--lg" tabindex="0">
+              <span dir="ltr">.c-tag.c-tag--lg .c-tag__remove</span>
+              <button class="c-tag__remove" tabindex="-1"></button>
+            </div>
+          </div
+          ><div class="l-grid__item u-1/3">
+            <div class="c-tag c-tag--lg c-tag--pill" tabindex="0">
+              <span dir="ltr">.c-tag.c-tag--lg.c-tag--pill .c-tag__remove</span>
+              <button class="c-tag__remove" tabindex="-1"></button>
+            </div>
           </div>
         </div>
         <div class="l-grid u-mb">

--- a/packages/tags/src/_avatar.css
+++ b/packages/tags/src/_avatar.css
@@ -26,14 +26,12 @@
 /* 1. Prevent flex shrink */
 
 .c-tag__avatar {
-  display: inline-block;
   flex-shrink: 0;
   margin: var(--zd-tag__avatar-margin);
   border-radius: var(--zd-tag__avatar-border-radius);
   width: var(--zd-tag__avatar-size);
   min-width: var(--zd-tag__avatar-size); /* [1] */
   height: var(--zd-tag__avatar-size);
-  vertical-align: middle;
   font-size: 0;
 }
 

--- a/packages/tags/src/_avatar.css
+++ b/packages/tags/src/_avatar.css
@@ -2,7 +2,7 @@
 
 :root {
   --zd-tag__avatar-border-radius: var(--zd-tag-border-radius);
-  --zd-tag__avatar-margin-left: -7.9px;
+  --zd-tag__avatar-margin-left: calc(var(--zd-tag__avatar-margin-vertical) - var(--zd-tag-padding-horizontal));
   --zd-tag__avatar-margin-right: 5px;
   --zd-tag__avatar-margin-vertical: 2px;
   --zd-tag__avatar-margin:
@@ -12,7 +12,7 @@
     var(--zd-tag__avatar-margin-left);
   --zd-tag__avatar-size: calc(var(--zd-tag-height) - (var(--zd-tag__avatar-margin-vertical) * 2));
   --zd-tag--lg__avatar-border-radius: calc(var(--zd-tag--lg-border-radius) - 1px);
-  --zd-tag--lg__avatar-margin-left: -6.9px;
+  --zd-tag--lg__avatar-margin-left: calc(var(--zd-tag--lg__avatar-margin-vertical) - var(--zd-tag--lg-padding-horizontal));
   --zd-tag--lg__avatar-margin-right: 10px;
   --zd-tag--lg__avatar-margin-vertical: 3px;
   --zd-tag--lg__avatar-margin:

--- a/packages/tags/src/_base.css
+++ b/packages/tags/src/_base.css
@@ -10,7 +10,8 @@
   --zd-tag-font-weight: var(--zd-font-weight-semibold);
   --zd-tag-height: var(--zd-spacing);
   --zd-tag-line-height: calc(20 / 12);
-  --zd-tag-padding: 0 calc(8 / 12 * 1em);
+  --zd-tag-padding-horizontal: 8px;
+  --zd-tag-padding: 0 var(--zd-tag-padding-horizontal);
   --zd-tag-transition: box-shadow .1s ease-in-out;
 }
 
@@ -48,6 +49,10 @@
     color(var(--zd-color-grey-600) alpha(35%));
   text-decoration: none; /* [2] */
   color: var(--zd-tag-color); /* [2] */
+}
+
+.c-tag:any-link:hover {
+  cursor: pointer;
 }
 
 .c-tag.is-rtl {

--- a/packages/tags/src/_base.css
+++ b/packages/tags/src/_base.css
@@ -21,6 +21,7 @@
 .c-tag {
   display: inline-flex;
   flex-wrap: nowrap;
+  align-items: center;
   transition: var(--zd-tag-transition);
   border: 0; /* [1] */
   border-radius: var(--zd-tag-border-radius);

--- a/packages/tags/src/_remove.css
+++ b/packages/tags/src/_remove.css
@@ -27,7 +27,6 @@
  * 2. Reset for text content. */
 
 .c-tag__remove {
-  display: inline-block;
   flex-shrink: 0;
   transition: var(--zd-tag__remove-transition);
   opacity: var(--zd-tag__remove-opacity);
@@ -39,7 +38,6 @@
   padding: 0; /* [1] */
   width: var(--zd-tag__remove-size);
   height: var(--zd-tag__remove-size);
-  vertical-align: middle;
   font-size: 0; /* [2] */
 }
 

--- a/packages/tags/src/_remove.css
+++ b/packages/tags/src/_remove.css
@@ -8,17 +8,18 @@
     center
     var(--zd-tag__remove-background-image)
     transparent; /* [1] */
-  --zd-tag__remove-margin: calc(var(--zd-spacing-sm) * -1);
+  --zd-tag__remove-margin: calc(var(--zd-tag-padding-horizontal) * -1);
   --zd-tag__remove-opacity: .8;
   --zd-tag__remove-size: var(--zd-spacing);
   --zd-tag__remove-transition: opacity .25s ease-in-out;
   --zd-tag__remove-hovered-opacity: .9;
   --zd-tag--lg__remove-background-size: var(--zd-font-size-delta);
   --zd-tag--lg__remove-size: var(--zd-spacing-lg);
+  --zd-tag--lg__remove-margin: calc(var(--zd-tag--lg-padding-horizontal) * -1);
   --zd-tag--color__remove-background-image: svg-load('14/remove.svg', color: var(--zd-tag--color-color));
   --zd-tag--yellow__remove-background-image: svg-load('14/remove.svg', color: var(--zd-tag--yellow-color));
   --zd-tag--sm__remove-background-size: var(--zd-font-size-milli);
-  --zd-tag--sm__remove-margin: calc(var(--zd-tag__remove-margin) / 2);
+  --zd-tag--sm__remove-margin: calc(var(--zd-tag--sm-padding-horizontal) * -1);
   --zd-tag--sm__remove-size: 15px;
 }
 
@@ -55,6 +56,7 @@
 }
 
 .c-tag--lg .c-tag__remove {
+  margin-right: var(--zd-tag--lg__remove-margin);
   background-size: var(--zd-tag--lg__remove-background-size);
   width: var(--zd-tag--lg__remove-size);
   height: var(--zd-tag--lg__remove-size);
@@ -81,7 +83,7 @@
 .c-tag--grey,
 .c-tag--kale,
 .c-tag--red
-) .c-tag--remove {
+) .c-tag__remove {
   background-image: var(--zd-tag--color__remove-background-image);
 }
 
@@ -93,6 +95,10 @@
   flex-direction: row-reverse;
   margin-right: 0;
   margin-left: var(--zd-tag__remove-margin);
+}
+
+.c-tag--lg.is-rtl .c-tag__remove {
+  margin-left: var(--zd-tag--lg__remove-margin);
 }
 
 .c-tag--sm.is-rtl .c-tag__remove {

--- a/packages/tags/src/_size.css
+++ b/packages/tags/src/_size.css
@@ -4,11 +4,13 @@
   --zd-tag--lg-border-radius: 4px;
   --zd-tag--lg-height: var(--zd-spacing-lg);
   --zd-tag--lg-line-height: calc(30 / 12);
-  --zd-tag--lg-padding: 0 1em;
+  --zd-tag--lg-padding-horizontal: 12px;
+  --zd-tag--lg-padding: 0 var(--zd-tag--lg-padding-horizontal);
   --zd-tag--sm-font-size: var(--zd-font-size-micro);
   --zd-tag--sm-height: 15px;
   --zd-tag--sm-line-height: calc(15 / 10);
-  --zd-tag--sm-padding: 0 calc(4 / 10 * 1em);
+  --zd-tag--sm-padding-horizontal: 4px;
+  --zd-tag--sm-padding: 0 var(--zd-tag--sm-padding-horizontal);
   --zd-tag--round--lg-min-width: 30px;
   --zd-tag--round--sm-min-width: 15px;
 }

--- a/packages/tags/src/_size.css
+++ b/packages/tags/src/_size.css
@@ -15,18 +15,18 @@
   --zd-tag--round--sm-min-width: 15px;
 }
 
-.c-tag--lg {
-  border-radius: var(--zd-tag--lg-border-radius);
-  padding: var(--zd-tag--lg-padding);
-  height: var(--zd-tag--lg-height);
-  line-height: var(--zd-tag--lg-line-height);
-}
-
 .c-tag--sm {
   padding: var(--zd-tag--sm-padding);
   height: var(--zd-tag--sm-height);
   line-height: var(--zd-tag--sm-line-height);
   font-size: var(--zd-tag--sm-font-size);
+}
+
+.c-tag--lg {
+  border-radius: var(--zd-tag--lg-border-radius);
+  padding: var(--zd-tag--lg-padding);
+  height: var(--zd-tag--lg-height);
+  line-height: var(--zd-tag--lg-line-height);
 }
 
 .c-tag--round.c-tag--sm,


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

* update avatar/remove offset margins to correspond with updated base-4 tag padding
* fix broken selector for remove styling on color tags
* link tags updated to receive `pointer` cursor

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
