### PR TITLE
fix(chrome): Reset cursor to default on active sub nav item

### DIFF
--- a/packages/chrome/src/_subnav.css
+++ b/packages/chrome/src/_subnav.css
@@ -85,6 +85,7 @@
 
 .c-chrome__subnav__item:--chrome-current {
   background-color: var(--zd-chrome__subnav__item-current-background-color);
+  cursor: default;
 }
 
 .c-chrome__subnav__item:first-child {


### PR DESCRIPTION
## Description

Sub nav items currently do not reset the cursor to `default` when they're active, this changes matches the top level nav behaviour.

## Detail

![aug-02-2018 12-25-22](https://user-images.githubusercontent.com/143402/43566729-c8e946e6-9672-11e8-845c-3abc26ab127c.gif)

## Checklist

* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
