### PR TITLE
feat(chrome): update nav elements with option to wrap text

### DIFF
--- a/demo/chrome/index.html
+++ b/demo/chrome/index.html
@@ -412,7 +412,7 @@
                   <span class="c-chrome__nav__fab__text">0</span>
                 </button>
               </nav>
-              <nav class="c-chrome__subnav">
+              <nav class="c-chrome__subnav" style="max-width:180px">
                 <a class="c-chrome__subnav__item is-current" href>
                   <span class="c-chrome__subnav__item__text">Personal</span>
                 </a>
@@ -421,6 +421,9 @@
                 </a>
                 <a class="c-chrome__subnav__item" href>
                   <span class="c-chrome__subnav__item__text">Channels</span>
+                </a>
+                <a class="c-chrome__subnav__item" href>
+                  <span class="c-chrome__subnav__item__text c-chrome__subnav__item__text--wrap">Experimental Features</span>
                 </a>
               </nav>
             </div>
@@ -891,6 +894,7 @@
           <li class="u-mb-sm"><code class="c-code">.c-chrome--custom</code> – toggles accent overrides (via settings menu).</li>
           <li class="u-mb-sm"><code class="c-code">.c-chrome__nav__item--logo</code> – style the product logo shown as the top item in the nav.</li>
           <li class="u-mb-sm"><code class="c-code">.c-chrome__nav__item.is-current</code> – indicate which item is current in the nav.</li>
+          <li class="u-mb-sm"><code class="c-code">.c-chrome__nav__item__text--wrap</code> – use to wrap long text in the nav.</li>
           <li class="u-mb-sm"><code class="c-code">.c-chrome__body__header__item--logo</code> – style the product logo shown as the first item in the header (only displayed in standalone).</li>
           <li class="u-mb-sm"><code class="c-code">.c-chrome__body__header__item--max-x</code> – horizontally maximize a flex item in the header to take as much space as possible (i.e. breadcrumb container or an empty element separating starting items from ending items).</li>
           <li class="u-mb-sm"><code class="c-code">.c-chrome__body__header__item--max-y</code> – vertically maximize the height for a header item (i.e. contains a search input).</li>

--- a/demo/chrome/index.html
+++ b/demo/chrome/index.html
@@ -895,6 +895,7 @@
           <li class="u-mb-sm"><code class="c-code">.c-chrome__nav__item--logo</code> – style the product logo shown as the top item in the nav.</li>
           <li class="u-mb-sm"><code class="c-code">.c-chrome__nav__item.is-current</code> – indicate which item is current in the nav.</li>
           <li class="u-mb-sm"><code class="c-code">.c-chrome__nav__item__text--wrap</code> – use to wrap long text in the nav.</li>
+          <li class="u-mb-sm"><code class="c-code">.c-chrome__subnav__item__text--wrap</code> – combine with max-width on the <code class="c-code">.c-chrome__subnav</code> container to wrap long text.</li>
           <li class="u-mb-sm"><code class="c-code">.c-chrome__body__header__item--logo</code> – style the product logo shown as the first item in the header (only displayed in standalone).</li>
           <li class="u-mb-sm"><code class="c-code">.c-chrome__body__header__item--max-x</code> – horizontally maximize a flex item in the header to take as much space as possible (i.e. breadcrumb container or an empty element separating starting items from ending items).</li>
           <li class="u-mb-sm"><code class="c-code">.c-chrome__body__header__item--max-y</code> – vertically maximize the height for a header item (i.e. contains a search input).</li>

--- a/demo/chrome/page.html
+++ b/demo/chrome/page.html
@@ -53,7 +53,7 @@
       <svg class="c-chrome__nav__item__icon">
         <use xlink:href="../index.svg#zd-svg-icon-26-settings-fill" />
       </svg>
-      <span class="c-chrome__nav__item__text">Settings</span>
+      <span class="c-chrome__nav__item__text c-chrome__nav__item__text--wrap">Administrative Settings</span>
     </a>
     <button class="c-chrome__nav__fab">
       <svg class="c-chrome__nav__fab__icon">
@@ -268,6 +268,7 @@
   <script>
   $(document).ready(function() {
     $('.c-chrome').toggleClass('is-rtl', Garden.parameters.dir === 'rtl');
+    $('.c-chrome__nav').toggleClass('c-chrome__nav--expanded', Garden.parameters.expanded === 'true');
     updateNavColor($('.c-chrome__nav'), Garden.parameters.color);
   });
   </script>

--- a/packages/chrome/src/_nav.css
+++ b/packages/chrome/src/_nav.css
@@ -26,6 +26,9 @@
   --zd-chrome__nav__fab__text-margin: 0 4px;
   --zd-chrome__nav__item-height: 50px;
   --zd-chrome__nav__item-opacity: .6;
+  --zd-chrome__nav__item-padding-horizontal: calc(calc(var(--zd-chrome__nav-width) - var(--zd-chrome__nav__item__icon-size)) / 4);
+  --zd-chrome__nav__item-padding-vertical: calc(calc(var(--zd-chrome__nav__item-height) - var(--zd-chrome__nav__item__icon-size)) / 2);
+  --zd-chrome__nav__item-padding: var(--zd-chrome__nav__item-padding-vertical) var(--zd-chrome__nav__item-padding-horizontal);
   --zd-chrome__nav__item-transition:
     box-shadow .1s ease-in-out,
     background-color .1s ease-in-out,
@@ -38,9 +41,9 @@
   --zd-chrome__nav__item-hovered-background-color: color(var(--zd-color-black) alpha(10%));
   --zd-chrome__nav__item__icon-border-radius: 4px;
   --zd-chrome__nav__item__icon-size: 26px;
+  --zd-chrome__nav__item__text-line-height: calc(20 / 14);
   --zd-chrome__nav--expanded-width: 200px;
-  --zd-chrome__nav--expanded__item-padding: 0 calc(calc(var(--zd-chrome__nav-width) - var(--zd-chrome__nav__item__icon-size)) / 4);
-  --zd-chrome__nav--expanded__item__-margin: var(--zd-chrome__nav--expanded__item-padding);
+  --zd-chrome__nav--expanded__item__-margin: 0 var(--zd-chrome__nav__item-padding-horizontal);
 }
 
 /* 1. Button reset.
@@ -69,7 +72,8 @@
   border: none; /* [1] */
   background: transparent; /* [1] */
   cursor: pointer;
-  height: var(--zd-chrome__nav__item-height);
+  padding: var(--zd-chrome__nav__item-padding);
+  min-height: var(--zd-chrome__nav__item-height);
   font-size: inherit; /* [1] */
 }
 
@@ -98,6 +102,7 @@
 }
 
 .c-chrome__nav__item__icon {
+  align-self: flex-start;
   order: var(--zd-chrome__nav__item__icon-order);
   border-radius: var(--zd-chrome__nav__item__icon-border-radius);
   width: var(--zd-chrome__nav__item__icon-size);
@@ -106,7 +111,12 @@
 
 .c-chrome__nav__item__text {
   order: var(--zd-chrome__nav__item__text-order);
+  line-height: var(--zd-chrome__nav__item__text-line-height);
   @apply --zd-chrome__item__text-clipped;
+}
+
+.c-chrome__nav__item__text--wrap {
+  white-space: normal;
 }
 
 .c-chrome__nav__fab {
@@ -151,7 +161,6 @@
 
 .c-chrome__nav--expanded .c-chrome__nav__item:not(.c-chrome__nav__item--logo) {
   justify-content: start;
-  padding: var(--zd-chrome__nav--expanded__item-padding);
   text-align: left;
 }
 

--- a/packages/chrome/src/_subnav.css
+++ b/packages/chrome/src/_subnav.css
@@ -9,8 +9,8 @@
   --zd-chrome__subnav-min-width: 180px;
   --zd-chrome__subnav-padding: 30px 20px;
   --zd-chrome__subnav__item-border-radius: 4px;
-  --zd-chrome__subnav__item-line-height: calc(30 / 14);
   --zd-chrome__subnav__item-margin: 8px;
+  --zd-chrome__subnav__item-min-height: 30px;
   --zd-chrome__subnav__item-opacity: .6;
   --zd-chrome__subnav__item-padding: 0 8px;
   --zd-chrome__subnav__item-transition:
@@ -23,6 +23,8 @@
     0 0 0 3px
     color(var(--zd-color-white) alpha(20%));
   --zd-chrome__subnav__item-hovered-background-color: color(var(--zd-color-black) alpha(10%));
+  --zd-chrome__subnav__item__text-line-height: calc(20 / 14);
+  --zd-chrome__subnav__item__text-margin: calc(calc(var(--zd-chrome__subnav__item-min-height) - 20px) / 2) 0;
 }
 
 .c-chrome__subnav {
@@ -40,6 +42,7 @@
 
 .c-chrome__subnav__item {
   display: flex;
+  align-items: center;
   transition: var(--zd-chrome__subnav__item-transition);
   opacity: var(--zd-chrome__subnav__item-opacity);
   margin-top: var(--zd-chrome__subnav__item-margin);
@@ -49,8 +52,7 @@
   cursor: pointer; /* [2] */
   padding: var(--zd-chrome__subnav__item-padding);
   width: 100%; /* [2] */
-  line-height: var(--zd-chrome__subnav__item-line-height);
-  white-space: nowrap;
+  min-height: var(--zd-chrome__subnav__item-min-height);
   font-size: inherit; /* [2] */
 }
 
@@ -97,6 +99,13 @@
 }
 
 .c-chrome__subnav__item__text {
+  margin: var(--zd-chrome__subnav__item__text-margin);
   overflow: hidden;
   text-overflow: ellipsis;
+  line-height: var(--zd-chrome__subnav__item__text-line-height);
+  white-space: nowrap;
+}
+
+.c-chrome__subnav__item__text--wrap {
+  white-space: normal;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -141,13 +141,6 @@ ajv-keywords@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.2.0.tgz#e86b819c602cf8821ad637413698f1dec021847a"
 
-ajv@^4.9.1:
-  version "4.11.8"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-4.11.8.tgz#82ffb02b29e662ae53bdc20af15947706739c536"
-  dependencies:
-    co "^4.6.0"
-    json-stable-stringify "^1.0.1"
-
 ajv@^5.1.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
@@ -311,10 +304,6 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
 
-assert-plus@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
-
 assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
@@ -371,15 +360,11 @@ autoprefixer@^9.0.0:
     postcss "^7.0.1"
     postcss-value-parser "^3.2.3"
 
-aws-sign2@~0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.6.0.tgz#14342dd38dbcc94d0e5b87d763cd63612c0e794f"
-
 aws-sign2@~0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
 
-aws4@^1.2.1, aws4@^1.6.0:
+aws4@^1.6.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
 
@@ -474,12 +459,6 @@ block-stream@*:
 boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
-
-boom@2.x.x:
-  version "2.10.1"
-  resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
-  dependencies:
-    hoek "2.x.x"
 
 bootstrap@^4.1.3:
   version "4.1.3"
@@ -895,7 +874,7 @@ columnify@^1.5.4:
     strip-ansi "^3.0.0"
     wcwidth "^1.0.0"
 
-combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
+combined-stream@1.0.6, combined-stream@~1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
   dependencies:
@@ -1166,12 +1145,6 @@ cross-spawn@^6.0.5:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
-
-cryptiles@2.x.x:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/cryptiles/-/cryptiles-2.0.5.tgz#3bdfecdc608147c1c67202fa291e7dca59eaa3b8"
-  dependencies:
-    boom "2.x.x"
 
 css-color-function@~1.3.3:
   version "1.3.3"
@@ -1787,7 +1760,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
+extend@^3.0.0, extend@~3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
 
@@ -1977,14 +1950,6 @@ foreach@^2.0.5:
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
-
-form-data@~2.1.1:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.1.4.tgz#33c183acf193276ecaa98143a69e94bfee1750d1"
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.5"
-    mime-types "^2.1.12"
 
 form-data@~2.3.1:
   version "2.3.2"
@@ -2305,20 +2270,9 @@ handlebars@4.0.11, handlebars@^4.0.2:
   optionalDependencies:
     uglify-js "^2.6"
 
-har-schema@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-1.0.5.tgz#d263135f43307c02c602afc8fe95970c0151369e"
-
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
-
-har-validator@~4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-4.2.1.tgz#33481d0f1bbff600dd203d75812a6a5fba002e2a"
-  dependencies:
-    ajv "^4.9.1"
-    har-schema "^1.0.5"
 
 har-validator@~5.0.3:
   version "5.0.3"
@@ -2386,22 +2340,9 @@ has@^1.0.0, has@^1.0.1:
   dependencies:
     function-bind "^1.1.1"
 
-hawk@~3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
-  dependencies:
-    boom "2.x.x"
-    cryptiles "2.x.x"
-    hoek "2.x.x"
-    sntp "1.x.x"
-
 hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
-
-hoek@2.x.x:
-  version "2.16.3"
-  resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
 hosted-git-info@^2.1.4, hosted-git-info@^2.5.0:
   version "2.7.1"
@@ -2455,14 +2396,6 @@ http-errors@~1.6.2:
 http-parser-js@>=0.4.0:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.4.13.tgz#3bd6d6fde6e3172c9334c3b33b6c193d80fe1137"
-
-http-signature@~1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
-  dependencies:
-    assert-plus "^0.2.0"
-    jsprim "^1.2.2"
-    sshpk "^1.7.0"
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -3008,12 +2941,6 @@ json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
 
-json-stable-stringify@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz#9a759d39c5f2ff503fd5300646ed445f88c4f9af"
-  dependencies:
-    jsonify "~0.0.0"
-
 json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
@@ -3029,10 +2956,6 @@ jsonfile@^4.0.0:
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
   optionalDependencies:
     graceful-fs "^4.1.6"
-
-jsonify@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
 
 jsonlint@1.6.3:
   version "1.6.3"
@@ -3448,7 +3371,7 @@ mime-db@~1.35.0:
   version "1.35.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.35.0.tgz#0569d657466491283709663ad379a99b90d9ab47"
 
-mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.18, mime-types@~2.1.7:
+mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.18:
   version "2.1.19"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.19.tgz#71e464537a7ef81c15f2db9d97e913fc0ff606f0"
   dependencies:
@@ -3596,8 +3519,8 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.4.tgz#d93962f6c52f2c1558c0fbda6d512819f1efe1c4"
 
 node-gyp@^3.3.1:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.7.0.tgz#789478e8f6c45e277aa014f3e28f958f286f9203"
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-3.8.0.tgz#540304261c330e80d0d5edce253a68cb3964218c"
   dependencies:
     fstream "^1.0.0"
     glob "^7.0.3"
@@ -3606,7 +3529,7 @@ node-gyp@^3.3.1:
     nopt "2 || 3"
     npmlog "0 || 1 || 2 || 3 || 4"
     osenv "0"
-    request ">=2.9.0 <2.82.0"
+    request "^2.87.0"
     rimraf "2"
     semver "~5.3.0"
     tar "^2.0.0"
@@ -3757,7 +3680,7 @@ number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
 
-oauth-sign@~0.8.1, oauth-sign@~0.8.2:
+oauth-sign@~0.8.2:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
@@ -4042,10 +3965,6 @@ pause-stream@0.0.11:
   resolved "https://registry.yarnpkg.com/pause-stream/-/pause-stream-0.0.11.tgz#fe5a34b0cbce12b5aa6a2b403ee2e73b602f1445"
   dependencies:
     through "~2.3"
-
-performance-now@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
 
 performance-now@^2.1.0:
   version "2.1.0"
@@ -4787,10 +4706,6 @@ q@^1.1.2, q@^1.4.1, q@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
 
-qs@~6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
-
 qs@~6.5.1:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
@@ -5057,7 +4972,7 @@ replace-ext@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
 
-request@2.87.0:
+request@2.87.0, request@^2.87.0:
   version "2.87.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
   dependencies:
@@ -5081,33 +4996,6 @@ request@2.87.0:
     tough-cookie "~2.3.3"
     tunnel-agent "^0.6.0"
     uuid "^3.1.0"
-
-"request@>=2.9.0 <2.82.0":
-  version "2.81.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
-  dependencies:
-    aws-sign2 "~0.6.0"
-    aws4 "^1.2.1"
-    caseless "~0.12.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.0"
-    forever-agent "~0.6.1"
-    form-data "~2.1.1"
-    har-validator "~4.2.1"
-    hawk "~3.1.3"
-    http-signature "~1.1.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.7"
-    oauth-sign "~0.8.1"
-    performance-now "^0.2.0"
-    qs "~6.4.0"
-    safe-buffer "^5.0.1"
-    stringstream "~0.0.4"
-    tough-cookie "~2.3.0"
-    tunnel-agent "^0.6.0"
-    uuid "^3.0.0"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -5386,12 +5274,6 @@ snapdragon@^0.8.1:
     source-map-resolve "^0.5.0"
     use "^3.1.0"
 
-sntp@1.x.x:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/sntp/-/sntp-1.0.9.tgz#6541184cc90aeea6c6e7b35e2659082443c66198"
-  dependencies:
-    hoek "2.x.x"
-
 sort-keys@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-1.1.2.tgz#441b6d4d346798f1b4e49e8920adfba0e543f9ad"
@@ -5591,10 +5473,6 @@ stringify-entities@^1.0.1:
     character-entities-legacy "^1.0.0"
     is-alphanumerical "^1.0.0"
     is-hexadecimal "^1.0.0"
-
-stringstream@~0.0.4:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.6.tgz#7880225b0d4ad10e30927d167a1d6f2fd3b33a72"
 
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
@@ -5904,7 +5782,7 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
-tough-cookie@~2.3.0, tough-cookie@~2.3.3:
+tough-cookie@~2.3.3:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"
   dependencies:


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Add `.c-chrome__nav__item__text--wrap` and `.c-chrome__subnav__item__text--wrap` to support styling for longer navigation text that needs to wrap.

## Detail

closes #82 

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
