### PR TITLE
fix(modals): add inline block display to dialog footer items

### DIFF
--- a/packages/modals/src/_footer.css
+++ b/packages/modals/src/_footer.css
@@ -19,6 +19,7 @@
 }
 
 .c-dialog__footer__item {
+  display: inline-block;
   margin-left: var(--zd-dialog__footer__btn-margin);
 }
 


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Allows `.c-dialog__footer__item` to function as an independent element.


## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [ ] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [ ] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
