### PR TITLE
fix(grid): apply border-box sizing to containers

### DIFF
--- a/packages/grid/src/index.scss
+++ b/packages/grid/src/index.scss
@@ -22,11 +22,11 @@ $grid-gutter-width: 20px !default;
 @import 'bootstrap/scss/utilities/flex';
 
 .container, .container-fluid {
-  box-sizing: inherit;
+  box-sizing: border-box;
 
-  ::before,
-  ::after {
-    box-sizing: inherit;
+  &::before,
+  &::after {
+    box-sizing: border-box;
   }
 
   *,


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "fix(buttons):
     increase specificity for disabled state". the title informs the
     semantic version bump if this PR is merged. -->

## Description

This Pr fixes 2 things relating to the `box-sizing` fix for css-grid.

* Turns out the `::before` and `::after` syntax wasn't valid SCSS. This is now fixed.
* Due to use removing the global, HTML `box-sizing`, we have to apply it directly to `.container` and `.container-fluid` rather than inheriting it.

## Checklist

* [ ] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [ ] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [ ] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [ ] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
