### PR TITLE
fix(modals): increase flexibility of footer alignment

### DIFF
--- a/packages/modals/src/_footer.css
+++ b/packages/modals/src/_footer.css
@@ -8,9 +8,10 @@
 }
 
 .c-dialog__footer {
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
   padding: var(--zd-dialog__footer-padding);
-  text-align: right;
 }
 
 .c-dialog--large .c-dialog__footer {
@@ -20,10 +21,6 @@
 
 .c-dialog__footer__item {
   margin-left: var(--zd-dialog__footer__btn-margin);
-}
-
-.c-dialog.is-rtl .c-dialog__footer {
-  text-align: left;
 }
 
 .c-dialog.is-rtl .c-dialog__footer__item {


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Change modal footer to use flex-box.

## Detail

<!-- supporting details; screen shot, code, etc. -->
> LTR
![image](https://user-images.githubusercontent.com/14362200/43670869-e9dfa470-9745-11e8-9082-6ad537d3d218.png)

> RTL
![image](https://user-images.githubusercontent.com/14362200/43670872-f6748af2-9745-11e8-9fbc-4c5938e6eaab.png)


<!-- closes GITHUB_ISSUE -->
Closes #86 

## Checklist

* [ ] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
☝️ tested in Chrome, Firefox, and Safari