### PR TITLE
fix(grid): apply debug styling to all columns

### DIFF
--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -35,6 +35,5 @@
   ],
   "publishConfig": {
     "access": "public"
-  },
-  "style": "src/index.css"
+  }
 }

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -22,9 +22,11 @@
     "test": "yarn lint",
     "watch": "yarn build --watch"
   },
-  "devDependencies": {
+  "dependencies": {
     "@zendeskgarden/css-variables": "^4.1.3",
-    "bootstrap": "^4.1.1",
+    "bootstrap": "^4.1.1"
+  },
+  "devDependencies": {
     "node-sass": "^4.9.0"
   },
   "keywords": [

--- a/packages/grid/src/index.scss
+++ b/packages/grid/src/index.scss
@@ -21,7 +21,7 @@ $grid-gutter-width: 20px !default;
  * Debug styling for columns
  */
 .is-debug {
-  .row > .col, .row > [class^='col-'] {
+  .row > [class*='col'] {
     border: 1px solid rgba($zd-color-blue-400, .35);
     background-color: rgba($zd-color-blue-200, .35);
     padding-top: .75rem;


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "fix(buttons):
     increase specificity for disabled state". the title informs the
     semantic version bump if this PR is merged. -->

## Description

* The `styles` property in the package.json was invalid. This PR removes that entry.
* When consumed through `css-modules` the `is-debug` styling was invalid for all columns that had a number or breakpoint value. This adds a wildcard attribute to apply to ALL `col` classes within it. 

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
