### PR TITLE
chore: prevent uncommitted changes from breaking `lerna publish`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ install: yarn --frozen-lockfile
 
 before_deploy:
   - export NODE_DEBUG=gh-pages
-  - find demo -type l | xargs sed -i '' || true # convert symlinks to regular files
   - npm config set //registry.npmjs.org/:_authToken $NPM_TOKEN
 
 deploy:


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

The symlink => regular file conversion was required by the Travis "pages" provider, which is no longer used.