### PR TITLE
fix(tables): specify width of row overflow button

### DIFF
--- a/packages/tables/src/_overflow.css
+++ b/packages/tables/src/_overflow.css
@@ -37,6 +37,7 @@
   background-color: transparent; /* [1] */
   cursor: pointer;
   padding: 0; /* [1] */
+  width: 100%;
   height: 100%;
   text-decoration: none; /* [2] */
   font-size: inherit; /* [1] */


### PR DESCRIPTION
## Description

When the `.c-table__row__cell__overflow` class is applied the element does not have a specified width. This can cause invalid positioning when used with our `react-menus` package.

## Detail

This PR specifies the width to match 100% of it's container, similar to it's height.

<img width="1070" alt="screen shot 2018-07-18 at 3 11 15 pm" src="https://user-images.githubusercontent.com/4030377/42910554-d8a1bff0-8a9c-11e8-855a-ebe187936efe.png">

## Checklist

* [ ] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [ ] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [ ] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [ ] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
