### PR TITLE
Remove unwanted font weights

### DIFF
--- a/demo/utilities/typography/index.html
+++ b/demo/utilities/typography/index.html
@@ -110,18 +110,6 @@
         <code class="c-code">.u-zeta</code>
         <span>(12px)</span></h3>
       <ul class="u-zeta u-mb-lg">
-        <li class="u-thin u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">THIN</span>
-          <code class="c-code">.u-thin</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
-        <li class="u-light u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">LIGHT</span>
-          <code class="c-code">.u-light</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
         <li class="u-regular u-mb-sm">
           <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">REGULAR</span>
           <code class="c-code">.u-regular</code>
@@ -140,18 +128,6 @@
         <code class="c-code">.u-epsilon</code>
         <span>(14px)</span></h3>
       <ul class="u-epsilon u-mb-lg">
-        <li class="u-thin u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">THIN</span>
-          <code class="c-code">.u-thin</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
-        <li class="u-light u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">LIGHT</span>
-          <code class="c-code">.u-light</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
         <li class="u-regular u-mb-sm">
           <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">REGULAR</span>
           <code class="c-code">.u-regular</code>
@@ -170,18 +146,6 @@
         <code class="c-code">.u-delta</code>
         <span>(16px)</span></h3>
       <ul class="u-delta u-mb-lg">
-        <li class="u-thin u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">THIN</span>
-          <code class="c-code">.u-thin</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
-        <li class="u-light u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">LIGHT</span>
-          <code class="c-code">.u-light</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
         <li class="u-regular u-mb-sm">
           <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">REGULAR</span>
           <code class="c-code">.u-regular</code>
@@ -200,18 +164,6 @@
         <code class="c-code">.u-gamma</code>
         <span>(18px)</span></h3>
       <ul class="u-gamma u-mb-lg">
-        <li class="u-thin u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">THIN</span>
-          <code class="c-code">.u-thin</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
-        <li class="u-light u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">LIGHT</span>
-          <code class="c-code">.u-light</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
         <li class="u-regular u-mb-sm">
           <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">REGULAR</span>
           <code class="c-code">.u-regular</code>
@@ -230,18 +182,6 @@
         <code class="c-code">.u-beta</code>
         <span>(20px)</span></h3>
       <ul class="u-beta u-mb-lg">
-        <li class="u-thin u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">THIN</span>
-          <code class="c-code">.u-thin</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
-        <li class="u-light u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">LIGHT</span>
-          <code class="c-code">.u-light</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
         <li class="u-regular u-mb-sm">
           <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">REGULAR</span>
           <code class="c-code">.u-regular</code>
@@ -260,18 +200,6 @@
         <code class="c-code">.u-alpha</code>
         <span>(22px)</span></h3>
       <ul class="u-alpha u-mb-lg">
-        <li class="u-thin u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">THIN</span>
-          <code class="c-code">.u-thin</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
-        <li class="u-light u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">LIGHT</span>
-          <code class="c-code">.u-light</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
         <li class="u-regular u-mb-sm">
           <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">REGULAR</span>
           <code class="c-code">.u-regular</code>
@@ -292,18 +220,6 @@
         <code class="c-code">.u-nano</code>
         <span>(9px)</span></h3>
       <ul class="u-nano u-mb-lg">
-        <li class="u-thin u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">THIN</span>
-          <code class="c-code">.u-thin</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
-        <li class="u-light u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">LIGHT</span>
-          <code class="c-code">.u-light</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
         <li class="u-regular u-mb-sm">
           <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">REGULAR</span>
           <code class="c-code">.u-regular</code>
@@ -322,18 +238,6 @@
         <code class="c-code">.u-micro</code>
         <span>(10px)</span></h3>
       <ul class="u-micro u-mb-lg">
-        <li class="u-thin u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">THIN</span>
-          <code class="c-code">.u-thin</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
-        <li class="u-light u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">LIGHT</span>
-          <code class="c-code">.u-light</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
         <li class="u-regular u-mb-sm">
           <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">REGULAR</span>
           <code class="c-code">.u-regular</code>
@@ -352,18 +256,6 @@
         <code class="c-code">.u-milli</code>
         <span>(11px)</span></h3>
       <ul class="u-milli u-mb-lg">
-        <li class="u-thin u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">THIN</span>
-          <code class="c-code">.u-thin</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
-        <li class="u-light u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">LIGHT</span>
-          <code class="c-code">.u-light</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
         <li class="u-regular u-mb-sm">
           <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">REGULAR</span>
           <code class="c-code">.u-regular</code>
@@ -382,18 +274,6 @@
         <code class="c-code">.u-kilo</code>
         <span>(25px)</span></h3>
       <ul class="u-kilo u-mb-lg">
-        <li class="u-thin u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">THIN</span>
-          <code class="c-code">.u-thin</code>
-          <p class="js-sample u-line-height-lg"></p>
-          <p><i class="js-sample u-line-height-lg"></i></p>
-        </li>
-        <li class="u-light u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">LIGHT</span>
-          <code class="c-code">.u-light</code>
-          <p class="js-sample u-line-height-lg"></p>
-          <p><i class="js-sample u-line-height-lg"></i></p>
-        </li>
         <li class="u-regular u-mb-sm">
           <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">REGULAR</span>
           <code class="c-code">.u-regular</code>
@@ -412,18 +292,6 @@
         <code class="c-code">.u-mega</code>
         <span>(28px)</span></h3>
       <ul class="u-mega u-mb-lg">
-        <li class="u-thin u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">THIN</span>
-          <code class="c-code">.u-thin</code>
-          <p class="js-sample u-line-height-lg"></p>
-          <p><i class="js-sample u-line-height-lg"></i></p>
-        </li>
-        <li class="u-light u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">LIGHT</span>
-          <code class="c-code">.u-light</code>
-          <p class="js-sample u-line-height-lg"></p>
-          <p><i class="js-sample u-line-height-lg"></i></p>
-        </li>
         <li class="u-regular u-mb-sm">
           <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">REGULAR</span>
           <code class="c-code">.u-regular</code>
@@ -442,18 +310,6 @@
         <code class="c-code">.u-giga</code>
         <span>(36px)</span></h3>
       <ul class="u-giga u-mb-lg">
-        <li class="u-thin u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">THIN</span>
-          <code class="c-code">.u-thin</code>
-          <p class="js-sample u-line-height-xl"></p>
-          <p><i class="js-sample u-line-height-xl"></i></p>
-        </li>
-        <li class="u-light u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">LIGHT</span>
-          <code class="c-code">.u-light</code>
-          <p class="js-sample u-line-height-xl"></p>
-          <p><i class="js-sample u-line-height-xl"></i></p>
-        </li>
         <li class="u-regular u-mb-sm">
           <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">REGULAR</span>
           <code class="c-code">.u-regular</code>

--- a/packages/utilities/src/font-weight.css
+++ b/packages/utilities/src/font-weight.css
@@ -8,27 +8,7 @@
 @import '@zendeskgarden/css-variables';
 
 /* stylelint-disable declaration-no-important */
-.u-thin { font-weight: var(--zd-font-weight-thin) !important; }
-
-.u-extralight { font-weight: var(--zd-font-weight-extralight) !important; }
-
-.u-light { font-weight: var(--zd-font-weight-light) !important; }
-
 .u-regular { font-weight: var(--zd-font-weight-regular) !important; }
 
-.u-medium { font-weight: var(--zd-font-weight-medium) !important; }
-
 .u-semibold { font-weight: var(--zd-font-weight-semibold) !important; }
-
-.u-bold { font-weight: var(--zd-font-weight-bold) !important; }
-
-.u-extrabold { font-weight: var(--zd-font-weight-extrabold) !important; }
-
-.u-black { font-weight: var(--zd-font-weight-black) !important; }
-
-.u-ultralight { font-weight: var(--zd-font-weight-ultralight) !important; }
-
-.u-ultrabold { font-weight: var(--zd-font-weight-ultrabold) !important; }
-
-.u-heavy { font-weight: var(--zd-font-weight-heavy) !important; }
 /* stylelint-enable declaration-no-important */

--- a/packages/utilities/src/jitterfix.css
+++ b/packages/utilities/src/jitterfix.css
@@ -28,21 +28,6 @@
 }
 
 /* stylelint-disable declaration-no-important, max-line-length */
-.u-jitterfix--thin::after { font-weight: var(--zd-font-weight-thin); }
-
-.u-jitterfix--extralight::after { font-weight: var(--zd-font-weight-extralight); }
-
-.u-jitterfix--light::after { font-weight: var(--zd-font-weight-light); }
-
 .u-jitterfix--regular::after { font-weight: var(--zd-font-weight-regular); }
-
-.u-jitterfix--medium::after { font-weight: var(--zd-font-weight-medium); }
-
 .u-jitterfix--semibold::after { font-weight: var(--zd-font-weight-semibold); }
-
-.u-jitterfix--bold::after { font-weight: var(--zd-font-weight-bold); }
-
-.u-jitterfix--extrabold::after { font-weight: var(--zd-font-weight-extrabold); }
-
-.u-jitterfix--black::after { font-weight: var(--zd-font-weight-black); }
 /* stylelint-enable declaration-no-important */

--- a/packages/variables/src/_font-weight.js
+++ b/packages/variables/src/_font-weight.js
@@ -7,22 +7,8 @@
 
 /* https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#Common_weight_name_mapping */
 let retVal = {
-  thin: 100,
-  extralight: 200,
-  light: 300,
   regular: 400,
-  medium: 500,
-  semibold: 600,
-  bold: 700,
-  extrabold: 800,
-  black: 900
+  semibold: 600
 };
-
-/* Aliases */
-retVal = Object.assign(retVal, {
-  ultralight: retVal.extralight,
-  ultrabold: retVal.extrabold,
-  heavy: retVal.black
-});
 
 module.exports = retVal;

--- a/packages/variables/src/_font-weight.js
+++ b/packages/variables/src/_font-weight.js
@@ -6,7 +6,7 @@
  */
 
 /* https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#Common_weight_name_mapping */
-let retVal = {
+const retVal = {
   regular: 400,
   semibold: 600
 };


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "fix(buttons):
     increase specificity for disabled state". the title informs the
     semantic version bump if this PR is merged. -->

- [x] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Our products are only to use font weights 400 (normal) and 600 (semi-bold), so let's remove others to avoid implicitly endorsing their usage.

This removes utility classes and variables, so it’s a breaking change.

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

* [ ] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [ ] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [ ] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [ ] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
