### PR TITLE
feat(variables, utilities): update with base4 spacing

### DIFF
--- a/demo/utilities/spacing/index.html
+++ b/demo/utilities/spacing/index.html
@@ -508,6 +508,84 @@
           </div>
         </div>
 
+        <div class="u-mb">
+          <h3 class="u-delta u-mb-sm">Extra Extra-Large</h3>
+          <div class="u-bg-grey-400 u-display-inline-block">
+            <div class="u-bg-pelorous u-m-xxl">
+              <code class="c-code">.u-m-xxl</code>
+            </div>
+          </div>
+          <div class="u-bg-grey-400 u-display-inline-block u-ml">
+            <div class="u-bg-pelorous u-mt-xxl">
+              <code class="c-code">.u-mt-xxl</code>
+            </div>
+          </div>
+          <div class="u-bg-grey-400 u-display-inline-block u-ml">
+            <div class="u-bg-pelorous u-mr-xxl">
+              <code class="c-code">.u-mr-xxl</code>
+            </div>
+          </div>
+          <div class="u-bg-grey-400 u-display-inline-block u-ml">
+            <div class="u-bg-pelorous u-mb-xxl">
+              <code class="c-code">.u-mb-xxl</code>
+            </div>
+          </div>
+          <div class="u-bg-grey-400 u-display-inline-block u-ml">
+            <div class="u-bg-pelorous u-ml-xxl">
+              <code class="c-code">.u-ml-xxl</code>
+            </div>
+          </div>
+          <div class="u-bg-grey-400 u-display-inline-block u-ml">
+            <div class="u-bg-pelorous u-mh-xxl">
+              <code class="c-code">.u-mh-xxl</code>
+            </div>
+          </div>
+          <div class="u-bg-grey-400 u-display-inline-block u-ml">
+            <div class="u-bg-pelorous u-mv-xxl">
+              <code class="c-code">.u-mv-xxl</code>
+            </div>
+          </div>
+        </div>
+
+        <div class="u-mb">
+          <h3 class="u-delta u-mb-sm">Extra Extra-Large (Negative)</h3>
+          <div class="u-bg-grey-400 u-display-inline-block">
+            <div class="u-bg-pelorous u-m-xxl u-m-xxl-">
+              <code class="c-code">.u-m-xxl-</code>
+            </div>
+          </div>
+          <div class="u-bg-grey-400 u-display-inline-block u-ml">
+            <div class="u-bg-pelorous u-m-xxl u-mt-xxl-">
+              <code class="c-code">.u-mt-xxl-</code>
+            </div>
+          </div>
+          <div class="u-bg-grey-400 u-display-inline-block u-ml">
+            <div class="u-bg-pelorous u-m-xxl u-mr-xxl-">
+              <code class="c-code">.u-mr-xxl-</code>
+            </div>
+          </div>
+          <div class="u-bg-grey-400 u-display-inline-block u-ml">
+            <div class="u-bg-pelorous u-m-xxl u-mb-xxl-">
+              <code class="c-code">.u-mb-xxl-</code>
+            </div>
+          </div>
+          <div class="u-bg-grey-400 u-display-inline-block u-ml">
+            <div class="u-bg-pelorous u-m-xxl u-ml-xxl-">
+              <code class="c-code">.u-ml-xxl-</code>
+            </div>
+          </div>
+          <div class="u-bg-grey-400 u-display-inline-block u-ml">
+            <div class="u-bg-pelorous u-m-xxl u-mh-xxl-">
+              <code class="c-code">.u-mh-xxl-</code>
+            </div>
+          </div>
+          <div class="u-bg-grey-400 u-display-inline-block u-ml">
+            <div class="u-bg-pelorous u-m-xxl u-mv-xxl-">
+              <code class="c-code">.u-mv-xxl-</code>
+            </div>
+          </div>
+        </div>
+
       </div>
 
       <h2 class="u-gamma u-mb">Padding</h2>
@@ -743,6 +821,45 @@
           <div class="u-bg-grey-400 u-display-inline-block u-ml">
             <div class="u-bg-pelorous u-pv-xl">
               <code class="c-code">.u-pv-xl</code>
+            </div>
+          </div>
+        </div>
+
+        <div class="u-mb">
+          <h3 class="u-delta u-mb-sm">Extra Extra-Large</h3>
+          <div class="u-bg-grey-400 u-display-inline-block">
+            <div class="u-bg-pelorous u-p-xxl">
+              <code class="c-code">.u-p-xxl</code>
+            </div>
+          </div>
+          <div class="u-bg-grey-400 u-display-inline-block u-ml">
+            <div class="u-bg-pelorous u-pt-xxl">
+              <code class="c-code">.u-pt-xxl</code>
+            </div>
+          </div>
+          <div class="u-bg-grey-400 u-display-inline-block u-ml">
+            <div class="u-bg-pelorous u-pr-xxl">
+              <code class="c-code">.u-pr-xxl</code>
+            </div>
+          </div>
+          <div class="u-bg-grey-400 u-display-inline-block u-ml">
+            <div class="u-bg-pelorous u-pb-xxl">
+              <code class="c-code">.u-pb-xxl</code>
+            </div>
+          </div>
+          <div class="u-bg-grey-400 u-display-inline-block u-ml">
+            <div class="u-bg-pelorous u-pl-xxl">
+              <code class="c-code">.u-pl-xxl</code>
+            </div>
+          </div>
+          <div class="u-bg-grey-400 u-display-inline-block u-ml">
+            <div class="u-bg-pelorous u-ph-xxl">
+              <code class="c-code">.u-ph-xxl</code>
+            </div>
+          </div>
+          <div class="u-bg-grey-400 u-display-inline-block u-ml">
+            <div class="u-bg-pelorous u-pv-xxl">
+              <code class="c-code">.u-pv-xxl</code>
             </div>
           </div>
         </div>

--- a/packages/callouts/src/_base.css
+++ b/packages/callouts/src/_base.css
@@ -10,7 +10,7 @@
   --zd-callout-line-height: calc(20 / 14);
   --zd-callout-padding-horizontal: var(--zd-spacing-xl);
   --zd-callout-padding: var(--zd-spacing) var(--zd-callout-padding-horizontal);
-  --zd-callout__paragraph-margin: var(--zd-spacing-sm) 0 0;
+  --zd-callout__paragraph-margin: 10px 0 0;
   --zd-callout__title-color: var(--zd-color-grey-800);
   --zd-callout__title-font-weight: var(--zd-font-weight-semibold);
 }

--- a/packages/forms/src/_checkbox/_base.css
+++ b/packages/forms/src/_checkbox/_base.css
@@ -15,7 +15,7 @@
   --zd-chk__label-line-height: calc(20 / 14);
   --zd-chk__label-padding: calc(var(--zd-chk-size) + var(--zd-chk__label-spacing));
   --zd-chk__label-spacing: 8px;
-  --zd-chk__label-top: var(--zd-spacing-sm);
+  --zd-chk__label-top: 10px;
   --zd-chk__label--regular-font-weight: var(--zd-font-weight-regular);
   --zd-chk__hint-line-height: calc(20 / 14);
   --zd-chk__message-line-height: calc(16 / 12);

--- a/packages/menus/src/_item.css
+++ b/packages/menus/src/_item.css
@@ -14,7 +14,7 @@
   --zd-menu__item--checked-background-offset: 10%;
   --zd-menu__item--checked-background:
     no-repeat
-    calc(50% + var(--zd-menu__item--checked-background-offset)) / var(--zd-spacing-sm)
+    calc(50% + var(--zd-menu__item--checked-background-offset)) / 10px
     svg-load('14/checkmark-lg.svg', color: var(--zd-menu-accent-color));
   --zd-menu__item--header-font-weight: var(--zd-font-weight-semibold);
   --zd-menu__item--header__icon-top: calc(calc(var(--zd-menu__item--icon-height) - var(--zd-menu__item--icon-background-size)) / 2);

--- a/packages/modals/src/_close.css
+++ b/packages/modals/src/_close.css
@@ -4,7 +4,7 @@
   --zd-dialog__close-background-image: svg-load('14/remove.svg', color: var(--zd-color-grey-500));
   --zd-dialog__close-right: var(--zd-spacing);
   --zd-dialog__close-size: var(--zd-spacing-xl);
-  --zd-dialog__close-top: var(--zd-spacing-sm);
+  --zd-dialog__close-top: 10px;
   --zd-dialog__close-transition: background-color .1s ease-in-out;
   --zd-dialog__close-hovered-background-image: svg-load('14/remove.svg', color: var(--zd-color-grey-800));
   --zd-dialog__close-focused-background-color: color(var(--zd-color-grey-600) alpha(15%));

--- a/packages/tags/src/_remove.css
+++ b/packages/tags/src/_remove.css
@@ -14,7 +14,7 @@
   --zd-tag__remove-transition: opacity .25s ease-in-out;
   --zd-tag__remove-hovered-opacity: .9;
   --zd-tag--lg__remove-background-size: var(--zd-font-size-delta);
-  --zd-tag--lg__remove-size: var(--zd-spacing-lg);
+  --zd-tag--lg__remove-size: 30px;
   --zd-tag--lg__remove-margin: calc(var(--zd-tag--lg-padding-horizontal) * -1);
   --zd-tag--color__remove-background-image: svg-load('14/remove.svg', color: var(--zd-tag--color-color));
   --zd-tag--yellow__remove-background-image: svg-load('14/remove.svg', color: var(--zd-tag--yellow-color));

--- a/packages/tags/src/_size.css
+++ b/packages/tags/src/_size.css
@@ -2,7 +2,7 @@
 
 :root {
   --zd-tag--lg-border-radius: 4px;
-  --zd-tag--lg-height: var(--zd-spacing-lg);
+  --zd-tag--lg-height: 30px;
   --zd-tag--lg-line-height: calc(30 / 12);
   --zd-tag--lg-padding-horizontal: 12px;
   --zd-tag--lg-padding: 0 var(--zd-tag--lg-padding-horizontal);

--- a/packages/utilities/src/spacing.css
+++ b/packages/utilities/src/spacing.css
@@ -358,6 +358,68 @@
   margin-bottom: calc(var(--zd-spacing-xs) * -1) !important;
 }
 
+/* Extra Extra-Large Spacing */
+
+.u-m-xxl { margin: var(--zd-spacing-xxl) !important; }
+
+.u-mt-xxl { margin-top: var(--zd-spacing-xxl) !important; }
+
+.u-mr-xxl { margin-right: var(--zd-spacing-xxl) !important; }
+
+.u-mb-xxl { margin-bottom: var(--zd-spacing-xxl) !important; }
+
+.u-ml-xxl { margin-left: var(--zd-spacing-xxl) !important; }
+
+.u-mh-xxl {
+  margin-right: var(--zd-spacing-xxl) !important;
+  margin-left: var(--zd-spacing-xxl) !important;
+}
+
+.u-mv-xxl {
+  margin-top: var(--zd-spacing-xxl) !important;
+  margin-bottom: var(--zd-spacing-xxl) !important;
+}
+
+.u-p-xxl { padding: var(--zd-spacing-xxl) !important; }
+
+.u-pt-xxl { padding-top: var(--zd-spacing-xxl) !important; }
+
+.u-pr-xxl { padding-right: var(--zd-spacing-xxl) !important; }
+
+.u-pb-xxl { padding-bottom: var(--zd-spacing-xxl) !important; }
+
+.u-pl-xxl { padding-left: var(--zd-spacing-xxl) !important; }
+
+.u-ph-xxl {
+  padding-right: var(--zd-spacing-xxl) !important;
+  padding-left: var(--zd-spacing-xxl) !important;
+}
+
+.u-pv-xxl {
+  padding-top: var(--zd-spacing-xxl) !important;
+  padding-bottom: var(--zd-spacing-xxl) !important;
+}
+
+.u-m-xxl- { margin: calc(var(--zd-spacing-xxl) * -1) !important; }
+
+.u-mt-xxl- { margin-top: calc(var(--zd-spacing-xxl) * -1) !important; }
+
+.u-mr-xxl- { margin-right: calc(var(--zd-spacing-xxl) * -1) !important; }
+
+.u-mb-xxl- { margin-bottom: calc(var(--zd-spacing-xxl) * -1) !important; }
+
+.u-ml-xxl- { margin-left: calc(var(--zd-spacing-xxl) * -1) !important; }
+
+.u-mh-xxl- {
+  margin-right: calc(var(--zd-spacing-xxl) * -1) !important;
+  margin-left: calc(var(--zd-spacing-xxl) * -1) !important;
+}
+
+.u-mv-xxl- {
+  margin-top: calc(var(--zd-spacing-xxl) * -1) !important;
+  margin-bottom: calc(var(--zd-spacing-xxl) * -1) !important;
+}
+
 /* Extra Extra-Small Spacing */
 
 .u-m-xxs { margin: var(--zd-spacing-xxs) !important; }

--- a/packages/variables/src/_spacing.js
+++ b/packages/variables/src/_spacing.js
@@ -7,12 +7,13 @@
 
 const base = 20;
 const retVal = {
+  'xxs': `${base * 0.2}px`,
+  'xs': `${base * 0.4}px`,
+  'sm': `${base * 0.6}px`,
   '': `${base}px`,
-  'lg': `${base * 1.5}px`,
-  'sm': `${base / 2}px`,
+  'lg': `${base * 1.6}px`,
   'xl': `${base * 2}px`,
-  'xs': `${base / 4}px`,
-  'xxs': `${base / 10}px`
+  'xxl': `${base * 2.4}px`
 };
 
 module.exports = retVal;


### PR DESCRIPTION
- [x] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

| BEFORE | AFTER |
| -------- | ------- |
| `--zd-spacing-xxs: 2px` | `--zd-spacing--xxs: 4px` |
| `--zd-spacing--xs: 5px` | `--zd-spacing--xs: 8px` |
| `--zd-spacing--sm: 10px` | `--zd-spacing--sm: 12px` |
| `--zd-spacing: 20px` | `--zd-spacing: 20px` |
| `--zd-spacing--lg: 30px` | `--zd-spacing--lg: 32px` |
| `--zd-spacing--xl: 40px` | `--zd-spacing--xl: 40px` |
| NA | `--zd-spacing--xxl: 48px` |

All `.u-m[*]` and `.u-p[*]` spacing utilities are updated accordingly with additions for XXL.

## Detail

* Replaced outdated component variable usage with absolute pixel units.
* Pre-deployed and spot-checked garden.zendesk.com website with no observable differences.

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [ ] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
