### PR TITLE
fix(tables): `.c-table__row__cell__overflow` styling applied to `<button>` element

### DIFF
--- a/packages/tables/src/_overflow.css
+++ b/packages/tables/src/_overflow.css
@@ -36,8 +36,10 @@
   border: none; /* [1] */
   background-color: transparent; /* [1] */
   cursor: pointer;
+  padding: 0; /* [1] */
   height: 100%;
   text-decoration: none; /* [2] */
+  font-size: inherit; /* [1] */
 }
 
 .c-table__row__cell__overflow::before,


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Add `<button>` element resets to `.c-table__row__cell__overflow`.

## Detail

closes https://github.com/zendeskgarden/css-components/issues/79

## Checklist

* [ ] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [ ] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
