### PR TITLE
fix(chrome): add subnav styling resets

### DIFF
--- a/demo/chrome/index.html
+++ b/demo/chrome/index.html
@@ -406,7 +406,7 @@
                   <svg class="c-chrome__nav__item__icon">
                     <use xlink:href="../index.svg#zd-svg-icon-26-settings-fill" />
                   </svg>
-                  <span class="c-chrome__nav__item__text">Settings</span>
+                  <span class="c-chrome__nav__item__text c-chrome__nav__item__text--wrap">Administrative Settings</span>
                 </a>
                 <button class="c-chrome__nav__fab">
                   <span class="c-chrome__nav__fab__text">0</span>

--- a/packages/chrome/src/_nav.css
+++ b/packages/chrome/src/_nav.css
@@ -161,7 +161,7 @@
 
 .c-chrome__nav--expanded .c-chrome__nav__item:not(.c-chrome__nav__item--logo) {
   justify-content: start;
-  text-align: left;
+  text-align: inherit;
 }
 
 .c-chrome__nav--expanded .c-chrome__nav__item__icon,
@@ -213,10 +213,6 @@
 .c-chrome__nav__item:not(.c-chrome__nav__item--logo):active:--chrome-focused,
 .c-chrome__nav__fab:active:--chrome-focused {
   box-shadow: var(--zd-chrome__nav__fab-box-shadow);
-}
-
-.c-chrome.is-rtl .c-chrome__nav--expanded .c-chrome__nav__item:not(.c-chrome__nav__item--logo) {
-  text-align: right;
 }
 /* stylelint-enable max-line-length, selector-max-specificity */
 

--- a/packages/chrome/src/_subnav.css
+++ b/packages/chrome/src/_subnav.css
@@ -53,6 +53,7 @@
   padding: var(--zd-chrome__subnav__item-padding);
   width: 100%; /* [2] */
   min-height: var(--zd-chrome__subnav__item-min-height);
+  text-align: inherit; /* [2] */
   font-size: inherit; /* [2] */
 }
 


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Currently if `c-chrome__subnav__item` elements are rendered using `<button>` elements, wrapped text will incorrectly center.

## Detail

<img width="179" alt="screen shot 2018-08-15 at 1 25 20 pm" src="https://user-images.githubusercontent.com/143773/44171624-86f87f00-a08f-11e8-951c-415c3d4b4d09.png">

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
