### PR TITLE
feat(modals): incorporate spacing for footer buttons

### DIFF
--- a/demo/modals/index.html
+++ b/demo/modals/index.html
@@ -15,12 +15,6 @@
   <link href="//zendeskgarden.github.io/index.css" rel="stylesheet">
   <link href="index.css" rel="stylesheet">
   <link href="../utilities/index.css" rel="stylesheet">
-  <style>
-  .is-rtl .u-ml {
-    margin-right: 20px !important;
-    margin-left: 0 !important;
-  }
-  </style>
 </head>
 <body>
   <header class="c-header">
@@ -291,8 +285,8 @@
     gastropub. Austin quinoa butcher, everyday carry echo park sartorial
     VHS.</p>
     <footer class="c-dialog__footer">
-      <code class="c-code" dir="ltr">.c-dialog__footer</code>
-      <button class="c-btn c-btn--medium c-btn--primary u-ml js-close">OK</button>
+      <code class="c-code" dir="ltr">.c-dialog__footer</code
+      ><button class="c-btn c-btn--medium c-btn--primary js-close">OK</button>
     </footer>
   </section>
 
@@ -332,7 +326,7 @@
     </div>
     <footer class="c-dialog__footer">
       <button class="c-btn c-btn--medium js-close">Cancel</button
-      ><button class="c-btn c-btn--medium c-btn--primary js-close u-ml">OK</button>
+      ><button class="c-btn c-btn--medium c-btn--primary js-close">OK</button>
     </footer>
   </section>
 
@@ -355,7 +349,7 @@
     90's, crucifix banjo seitan knausgaard kitsch salvia actually bespoke.</p>
     <footer class="c-dialog__footer">
       <button class="c-btn c-btn--medium js-close">Cancel</button
-      ><button class="c-btn c-btn--medium c-btn--primary js-close u-ml">OK</button>
+      ><button class="c-btn c-btn--medium c-btn--primary js-close">OK</button>
     </footer>
   </section>
 
@@ -394,7 +388,7 @@
     </div>
     <footer class="c-dialog__footer">
       <button class="c-btn c-btn--medium js-close">Cancel</button
-      ><button class="c-btn c-btn--medium c-btn--primary js-close u-ml">OK</button>
+      ><button class="c-btn c-btn--medium c-btn--primary js-close">OK</button>
     </footer>
   </section>
 

--- a/demo/modals/index.html
+++ b/demo/modals/index.html
@@ -258,7 +258,7 @@
     tincidunt id purus vel posuere.</p>
   </div>
   <footer class="c-dialog__footer">
-    <button class="c-btn c-btn--primary js-close">OK</button>
+    <button class="c-dialog__footer__item c-btn c-btn--primary js-close">OK</button>
   </footer>
 </section></textarea>
         </div>
@@ -285,8 +285,8 @@
     gastropub. Austin quinoa butcher, everyday carry echo park sartorial
     VHS.</p>
     <footer class="c-dialog__footer">
-      <code class="c-code" dir="ltr">.c-dialog__footer</code
-      ><button class="c-btn c-btn--primary js-close">OK</button>
+      <code class="c-dialog__footer__item c-code" dir="ltr">.c-dialog__footer</code
+      ><button class="c-dialog__footer__item c-btn c-btn--primary js-close">OK</button>
     </footer>
   </section>
 
@@ -325,8 +325,8 @@
       mlkshk hexagon.</p>
     </div>
     <footer class="c-dialog__footer">
-      <button class="c-btn js-close">Cancel</button
-      ><button class="c-btn c-btn--primary js-close">OK</button>
+      <button class="c-dialog__footer__item c-btn js-close">Cancel</button
+      ><button class="c-dialog__footer__item c-btn c-btn--primary js-close">OK</button>
     </footer>
   </section>
 
@@ -348,8 +348,8 @@
     bitters, blog letterpress pinterest vegan dreamcatcher. Selvage meh lomo
     90's, crucifix banjo seitan knausgaard kitsch salvia actually bespoke.</p>
     <footer class="c-dialog__footer">
-      <button class="c-btn js-close">Cancel</button
-      ><button class="c-btn c-btn--primary js-close">OK</button>
+      <button class="c-dialog__footer__item c-btn js-close">Cancel</button
+      ><button class="c-dialog__footer__item c-btn c-btn--primary js-close">OK</button>
     </footer>
   </section>
 
@@ -387,8 +387,8 @@
       mlkshk hexagon.</p>
     </div>
     <footer class="c-dialog__footer">
-      <button class="c-btn js-close">Cancel</button
-      ><button class="c-btn c-btn--primary js-close">OK</button>
+      <button class="c-dialog__footer__item c-btn js-close">Cancel</button
+      ><button class="c-dialog__footer__item c-btn c-btn--primary js-close">OK</button>
     </footer>
   </section>
 

--- a/demo/modals/index.html
+++ b/demo/modals/index.html
@@ -153,11 +153,11 @@
   </header>
   <p class="c-dialog__body">Hello World</p>
   <footer class="c-dialog__footer">
-    <button class="c-btn c-btn--medium js-close">Goodbye</button>
+    <button class="c-btn js-close">Goodbye</button>
   </footer>
 </section>
 
-<a class="c-btn c-btn--medium js-dialog js-backdrop u-mh"
+<a class="c-btn js-dialog js-backdrop u-mh"
    href="#zd-test-modal-lg"
    role="button">Open Big Modal</a>
 
@@ -258,7 +258,7 @@
     tincidunt id purus vel posuere.</p>
   </div>
   <footer class="c-dialog__footer">
-    <button class="c-btn c-btn--medium c-btn--primary js-close">OK</button>
+    <button class="c-btn c-btn--primary js-close">OK</button>
   </footer>
 </section></textarea>
         </div>
@@ -286,7 +286,7 @@
     VHS.</p>
     <footer class="c-dialog__footer">
       <code class="c-code" dir="ltr">.c-dialog__footer</code
-      ><button class="c-btn c-btn--medium c-btn--primary js-close">OK</button>
+      ><button class="c-btn c-btn--primary js-close">OK</button>
     </footer>
   </section>
 
@@ -325,8 +325,8 @@
       mlkshk hexagon.</p>
     </div>
     <footer class="c-dialog__footer">
-      <button class="c-btn c-btn--medium js-close">Cancel</button
-      ><button class="c-btn c-btn--medium c-btn--primary js-close">OK</button>
+      <button class="c-btn js-close">Cancel</button
+      ><button class="c-btn c-btn--primary js-close">OK</button>
     </footer>
   </section>
 
@@ -348,8 +348,8 @@
     bitters, blog letterpress pinterest vegan dreamcatcher. Selvage meh lomo
     90's, crucifix banjo seitan knausgaard kitsch salvia actually bespoke.</p>
     <footer class="c-dialog__footer">
-      <button class="c-btn c-btn--medium js-close">Cancel</button
-      ><button class="c-btn c-btn--medium c-btn--primary js-close">OK</button>
+      <button class="c-btn js-close">Cancel</button
+      ><button class="c-btn c-btn--primary js-close">OK</button>
     </footer>
   </section>
 
@@ -387,8 +387,8 @@
       mlkshk hexagon.</p>
     </div>
     <footer class="c-dialog__footer">
-      <button class="c-btn c-btn--medium js-close">Cancel</button
-      ><button class="c-btn c-btn--medium c-btn--primary js-close">OK</button>
+      <button class="c-btn js-close">Cancel</button
+      ><button class="c-btn c-btn--primary js-close">OK</button>
     </footer>
   </section>
 

--- a/packages/modals/src/_close.css
+++ b/packages/modals/src/_close.css
@@ -14,6 +14,7 @@
 
 /* 1. Reset for <button> element.
  * 2. Reset for <a>nchor element.
+ * 3. Reset for FF.
  */
 .c-dialog__close {
   display: block;
@@ -31,6 +32,10 @@
   text-decoration: none; /* [2] */
   font-size: 0; /* [2] */
   user-select: none;
+}
+
+.c-dialog__close::-moz-focus-inner {
+  border: 0; /* [3] */
 }
 
 .c-dialog__close::before,

--- a/packages/modals/src/_footer.css
+++ b/packages/modals/src/_footer.css
@@ -18,17 +18,15 @@
   padding: var(--zd-dialog--large__footer-padding);
 }
 
+.c-dialog__footer__item {
+  margin-left: var(--zd-dialog__footer__btn-margin);
+}
+
 .c-dialog.is-rtl .c-dialog__footer {
   text-align: left;
 }
 
-.c-dialog__footer .c-btn {
-  margin-left: var(--zd-dialog__footer__btn-margin);
-}
-
-/* stylelint-disable selector-max-specificity */
-.c-dialog.is-rtl .c-dialog__footer .c-btn {
+.c-dialog.is-rtl .c-dialog__footer__item {
   margin-right: var(--zd-dialog__footer__btn-margin);
   margin-left: 0;
 }
-/* stylelint-enable selector-max-specificity */

--- a/packages/modals/src/_footer.css
+++ b/packages/modals/src/_footer.css
@@ -2,6 +2,7 @@
 
 :root {
   --zd-dialog__footer-padding: 0 var(--zd-spacing-xl) 32px;
+  --zd-dialog__footer__btn-margin: 20px;
   --zd-dialog--large__footer-padding: 32px var(--zd-spacing-xl);
   --zd-dialog--large__footer-border-top: var(--zd-dialog__header-border-bottom);
 }
@@ -20,3 +21,14 @@
 .c-dialog.is-rtl .c-dialog__footer {
   text-align: left;
 }
+
+.c-dialog__footer .c-btn {
+  margin-left: var(--zd-dialog__footer__btn-margin);
+}
+
+/* stylelint-disable selector-max-specificity */
+.c-dialog.is-rtl .c-dialog__footer .c-btn {
+  margin-right: var(--zd-dialog__footer__btn-margin);
+  margin-left: 0;
+}
+/* stylelint-enable selector-max-specificity */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2297,11 +2297,11 @@ globjoin@^0.1.4:
   resolved "https://registry.yarnpkg.com/globjoin/-/globjoin-0.1.4.tgz#2f4494ac8919e3767c5cbb691e9f463324285d43"
 
 globule@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/globule/-/globule-1.2.0.tgz#1dc49c6822dd9e8a2fa00ba2a295006e8664bd09"
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/globule/-/globule-1.2.1.tgz#5dffb1b191f22d20797a9369b49eab4e9839696d"
   dependencies:
     glob "~7.1.1"
-    lodash "~4.17.4"
+    lodash "~4.17.10"
     minimatch "~3.0.2"
 
 gonzales-pe@^4.2.3:
@@ -3216,7 +3216,7 @@ lodash@>=2.4.0, lodash@^4.14.0, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lo
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
-lodash@^4.0.0, lodash@~4.17.4:
+lodash@^4.0.0, lodash@~4.17.10:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -6007,7 +6007,13 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@1, which@^1.2.9:
+which@1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  dependencies:
+    isexe "^2.0.0"
+
+which@^1.2.9:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
   dependencies:


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Add `20px` spacing for buttons within a modal dialog's footer.

## Details

Demo is published for review: https://garden.zendesk.com/css-components/modals/

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
