### PR TITLE
feat(variables|utilities): add support for updated typography

### DIFF
--- a/demo/arrows/index.html
+++ b/demo/arrows/index.html
@@ -181,7 +181,7 @@
         </div>
       </div>
       <h1 class="u-beta u-mb-xs">Examples</h1>
-      <h2 class="u-zeta u-semibold u-mb">USING CSS-MENUS</h2>
+      <h2 class="u-fs-sm u-semibold u-mb">USING CSS-MENUS</h2>
       <p class="u-mb">Component classes for adding arrows to other elements
       (typically used in conjunction with with the menu and tooltip
       components). Arrows consist of the base
@@ -189,7 +189,7 @@
       class in addition to a positioning modifier class.</p>
       <div class="l-grid u-mv-xl">
         <div class="l-grid__item u-1/3">
-          <h2 class="u-zeta u-semibold u-mb">BOTTOM LEFT</h2>
+          <h2 class="u-fs-sm u-semibold u-mb">BOTTOM LEFT</h2>
           <code class="c-code">.c-arrow.c-arrow--bl</code>
           <div class="u-mt u-position-relative u-z-index-0">
             <ul class="c-menu c-arrow c-arrow--bl u-bc-blue-600 u-bg-grey-100 u-opacity-opaque u-visibility-visible">
@@ -200,7 +200,7 @@
           </div>
         </div
         ><div class="l-grid__item u-1/3">
-          <h2 class="u-zeta u-semibold u-mb">BOTTOM</h2>
+          <h2 class="u-fs-sm u-semibold u-mb">BOTTOM</h2>
           <code class="c-code">.c-arrow.c-arrow--b</code>
           <div class="u-mt u-position-relative u-z-index-0">
             <ul class="c-menu c-arrow c-arrow--b u-bc-blue-600 u-bg-grey-100 u-opacity-opaque u-visibility-visible">
@@ -211,7 +211,7 @@
           </div>
         </div
         ><div class="l-grid__item u-1/3">
-          <h2 class="u-zeta u-semibold u-mb">BOTTOM RIGHT</h2>
+          <h2 class="u-fs-sm u-semibold u-mb">BOTTOM RIGHT</h2>
           <code class="c-code">.c-arrow.c-arrow--br</code>
           <div class="u-mt u-position-relative u-z-index-0">
             <ul class="c-menu c-arrow c-arrow--br u-bc-blue-600 u-bg-grey-100 u-opacity-opaque u-visibility-visible">
@@ -225,7 +225,7 @@
 
       <div class="l-grid u-mv-xl">
         <div class="l-grid__item u-1/3">
-          <h2 class="u-zeta u-semibold u-mb">LEFT TOP</h2>
+          <h2 class="u-fs-sm u-semibold u-mb">LEFT TOP</h2>
           <code class="c-code">.c-arrow.c-arrow--lt</code>
           <div class="u-mt u-position-relative u-z-index-0">
             <ul class="c-menu c-arrow c-arrow--lt u-bc-blue-600 u-bg-grey-100 u-opacity-opaque u-visibility-visible">
@@ -238,7 +238,7 @@
         ><div class="l-grid__item u-1/3">
         </div
         ><div class="l-grid__item u-1/3">
-          <h2 class="u-zeta u-semibold u-mb">RIGHT TOP</h2>
+          <h2 class="u-fs-sm u-semibold u-mb">RIGHT TOP</h2>
           <code class="c-code">.c-arrow.c-arrow--rt</code>
           <div class="u-mt u-position-relative u-z-index-0">
             <ul class="c-menu c-arrow c-arrow--rt u-bc-blue-600 u-bg-grey-100 u-opacity-opaque u-visibility-visible">
@@ -252,7 +252,7 @@
 
       <div class="l-grid u-mv-xl">
         <div class="l-grid__item u-1/3">
-          <h2 class="u-zeta u-semibold u-mb">CENTER LEFT</h2>
+          <h2 class="u-fs-sm u-semibold u-mb">CENTER LEFT</h2>
           <code class="c-code">.c-arrow.c-arrow--l</code>
           <div class="u-mt u-position-relative u-z-index-0">
             <ul class="c-menu c-arrow c-arrow--l u-bc-blue-600 u-bg-grey-100 u-opacity-opaque u-visibility-visible">
@@ -265,7 +265,7 @@
         ><div class="l-grid__item u-1/3">
         </div
         ><div class="l-grid__item u-1/3">
-          <h2 class="u-zeta u-semibold u-mb">CENTER RIGHT</h2>
+          <h2 class="u-fs-sm u-semibold u-mb">CENTER RIGHT</h2>
           <code class="c-code">.c-arrow.c-arrow--r</code>
           <div class="u-mt u-position-relative u-z-index-0">
             <ul class="c-menu c-arrow c-arrow--r u-bc-blue-600 u-bg-grey-100 u-opacity-opaque u-visibility-visible">
@@ -279,7 +279,7 @@
 
       <div class="l-grid u-mv-xl">
         <div class="l-grid__item u-1/3">
-          <h2 class="u-zeta u-semibold u-mb">LEFT BOTTOM</h2>
+          <h2 class="u-fs-sm u-semibold u-mb">LEFT BOTTOM</h2>
           <code class="c-code">.c-arrow.c-arrow--lb</code>
           <div class="u-mt u-position-relative u-z-index-0">
             <ul class="c-menu c-arrow c-arrow--lb u-bc-blue-600 u-bg-grey-100 u-opacity-opaque u-visibility-visible">
@@ -292,7 +292,7 @@
         ><div class="l-grid__item u-1/3">
         </div
         ><div class="l-grid__item u-1/3">
-          <h2 class="u-zeta u-semibold u-mb">RIGHT BOTTOM</h2>
+          <h2 class="u-fs-sm u-semibold u-mb">RIGHT BOTTOM</h2>
           <code class="c-code">.c-arrow.c-arrow--rb</code>
           <div class="u-mt u-position-relative u-z-index-0">
             <ul class="c-menu c-arrow c-arrow--rb u-bc-blue-600 u-bg-grey-100 u-opacity-opaque u-visibility-visible">
@@ -306,7 +306,7 @@
 
       <div class="l-grid u-mv-xl">
         <div class="l-grid__item u-1/3">
-          <h2 class="u-zeta u-semibold u-mb">TOP LEFT</h2>
+          <h2 class="u-fs-sm u-semibold u-mb">TOP LEFT</h2>
           <code class="c-code">.c-arrow.c-arrow--tl</code>
           <div class="u-mt u-position-relative u-z-index-0">
             <ul class="c-menu c-arrow c-arrow--tl u-bc-blue-600 u-bg-grey-100 u-opacity-opaque u-visibility-visible">
@@ -317,7 +317,7 @@
           </div>
         </div
         ><div class="l-grid__item u-1/3">
-          <h2 class="u-zeta u-semibold u-mb">TOP</h2>
+          <h2 class="u-fs-sm u-semibold u-mb">TOP</h2>
           <code class="c-code">.c-arrow.c-arrow--t</code>
           <div class="u-mt u-position-relative u-z-index-0">
             <ul class="c-menu c-arrow c-arrow--t u-bc-blue-600 u-bg-grey-100 u-opacity-opaque u-visibility-visible">
@@ -328,7 +328,7 @@
           </div>
         </div
         ><div class="l-grid__item u-1/3">
-          <h2 class="u-zeta u-semibold u-mb">TOP RIGHT</h2>
+          <h2 class="u-fs-sm u-semibold u-mb">TOP RIGHT</h2>
           <code class="c-code">.c-arrow.c-arrow--tr</code>
           <div class="u-mt u-position-relative u-z-index-0">
             <ul class="c-menu c-arrow c-arrow--tr u-bc-blue-600 u-bg-grey-100 u-opacity-opaque u-visibility-visible">

--- a/demo/avatars/index.html
+++ b/demo/avatars/index.html
@@ -45,7 +45,7 @@
       <p class="u-mb">Component classes for styling your avatars. Enabling "Dark Mode" adds the
         <code class="c-code">.c-avatar--borderless</code>
         class to each avatar for improved display on a dark background.</p>
-      <h2 class="u-gamma u-mb-sm">Types</h2>
+      <h2 class="u-fs-lg u-mb-sm">Types</h2>
       <ul class="u-mb">
         <li class="l-flag u-mb-sm">
           <div class="l-flag__figure">
@@ -68,7 +68,7 @@
           </div>
         </li>
       </ul>
-      <h2 class="u-gamma u-mb-sm">Sizes</h2>
+      <h2 class="u-fs-lg u-mb-sm">Sizes</h2>
       <ul class="u-mb">
         <li class="l-grid u-mb-sm">
           <div class="l-flag l-grid__item u-1/2">
@@ -115,7 +115,7 @@
           </div>
         </li>
       </ul>
-      <h2 class="u-gamma u-mb-sm">States</h2>
+      <h2 class="u-fs-lg u-mb-sm">States</h2>
       <div class="u-mb u-ml-sm">
         <h3 class="u-delta u-mb-sm">Disabled</h3>
         <ul class="u-mb-sm">
@@ -187,7 +187,7 @@
           </li>
         </ul>
       </div>
-      <h2 class="u-gamma u-mb-sm">Layout</h2>
+      <h2 class="u-fs-lg u-mb-sm">Layout</h2>
       <ul class="l-grid u-mb-lg">
         <li class="l-grid__item u-1/3">
           <div class="l-flag">

--- a/demo/buttons/index.html
+++ b/demo/buttons/index.html
@@ -67,7 +67,7 @@
         consistent button styling. See the Garden React
         <a href="//zendeskgarden.github.io/react-components/buttons/">buttons</a>
         package for enhanced keyboard and event behavior.</p>
-      <h2 class="u-gamma u-mb-sm">Types</h2>
+      <h2 class="u-fs-lg u-mb-sm">Types</h2>
       <ul class="u-mb">
         <li class="u-mb-sm"><button class="c-btn">.c-btn</button></li>
         <li class="u-mb-sm"><button class="c-btn c-btn--primary">.c-btn.c-btn--primary</button></li>
@@ -76,7 +76,7 @@
         <li class="u-mb-sm"><button class="c-btn c-btn--muted">.c-btn.c-btn--muted</button></li>
         <li class="u-mb-sm"><button class="c-btn c-btn--anchor">.c-btn.c-btn--anchor</button></li>
       </ul>
-      <h2 class="u-gamma u-mb-sm">Colors</h2>
+      <h2 class="u-fs-lg u-mb-sm">Colors</h2>
       <ul class="u-mb">
         <li class="u-mb-sm"><button class="c-btn c-btn--danger">.c-btn.c-btn--danger</button></li>
         <li class="u-mb-sm"><button class="c-btn c-btn--primary c-btn--danger">.c-btn.c-btn--primary.c-btn--danger</button></li>
@@ -84,7 +84,7 @@
         <li class="u-mb-sm"><button class="c-btn c-btn--basic c-btn--danger">.c-btn.c-btn--basic.c-btn--danger</button></li>
         <li class="u-mb-sm"><button class="c-btn c-btn--anchor c-btn--danger">.c-btn.c-btn--anchor.c-btn--danger</button></li>
       </ul>
-      <h2 class="u-gamma u-mb-sm">Sizes</h2>
+      <h2 class="u-fs-lg u-mb-sm">Sizes</h2>
       <ul class="u-mb">
         <li class="u-mb-sm"><button class="c-btn c-btn--sm">.c-btn.c-btn--sm</button></li>
         <li class="u-mb-sm"><button class="c-btn c-btn--lg">.c-btn.c-btn--lg</button></li>
@@ -94,7 +94,7 @@
           ><span class="l-grid__item u-1/3"><button class="c-btn c-btn--full">.c-btn.c-btn--full</button></span>
         </li>
       </ul>
-      <h2 class="u-gamma u-mb-sm">States</h2>
+      <h2 class="u-fs-lg u-mb-sm">States</h2>
       <div class="l-grid u-mb" style="min-width:1380px">
         <ul class="l-grid__item u-1/5">
           <li class="u-mb-sm"><button class="c-btn is-disabled" disabled>.c-btn.is-disabled</button></li>
@@ -127,14 +127,14 @@
           <li class="u-mb-sm"><button class="c-btn c-btn--anchor is-active u-mb-sm">.c-btn.c-btn--anchor.is-active</button></li>
         </ul>
       </div>
-      <h2 class="u-gamma u-mb-sm">Elements</h2>
+      <h2 class="u-fs-lg u-mb-sm">Elements</h2>
       <ul class="u-mb">
         <li class="u-mb-sm"><a class="c-btn" href="#" role="button">&lt;a&gt;</a></li>
         <li class="u-mb-sm"><input class="c-btn" type="button" value="&lt;input&gt;"></li>
         <li class="u-mb-sm"><input class="c-btn" disabled type="button" value="&lt;input [disabled]&gt;"></li>
         <li class="u-mb-sm"><div class="c-btn" tabindex="0">&lt;div&gt;</div></li>
       </ul>
-      <h2 class="u-gamma u-mb-sm">Icons</h2>
+      <h2 class="u-fs-lg u-mb-sm">Icons</h2>
       <p class="u-mb-sm">The
         <code class="c-code">.c-btn--icon</code>
         modifier is used to support icon buttons. Style the child image using
@@ -194,7 +194,7 @@
           </button>
         </ul>
       </div>
-      <h2 class="u-gamma u-mb-sm">Groups</h2>
+      <h2 class="u-fs-lg u-mb-sm">Groups</h2>
       <p class="u-mb-sm">The
         <code class="c-code">.l-btn-group</code>
         layout class can be used as a container for grouped buttons. Use
@@ -234,7 +234,7 @@
         </div>
       </div>
       <section id="playground">
-        <h1 class="c-main__subtitle u-alpha u-mb">Playground</h1>
+        <h1 class="c-main__subtitle u-fs-xl u-mb">Playground</h1>
         <div class="c-playground">
           <div class="c-playground__preview"></div>
 <textarea class="c-playground__code"><div class="l-btn-group">

--- a/demo/callouts/index.html
+++ b/demo/callouts/index.html
@@ -103,7 +103,7 @@
             </div>
           </div>
         </div>
-        <h2 class="u-gamma u-mb-sm">Alert Modifications</h2>
+        <h2 class="u-fs-lg u-mb-sm">Alert Modifications</h2>
         <div class="l-grid u-mb-lg">
           <div class="l-grid__item u-1/2 u-mb">
             <div class="c-callout c-callout--success">
@@ -166,7 +166,7 @@
             </div>
           </div>
         </div>
-        <h2 class="u-gamma u-mb-sm">Close Button</h2>
+        <h2 class="u-fs-lg u-mb-sm">Close Button</h2>
         <p class="u-mb">Include the optional
           <code class="c-code">.c-callout__close</code> child element to produce
           a dismissable alert.</p>
@@ -246,7 +246,7 @@
         </div>
       </div>
       <section id="playground">
-        <h1 class="c-main__subtitle u-alpha u-mb">Playground</h1>
+        <h1 class="c-main__subtitle u-fs-xl u-mb">Playground</h1>
         <div class="c-playground">
           <div class="c-playground__preview"></div>
 <textarea class="c-playground__code"><div class="c-callout c-callout--recessed">

--- a/demo/chrome/index.html
+++ b/demo/chrome/index.html
@@ -78,7 +78,7 @@
       specific product pages.</p>
 
       <div class="u-mb-lg">
-        <h2 class="c-main__subtitle u-gamma u-mb">Basic Structure</h2>
+        <h2 class="c-main__subtitle u-fs-lg u-mb">Basic Structure</h2>
         <p class="u-mb">The product chrome CSS classes describe the following
         canonical structure. Although exact implementations will vary, be sure
         to sequence the components as indicated so that tab order is consistent
@@ -168,7 +168,7 @@
       </div>
 
       <div class="u-mb-xl">
-        <h2 class="c-main__subtitle u-gamma u-mb">Navigation</h2>
+        <h2 class="c-main__subtitle u-fs-lg u-mb">Navigation</h2>
         <p class="u-mb">The <code class="c-code">.c-chrome__nav</code> element
         is the home for the product logo and main navigation items. In addition,
         products may include a floating action button (FAB) in the nav. The nav
@@ -432,7 +432,7 @@
       </div>
 
       <div class="u-mb-xl">
-        <h2 class="c-main__subtitle u-gamma u-mb">Header</h2>
+        <h2 class="c-main__subtitle u-fs-lg u-mb">Header</h2>
         <p class="u-mb">The <code class="c-code">.c-chrome__body__header</code>
         element contains header menu items. The
         <a href="//zendeskgarden.github.io/css-menus/"><code class="c-code">.c-menu</code></a>
@@ -884,7 +884,7 @@
       </div>
 
       <div class="u-mb-lg">
-        <h2 class="c-main__subtitle u-gamma u-mb">Modification</h2>
+        <h2 class="c-main__subtitle u-fs-lg u-mb">Modification</h2>
         <p class="u-mb">In addition to the navigation and header modifiers
         shown above, the following BEM classes are available to modify various
         components of the chrome.</p>
@@ -906,7 +906,7 @@
       </div>
 
       <div class="u-mb-lg">
-        <h2 class="c-main__subtitle u-gamma u-mb">State</h2>
+        <h2 class="c-main__subtitle u-fs-lg u-mb">State</h2>
         <div class="c-playground l-grid u-bc-transparent">
           <div class="l-grid__item u-1/2">
             <div class="c-chrome c-chrome--demo">
@@ -953,7 +953,7 @@
       </div>
 
       <section id="playground">
-        <h1 class="c-main__subtitle u-alpha u-mb">Playground</h1>
+        <h1 class="c-main__subtitle u-fs-xl u-mb">Playground</h1>
         <div class="c-playground">
           <div class="c-playground__preview"></div>
 <textarea class="c-playground__code"><div class="c-chrome" style="height: 350px">
@@ -1023,7 +1023,7 @@
     </header>
     <div class="c-chrome__body__content">
       <aside class="c-chrome__body__content__sidebar u-p-lg">
-        <h1 class="u-alpha">Sidebar</h1>
+        <h1 class="u-fs-xl">Sidebar</h1>
         <p class="u-mt-sm">Organic fingerstache cronut bushwick. Typewriter
         mumblecore narwhal, meggings letterpress kogi yr asymmetrical YOLO.</p>
         <p class="u-mt">Slow-carb letterpress tbh glossier pabst mixtape twee
@@ -1032,7 +1032,7 @@
         portland pitchfork 90's hammock hexagon hot chicken prism leggings.</p>
       </aside>
       <main class="c-chrome__body__content__main u-p-lg">
-        <h1 class="u-alpha">Main</h1>
+        <h1 class="u-fs-xl">Main</h1>
         <p class="u-mt-sm">Lorem ipsum dolor sit amet, consectetur adipiscing
         elit, sed do eiusmod tempor incididunt ut labore et dolore magna
         aliqua. Ut aliquam purus sit amet. Cum sociis natoque penatibus et

--- a/demo/chrome/page.html
+++ b/demo/chrome/page.html
@@ -118,9 +118,9 @@
     </header>
     <div class="c-chrome__body__content">
       <aside class="c-chrome__body__content__sidebar u-p-lg">
-        <h1 class="u-alpha">Sidebar</h1>
+        <h1 class="u-fs-xl">Sidebar</h1>
         <hr class="u-mb-lg u-mt u-bc-grey-500">
-        <div class="u-zeta">
+        <div class="u-fs-sm">
           <p class="u-mb">Note this page accepts the following URL parameters:</p>
           <ul class="u-mb-lg u-list-style-disc">
             <li class="u-mb-sm"><code class="c-code">mode</code> – "dark" to view this page in dark mode.</li>
@@ -154,7 +154,7 @@
         quinoa food truck meditation paleo venmo everyday carry gochujang.</p>
       </aside>
       <main class="c-chrome__body__content__main u-p-lg">
-        <h1 class="u-alpha">Main</h1>
+        <h1 class="u-fs-xl">Main</h1>
         <p class="u-mt-sm">Lorem ipsum dolor sit amet, consectetur adipiscing
         elit, sed do eiusmod tempor incididunt ut labore et dolore magna
         aliqua. Ut aliquam purus sit amet. Cum sociis natoque penatibus et

--- a/demo/forms/checkbox/index.html
+++ b/demo/forms/checkbox/index.html
@@ -195,19 +195,19 @@
           <div class="l-grid__item u-1/3">
             <div class="c-chk">
               <input class="c-chk__input" id="chk-1" type="checkbox">
-              <label class="c-chk__label is-checked u-zeta" dir="ltr" for="chk-1">.c-chk__label.is-checked</label>
+              <label class="c-chk__label is-checked u-fs-sm" dir="ltr" for="chk-1">.c-chk__label.is-checked</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk">
               <input class="c-chk__input" id="tgl-1" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle is-checked u-zeta" dir="ltr" for="tgl-1">.c-chk__label--toggle.is-checked</label>
+              <label class="c-chk__label c-chk__label--toggle is-checked u-fs-sm" dir="ltr" for="tgl-1">.c-chk__label--toggle.is-checked</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk">
               <input class="c-chk__input" id="rdo-1" type="radio">
-              <label class="c-chk__label c-chk__label--radio is-checked u-zeta" dir="ltr" for="rdo-1">c-chk__label--radio.is-checked</label>
+              <label class="c-chk__label c-chk__label--radio is-checked u-fs-sm" dir="ltr" for="rdo-1">c-chk__label--radio.is-checked</label>
             </div>
           </div>
         </div>
@@ -215,19 +215,19 @@
           <div class="l-grid__item u-1/3">
             <div class="c-chk">
               <input checked class="c-chk__input" id="chk-2" type="checkbox">
-              <label class="c-chk__label u-zeta" dir="ltr" for="chk-2">.c-chk__input[checked]</label>
+              <label class="c-chk__label u-fs-sm" dir="ltr" for="chk-2">.c-chk__input[checked]</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk">
               <input checked class="c-chk__input" id="tgl-2" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle u-zeta" dir="ltr" for="tgl-2">.c-chk__input[checked] .c-chk__label--toggle</label>
+              <label class="c-chk__label c-chk__label--toggle u-fs-sm" dir="ltr" for="tgl-2">.c-chk__input[checked] .c-chk__label--toggle</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk">
               <input checked class="c-chk__input" id="rdo-2" type="radio">
-              <label class="c-chk__label c-chk__label--radio u-zeta" dir="ltr" for="rdo-2">.c-chk__input[checked] .c-chk__label--radio</label>
+              <label class="c-chk__label c-chk__label--radio u-fs-sm" dir="ltr" for="rdo-2">.c-chk__input[checked] .c-chk__label--radio</label>
             </div>
           </div>
         </div>
@@ -237,19 +237,19 @@
           <div class="l-grid__item u-1/3">
             <div class="c-chk">
               <input class="c-chk__input" id="chk-i1" type="checkbox">
-              <label class="c-chk__label is-indeterminate u-zeta" dir="ltr" for="chk-i1">.c-chk__label.is-indeterminate</label>
+              <label class="c-chk__label is-indeterminate u-fs-sm" dir="ltr" for="chk-i1">.c-chk__label.is-indeterminate</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk">
               <input class="c-chk__input" id="tgl-i1" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle is-indeterminate u-zeta" dir="ltr" for="tgl-i1">.c-chk__label--toggle.is-indeterminate</label>
+              <label class="c-chk__label c-chk__label--toggle is-indeterminate u-fs-sm" dir="ltr" for="tgl-i1">.c-chk__label--toggle.is-indeterminate</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk">
               <input class="c-chk__input" id="rdo-i1" type="radio">
-              <label class="c-chk__label c-chk__label--radio is-indeterminate u-zeta" dir="ltr" for="rdo-i1">.c-chk__label--radio.is-indeterminate</label>
+              <label class="c-chk__label c-chk__label--radio is-indeterminate u-fs-sm" dir="ltr" for="rdo-i1">.c-chk__label--radio.is-indeterminate</label>
             </div>
           </div>
         </div>
@@ -257,19 +257,19 @@
           <div class="l-grid__item u-1/3">
             <div class="c-chk">
               <input indeterminate class="c-chk__input" id="chk-i2" type="checkbox">
-              <label class="c-chk__label u-zeta" dir="ltr" for="chk-i2">.c-chk__input:indeterminate</label>
+              <label class="c-chk__label u-fs-sm" dir="ltr" for="chk-i2">.c-chk__input:indeterminate</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk">
               <input indeterminate class="c-chk__input" id="tgl-i2" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle u-zeta" dir="ltr" for="tgl-i2">.c-chk__input:indeterminate .c-chk__label--toggle</label>
+              <label class="c-chk__label c-chk__label--toggle u-fs-sm" dir="ltr" for="tgl-i2">.c-chk__input:indeterminate .c-chk__label--toggle</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk">
               <input indeterminate class="c-chk__input" id="rdo-i2" type="radio">
-              <label class="c-chk__label c-chk__label--radio u-zeta" dir="ltr" for="rdo-i2">.c-chk__input:indeterminate .c-chk__label--radio</label>
+              <label class="c-chk__label c-chk__label--radio u-fs-sm" dir="ltr" for="rdo-i2">.c-chk__input:indeterminate .c-chk__label--radio</label>
             </div>
           </div>
         </div>
@@ -301,19 +301,19 @@
           <div class="l-grid__item u-1/3">
             <div class="c-chk">
               <input class="c-chk__input" id="chk-3" type="checkbox">
-              <label class="c-chk__label is-focused u-zeta" dir="ltr" for="chk-3">.c-chk__label.is-focused</label>
+              <label class="c-chk__label is-focused u-fs-sm" dir="ltr" for="chk-3">.c-chk__label.is-focused</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk">
               <input class="c-chk__input" id="tgl-3" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle is-focused u-zeta" dir="ltr" for="tgl-3">.c-chk__label--toggle.is-focused</label>
+              <label class="c-chk__label c-chk__label--toggle is-focused u-fs-sm" dir="ltr" for="tgl-3">.c-chk__label--toggle.is-focused</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk">
               <input class="c-chk__input" id="rdo-3" type="radio">
-              <label class="c-chk__label c-chk__label--radio is-focused u-zeta" dir="ltr" for="rdo-3">.c-chk__label--radio.is-focused</label>
+              <label class="c-chk__label c-chk__label--radio is-focused u-fs-sm" dir="ltr" for="rdo-3">.c-chk__label--radio.is-focused</label>
             </div>
           </div>
         </div>
@@ -321,19 +321,19 @@
           <div class="l-grid__item u-1/3">
             <div class="c-chk">
               <input class="c-chk__input" id="chk-3" type="checkbox">
-              <label class="c-chk__label is-checked is-focused u-zeta" dir="ltr" for="chk-3">.c-chk__label.is-checked.is-focused</label>
+              <label class="c-chk__label is-checked is-focused u-fs-sm" dir="ltr" for="chk-3">.c-chk__label.is-checked.is-focused</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk">
               <input class="c-chk__input" id="tgl-3" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle is-checked is-focused u-zeta" dir="ltr" for="tgl-3">.c-chk__label--toggle.is-checked.is-focused</label>
+              <label class="c-chk__label c-chk__label--toggle is-checked is-focused u-fs-sm" dir="ltr" for="tgl-3">.c-chk__label--toggle.is-checked.is-focused</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk">
               <input class="c-chk__input" id="rdo-3" type="radio">
-              <label class="c-chk__label c-chk__label--radio is-checked is-focused u-zeta" dir="ltr" for="rdo-3">.c-chk__label--radio.is-checked.is-focused</label>
+              <label class="c-chk__label c-chk__label--radio is-checked is-focused u-fs-sm" dir="ltr" for="rdo-3">.c-chk__label--radio.is-checked.is-focused</label>
             </div>
           </div>
         </div>
@@ -343,19 +343,19 @@
           <div class="l-grid__item u-1/3">
             <div class="c-chk">
               <input class="c-chk__input" id="chk-4" type="checkbox">
-              <label class="c-chk__label is-active u-zeta" dir="ltr" for="chk-4">.c-chk__label.is-active</label>
+              <label class="c-chk__label is-active u-fs-sm" dir="ltr" for="chk-4">.c-chk__label.is-active</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk">
               <input class="c-chk__input" id="tgl-4" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle is-active u-zeta" dir="ltr" for="tgl-4">.c-chk__label--toggle.is-active</label>
+              <label class="c-chk__label c-chk__label--toggle is-active u-fs-sm" dir="ltr" for="tgl-4">.c-chk__label--toggle.is-active</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk">
               <input class="c-chk__input" id="rdo-4" type="radio">
-              <label class="c-chk__label c-chk__label--radio is-active u-zeta" dir="ltr" for="rdo-4">.c-chk__label--radio.is-active</label>
+              <label class="c-chk__label c-chk__label--radio is-active u-fs-sm" dir="ltr" for="rdo-4">.c-chk__label--radio.is-active</label>
             </div>
           </div>
         </div>
@@ -363,19 +363,19 @@
           <div class="l-grid__item u-1/3">
             <div class="c-chk">
               <input class="c-chk__input" id="chk-5" type="checkbox">
-              <label class="c-chk__label is-active is-checked u-zeta" dir="ltr" for="chk-5">.c-chk__label.is-active.is-checked</label>
+              <label class="c-chk__label is-active is-checked u-fs-sm" dir="ltr" for="chk-5">.c-chk__label.is-active.is-checked</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk">
               <input class="c-chk__input" id="tgl-5" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle is-active is-checked u-zeta" dir="ltr" for="tgl-5">.c-chk__label--toggle.is-active.is-checked</label>
+              <label class="c-chk__label c-chk__label--toggle is-active is-checked u-fs-sm" dir="ltr" for="tgl-5">.c-chk__label--toggle.is-active.is-checked</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk">
               <input class="c-chk__input" id="rdo-5" type="radio">
-              <label class="c-chk__label c-chk__label--radio is-active is-checked u-zeta" dir="ltr" for="rdo-5">.c-chk__label--radio.is-active.is-checked</label>
+              <label class="c-chk__label c-chk__label--radio is-active is-checked u-fs-sm" dir="ltr" for="rdo-5">.c-chk__label--radio.is-active.is-checked</label>
             </div>
           </div>
         </div>
@@ -383,19 +383,19 @@
           <div class="l-grid__item u-1/3">
             <div class="c-chk">
               <input class="c-chk__input" id="chk-i5" type="checkbox">
-              <label class="c-chk__label is-active is-indeterminate u-zeta" dir="ltr" for="chk-i5">.c-chk__label.is-active.is-indeterminate</label>
+              <label class="c-chk__label is-active is-indeterminate u-fs-sm" dir="ltr" for="chk-i5">.c-chk__label.is-active.is-indeterminate</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk">
               <input class="c-chk__input" id="tgl-i5" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle is-active is-indeterminate u-zeta" dir="ltr" for="tgl-i5">.c-chk__label--toggle.is-active.is-indeterminate</label>
+              <label class="c-chk__label c-chk__label--toggle is-active is-indeterminate u-fs-sm" dir="ltr" for="tgl-i5">.c-chk__label--toggle.is-active.is-indeterminate</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk">
               <input class="c-chk__input" id="rdo-i5" type="radio">
-              <label class="c-chk__label c-chk__label--radio is-active is-indeterminate u-zeta" dir="ltr" for="rdo-i5">.c-chk__label--radio.is-active.is-indeterminate</label>
+              <label class="c-chk__label c-chk__label--radio is-active is-indeterminate u-fs-sm" dir="ltr" for="rdo-i5">.c-chk__label--radio.is-active.is-indeterminate</label>
             </div>
           </div>
         </div>
@@ -403,19 +403,19 @@
           <div class="l-grid__item u-1/3">
             <div class="c-chk">
               <input indeterminate class="c-chk__input" id="chk-i6" type="checkbox">
-              <label class="c-chk__label is-active u-zeta" dir="ltr" for="chk-i6">.c-chk__input:indeterminate .c-chk__label.is-active</label>
+              <label class="c-chk__label is-active u-fs-sm" dir="ltr" for="chk-i6">.c-chk__input:indeterminate .c-chk__label.is-active</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk">
               <input indeterminate class="c-chk__input" id="tgl-i6" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle is-active u-zeta" dir="ltr" for="tgl-i6">.c-chk__input:indeterminate .c-chk__label--toggle.is-active</label>
+              <label class="c-chk__label c-chk__label--toggle is-active u-fs-sm" dir="ltr" for="tgl-i6">.c-chk__input:indeterminate .c-chk__label--toggle.is-active</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk">
               <input indeterminate class="c-chk__input" id="rdo-i6" type="radio">
-              <label class="c-chk__label c-chk__label--radio is-active u-zeta" dir="ltr" for="rdo-i6">.c-chk__input:indeterminate .c-chk__label--radio.is-active</label>
+              <label class="c-chk__label c-chk__label--radio is-active u-fs-sm" dir="ltr" for="rdo-i6">.c-chk__input:indeterminate .c-chk__label--radio.is-active</label>
             </div>
           </div>
         </div>
@@ -425,19 +425,19 @@
           <div class="l-grid__item u-1/3">
             <div class="c-chk u-milli">
               <input class="c-chk__input" id="chk-7" type="checkbox">
-              <label class="c-chk__label is-disabled u-zeta" dir="ltr" for="chk-7">.c-chk__label.is-disabled</label>
+              <label class="c-chk__label is-disabled u-fs-sm" dir="ltr" for="chk-7">.c-chk__label.is-disabled</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk u-milli">
               <input class="c-chk__input" id="tgl-7" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle is-disabled u-zeta" dir="ltr" for="tgl-7">.c-chk__label--toggle.is-disabled</label>
+              <label class="c-chk__label c-chk__label--toggle is-disabled u-fs-sm" dir="ltr" for="tgl-7">.c-chk__label--toggle.is-disabled</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk u-milli">
               <input class="c-chk__input" id="rdo-7" type="radio">
-              <label class="c-chk__label c-chk__label--radio is-disabled u-zeta" dir="ltr" for="rdo-7">.c-chk__label--radio.is-disabled</label>
+              <label class="c-chk__label c-chk__label--radio is-disabled u-fs-sm" dir="ltr" for="rdo-7">.c-chk__label--radio.is-disabled</label>
             </div>
           </div>
         </div>
@@ -445,19 +445,19 @@
           <div class="l-grid__item u-1/3">
             <div class="c-chk u-milli">
               <input class="c-chk__input" disabled id="chk-8" type="checkbox">
-              <label class="c-chk__label u-zeta" dir="ltr" for="chk-8">.c-chk__input[disabled]</label>
+              <label class="c-chk__label u-fs-sm" dir="ltr" for="chk-8">.c-chk__input[disabled]</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk u-milli">
               <input class="c-chk__input" disabled id="tgl-8" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle u-zeta" dir="ltr" for="tgl-8">.c-chk__input[disabled] .c-chk__label--toggle</label>
+              <label class="c-chk__label c-chk__label--toggle u-fs-sm" dir="ltr" for="tgl-8">.c-chk__input[disabled] .c-chk__label--toggle</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk u-milli">
               <input class="c-chk__input" disabled id="rdo-8" type="radio">
-              <label class="c-chk__label c-chk__label--radio u-zeta" dir="ltr" for="rdo-8">.c-chk__input[disabled] .c-chk__label--radio</label>
+              <label class="c-chk__label c-chk__label--radio u-fs-sm" dir="ltr" for="rdo-8">.c-chk__input[disabled] .c-chk__label--radio</label>
             </div>
           </div>
         </div>
@@ -465,19 +465,19 @@
           <div class="l-grid__item u-1/3">
             <div class="c-chk u-milli">
               <input class="c-chk__input" id="chk-9" type="checkbox">
-              <label class="c-chk__label is-disabled is-checked u-zeta" dir="ltr" for="chk-9">.c-chk__label.is-disabled.is-checked</label>
+              <label class="c-chk__label is-disabled is-checked u-fs-sm" dir="ltr" for="chk-9">.c-chk__label.is-disabled.is-checked</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk u-milli">
               <input class="c-chk__input" id="tgl-9" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle is-disabled is-checked u-zeta" dir="ltr" for="tgl-9">.c-chk__label--toggle.is-disabled.is-checked</label>
+              <label class="c-chk__label c-chk__label--toggle is-disabled is-checked u-fs-sm" dir="ltr" for="tgl-9">.c-chk__label--toggle.is-disabled.is-checked</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk u-milli">
               <input class="c-chk__input" id="rdo-9" type="radio">
-              <label class="c-chk__label c-chk__label--radio is-disabled is-checked u-zeta" dir="ltr" for="rdo-9">.c-chk__label--radio.is-disabled.is-checked</label>
+              <label class="c-chk__label c-chk__label--radio is-disabled is-checked u-fs-sm" dir="ltr" for="rdo-9">.c-chk__label--radio.is-disabled.is-checked</label>
             </div>
           </div>
         </div>
@@ -485,19 +485,19 @@
           <div class="l-grid__item u-1/3">
             <div class="c-chk u-milli">
               <input class="c-chk__input" disabled id="chk-10" type="checkbox">
-              <label class="c-chk__label is-checked u-zeta" dir="ltr" for="chk-10">.c-chk__input[disabled] .c-chk__label.is-checked</label>
+              <label class="c-chk__label is-checked u-fs-sm" dir="ltr" for="chk-10">.c-chk__input[disabled] .c-chk__label.is-checked</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk u-milli">
               <input class="c-chk__input" disabled id="tgl-10" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle is-checked u-zeta" dir="ltr" for="tgl-10">.c-chk__input[disabled] .c-chk__label--toggle.is-checked</label>
+              <label class="c-chk__label c-chk__label--toggle is-checked u-fs-sm" dir="ltr" for="tgl-10">.c-chk__input[disabled] .c-chk__label--toggle.is-checked</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk u-milli">
               <input class="c-chk__input" disabled id="rdo-10" type="radio">
-              <label class="c-chk__label c-chk__label--radio is-checked u-zeta" dir="ltr" for="rdo-10">.c-chk__input[disabled] .c-chk__label--radio.is-checked</label>
+              <label class="c-chk__label c-chk__label--radio is-checked u-fs-sm" dir="ltr" for="rdo-10">.c-chk__input[disabled] .c-chk__label--radio.is-checked</label>
             </div>
           </div>
         </div>
@@ -505,19 +505,19 @@
           <div class="l-grid__item u-1/3">
             <div class="c-chk u-milli">
               <input checked class="c-chk__input" disabled id="chk-11" type="checkbox">
-              <label class="c-chk__label u-zeta" dir="ltr" for="chk-11">.c-chk__input[checked][disabled]</label>
+              <label class="c-chk__label u-fs-sm" dir="ltr" for="chk-11">.c-chk__input[checked][disabled]</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk u-milli">
               <input checked class="c-chk__input" disabled id="tgl-11" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle u-zeta" dir="ltr" for="tgl-11">.c-chk__input[checked][disabled] .c-chk__label--toggle</label>
+              <label class="c-chk__label c-chk__label--toggle u-fs-sm" dir="ltr" for="tgl-11">.c-chk__input[checked][disabled] .c-chk__label--toggle</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk u-milli">
               <input checked class="c-chk__input" disabled id="rdo-11" type="radio">
-              <label class="c-chk__label c-chk__label--radio u-zeta" dir="ltr" for="rdo-11">.c-chk__input[checked][disabled] .c-chk__label--radio</label>
+              <label class="c-chk__label c-chk__label--radio u-fs-sm" dir="ltr" for="rdo-11">.c-chk__input[checked][disabled] .c-chk__label--radio</label>
             </div>
           </div>
         </div>
@@ -525,19 +525,19 @@
           <div class="l-grid__item u-1/3">
             <div class="c-chk u-milli">
               <input class="c-chk__input" id="chk-i9" type="checkbox">
-              <label class="c-chk__label is-disabled is-indeterminate u-zeta" dir="ltr" for="chk-i9">.c-chk__label.is-disabled.is-indeterminate</label>
+              <label class="c-chk__label is-disabled is-indeterminate u-fs-sm" dir="ltr" for="chk-i9">.c-chk__label.is-disabled.is-indeterminate</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk u-milli">
               <input class="c-chk__input" id="tgl-i9" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle is-disabled is-indeterminate u-zeta" dir="ltr" for="tgl-i9">.c-chk__label--toggle.is-disabled.is-indeterminate</label>
+              <label class="c-chk__label c-chk__label--toggle is-disabled is-indeterminate u-fs-sm" dir="ltr" for="tgl-i9">.c-chk__label--toggle.is-disabled.is-indeterminate</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk u-milli">
               <input class="c-chk__input" id="rdo-i9" type="radio">
-              <label class="c-chk__label c-chk__label--radio is-disabled is-indeterminate u-zeta" dir="ltr" for="rdo-i9">.c-chk__label--radio.is-disabled.is-indeterminate</label>
+              <label class="c-chk__label c-chk__label--radio is-disabled is-indeterminate u-fs-sm" dir="ltr" for="rdo-i9">.c-chk__label--radio.is-disabled.is-indeterminate</label>
             </div>
           </div>
         </div>
@@ -545,19 +545,19 @@
           <div class="l-grid__item u-1/3">
             <div class="c-chk u-milli">
               <input class="c-chk__input" disabled id="chk-i10" type="checkbox">
-              <label class="c-chk__label is-indeterminate u-zeta" dir="ltr" for="chk-i10">.c-chk__input[disabled] .c-chk__label.is-indeterminate</label>
+              <label class="c-chk__label is-indeterminate u-fs-sm" dir="ltr" for="chk-i10">.c-chk__input[disabled] .c-chk__label.is-indeterminate</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk u-milli">
               <input class="c-chk__input" disabled id="tgl-i10" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle is-indeterminate u-zeta" dir="ltr" for="tgl-i10">.c-chk__input[disabled] .c-chk__label--toggle.is-indeterminate</label>
+              <label class="c-chk__label c-chk__label--toggle is-indeterminate u-fs-sm" dir="ltr" for="tgl-i10">.c-chk__input[disabled] .c-chk__label--toggle.is-indeterminate</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk u-milli">
               <input class="c-chk__input" disabled id="rdo-i10" type="radio">
-              <label class="c-chk__label c-chk__label--radio is-indeterminate u-zeta" dir="ltr" for="rdo-i10">.c-chk__input[disabled] .c-chk__label--radio.is-indeterminate</label>
+              <label class="c-chk__label c-chk__label--radio is-indeterminate u-fs-sm" dir="ltr" for="rdo-i10">.c-chk__input[disabled] .c-chk__label--radio.is-indeterminate</label>
             </div>
           </div>
         </div>
@@ -565,25 +565,25 @@
           <div class="l-grid__item u-1/3">
             <div class="c-chk u-milli">
               <input indeterminate class="c-chk__input" disabled id="chk-i11" type="checkbox">
-              <label class="c-chk__label u-zeta" dir="ltr" for="chk-i11">.c-chk__input:indeterminate[disabled]</label>
+              <label class="c-chk__label u-fs-sm" dir="ltr" for="chk-i11">.c-chk__input:indeterminate[disabled]</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk u-milli">
               <input indeterminate class="c-chk__input" disabled id="tgl-i11" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle u-zeta" dir="ltr" for="tgl-i11">.c-chk__input:indeterminate[disabled] .c-chk__label--toggle</label>
+              <label class="c-chk__label c-chk__label--toggle u-fs-sm" dir="ltr" for="tgl-i11">.c-chk__input:indeterminate[disabled] .c-chk__label--toggle</label>
             </div>
           </div
           ><div class="l-grid__item u-1/3">
             <div class="c-chk u-milli">
               <input indeterminate class="c-chk__input" disabled id="rdo-i11" type="radio">
-              <label class="c-chk__label c-chk__label--radio u-zeta" dir="ltr" for="rdo-i11">.c-chk__input:indeterminate[disabled] .c-chk__label--radio</label>
+              <label class="c-chk__label c-chk__label--radio u-fs-sm" dir="ltr" for="rdo-i11">.c-chk__input:indeterminate[disabled] .c-chk__label--radio</label>
             </div>
           </div>
         </div>
       </div>
       <section id="playground">
-        <h1 class="c-main__subtitle u-alpha u-mb">Playground</h1>
+        <h1 class="c-main__subtitle u-fs-xl u-mb">Playground</h1>
         <div class="c-playground">
           <div class="c-playground__preview"></div>
 <textarea class="c-playground__code"><form>

--- a/demo/forms/range/index.html
+++ b/demo/forms/range/index.html
@@ -300,24 +300,24 @@
       attribute values.</p>
       <form class="u-mb-lg" style="max-width:480px">
         <div class="c-range u-mb-lg">
-          <label class="c-range__label u-epsilon" for="range-4"><span dir="ltr">.c-range__input[value="10"]</span></label>
+          <label class="c-range__label u-fs-md" for="range-4"><span dir="ltr">.c-range__input[value="10"]</span></label>
           <input class="c-range__input" id="range-4" type="range" value="10">
         </div>
         <div class="c-range u-mb-lg">
-          <label class="c-range__label u-epsilon" for="range-5"><span dir="ltr">.c-range__input[max="40"][value="10"]</span></label>
+          <label class="c-range__label u-fs-md" for="range-5"><span dir="ltr">.c-range__input[max="40"][value="10"]</span></label>
           <input class="c-range__input" id="range-5" max="40" type="range" value="10">
         </div>
         <div class="c-range u-mb-lg">
-          <label class="c-range__label u-epsilon" for="range-6"><span dir="ltr">.c-range__input[max="60"][min="30"][value="45"]</span></label>
+          <label class="c-range__label u-fs-md" for="range-6"><span dir="ltr">.c-range__input[max="60"][min="30"][value="45"]</span></label>
           <input class="c-range__input" id="range-6" max="60" min="30" type="range" value="45">
         </div>
         <div class="c-range u-mb-lg">
-          <label class="c-range__label u-epsilon" for="range-7"><span dir="ltr">.c-range__input[step="5"][value="75"]</span></label>
+          <label class="c-range__label u-fs-md" for="range-7"><span dir="ltr">.c-range__input[step="5"][value="75"]</span></label>
           <input class="c-range__input" id="range-7" step="5" type="range" value="75">
         </div>
       </form>
       <section id="playground">
-        <h1 class="c-main__subtitle u-alpha u-mb">Playground</h1>
+        <h1 class="c-main__subtitle u-fs-xl u-mb">Playground</h1>
         <div class="c-playground">
           <div class="c-playground__preview"></div>
 <textarea class="c-playground__code"><div class="c-range u-mb">

--- a/demo/forms/text/index.html
+++ b/demo/forms/text/index.html
@@ -144,7 +144,7 @@
           </div>
         </div>
       </form>
-      <h3 class="u-gamma u-mb">Modifiers</h3>
+      <h3 class="u-fs-lg u-mb">Modifiers</h3>
       <p class="u-mb">Use the
       <code class="c-code">.c-txt--inline</code>
       class modifier to layout text controls inline.</p>
@@ -218,7 +218,7 @@
           <textarea class="c-txt__input c-txt__input--area is-resizable" id="txtarea-1" placeholder=".c-txt__input.c-txt__input--area.is-resizable"></textarea>
         </div>
       </form>
-      <h3 class="u-gamma u-mb">States</h3>
+      <h3 class="u-fs-lg u-mb">States</h3>
       <div class="c-txt u-mb-lg">
         <input class="c-txt__input is-hovered" placeholder=".c-txt__input.is-hovered" type="text">
       </div>
@@ -231,7 +231,7 @@
       <div class="c-txt u-mb-lg">
         <input class="c-txt__input" disabled placeholder=".c-txt__input[disabled]" type="text">
       </div>
-      <h3 class="u-gamma u-mb">Types</h3>
+      <h3 class="u-fs-lg u-mb">Types</h3>
       <p class="u-mb">The fields shown below demonstrate how
         <code class="c-code">.c-txt__input</code> works in combination with
         various input types. In general, we attempt to knock out non-standard
@@ -297,7 +297,7 @@
         <button class="c-btn u-mt-sm" type="submit">Test</button>
       </form>
       <section id="playground">
-        <h1 class="c-main__subtitle u-alpha u-mb">Playground</h1>
+        <h1 class="c-main__subtitle u-fs-xl u-mb">Playground</h1>
         <div class="c-playground">
           <div class="c-playground__preview"></div>
 <textarea class="c-playground__code"><form class="l-wrapper--370">

--- a/demo/grid/index.html
+++ b/demo/grid/index.html
@@ -51,7 +51,7 @@
         <code class="c-code">.container</code> or <code class="c-code">.container-fluid</code>
         wrapper classes</a>.
       </p>
-      <h2 class="u-gamma u-mb">Mobile-Responsive Columns</h2>
+      <h2 class="u-fs-lg u-mb">Mobile-Responsive Columns</h2>
       <div class="container-fluid is-debug u-mb-xl">
         <div class="row">
           <div class="col-md">
@@ -65,7 +65,7 @@
           </div>
         </div>
       </div>
-      <h2 class="u-gamma u-mb">Setting One Column Width</h2>
+      <h2 class="u-fs-lg u-mb">Setting One Column Width</h2>
       <div class="container-fluid is-debug u-mb-xl">
         <div class="row">
           <div class="col">
@@ -90,7 +90,7 @@
           </div>
         </div>
       </div>
-      <h2 class="u-gamma u-mb">Variable Width Content</h2>
+      <h2 class="u-fs-lg u-mb">Variable Width Content</h2>
       <div class="container-fluid is-debug u-mb-xl">
         <div class="row justify-content-md-center">
           <div class="col col-lg-2">
@@ -116,7 +116,7 @@
         </div>
       </div>
       <section id="playground">
-        <h1 class="c-main__subtitle u-alpha u-mb">Playground</h1>
+        <h1 class="c-main__subtitle u-fs-xl u-mb">Playground</h1>
         <div class="c-playground">
           <div class="c-playground__preview"></div>
 <textarea class="c-playground__code"><div class="container-fluid is-debug">

--- a/demo/menus/index.html
+++ b/demo/menus/index.html
@@ -104,7 +104,7 @@
         component classes are used to style menus.</p>
 
       <div class="u-mb-lg">
-        <h2 class="c-main__subtitle u-gamma u-mb">Basic Structure</h2>
+        <h2 class="c-main__subtitle u-fs-lg u-mb">Basic Structure</h2>
         <p class="u-mb">Menus typically originate from a control (i.e. a
           menubar, <code class="c-code">&lt;select&gt;</code> dropdown, or
           button). The basic BEM structure is <code class="c-code">.c-menu &gt;
@@ -134,7 +134,7 @@
       </div>
 
       <div class="u-mb-lg">
-        <h2 class="c-main__subtitle u-gamma u-mb">Show/Hide Animations</h2>
+        <h2 class="c-main__subtitle u-fs-lg u-mb">Show/Hide Animations</h2>
         <p class="u-mb">Each menu connected with the buttons below is hidden
           and oriented with respect to a relatively positioned container. When a
           button is clicked, the <code class="c-code">.is-open</code> class is
@@ -207,7 +207,7 @@
       </div>
 
       <div class="u-mb-lg">
-        <h2 class="c-main__subtitle u-gamma u-mb">Menu Modifications</h2>
+        <h2 class="c-main__subtitle u-fs-lg u-mb">Menu Modifications</h2>
         <p class="u-mb">Use the main settings menu to modify styling for the
           menus displayed throughout the page.</p>
         <ul class="u-list-style-disc">
@@ -223,7 +223,7 @@
       <div class="u-mb-lg">
         <div class="l-grid">
           <div class="l-grid__item u-1/2">
-            <h2 class="c-main__subtitle u-gamma u-mb">Menu Item Modifications</h2>
+            <h2 class="c-main__subtitle u-fs-lg u-mb">Menu Item Modifications</h2>
             <ul class="c-menu u-opacity-opaque u-visibility-visible u-position-static" style="min-width:270px">
               <li class="c-menu__item c-menu__item--previous" tabindex="0"><span dir="ltr">.c-menu__item--previous</span></li>
               <li class="c-menu__separator">
@@ -255,7 +255,7 @@
             </ul>
           </div
           ><div class="l-grid__item u-1/2">
-            <h2 class="c-main__subtitle u-gamma u-mb">Menu Item State</h2>
+            <h2 class="c-main__subtitle u-fs-lg u-mb">Menu Item State</h2>
             <ul class="c-menu u-opacity-opaque u-visibility-visible u-position-static">
               <li class="c-menu__item" tabindex="0">default</li>
               <li class="c-menu__separator">
@@ -280,7 +280,7 @@
       </div>
 
       <div class="u-mb-lg">
-        <h2 class="c-main__subtitle u-gamma u-mb">Sizing</h2>
+        <h2 class="c-main__subtitle u-fs-lg u-mb">Sizing</h2>
         <p class="u-mb">By default, a menu will expand to accommodate the width
         of it's items. Override the menu's <code class="c-code">min-width</code>
         to increase the container size. Overriding <code class="c-code">max-width</code>
@@ -311,7 +311,7 @@
       </div>
 
       <section id="playground">
-        <h1 class="c-main__subtitle u-alpha u-mb">Playground</h1>
+        <h1 class="c-main__subtitle u-fs-xl u-mb">Playground</h1>
         <div class="c-playground">
           <div class="c-playground__preview"></div>
 <textarea class="c-playground__code"><ul class="c-menu u-opacity-opaque u-visibility-visible u-position-static" role="menu">

--- a/demo/modals/index.html
+++ b/demo/modals/index.html
@@ -46,7 +46,7 @@
       <p class="u-mb-lg">Use
         <code class="c-code">.c-dialog</code>
         component classes for styling modal dialogs.</p>
-      <h2 class="u-gamma u-mb-sm">Dialog</h2>
+      <h2 class="u-fs-lg u-mb-sm">Dialog</h2>
       <p class="u-mb-sm">The default component class is used to style a simple
       dialog box. Add absolute positioning properties in order to logically
       associate the dialog with its opener.</p>
@@ -55,7 +55,7 @@
          role="button">Open
         <code class="c-code">.c-dialog</code>
         Dialog</a>
-      <h2 class="u-gamma u-mb-sm">Large Dialog</h2>
+      <h2 class="u-fs-lg u-mb-sm">Large Dialog</h2>
       <p class="u-mb-sm">The large dialog modification affects the dialog
       footer and sets a larger dialog width.</p>
       <a class="c-btn js-dialog u-mb-lg"
@@ -63,7 +63,7 @@
          role="button">Open
         <code class="c-code">.c-dialog.c-dialog--large</code>
         Dialog</a>
-      <h2 class="u-gamma u-mb-sm">Dialog with Backdrop Layout</h2>
+      <h2 class="u-fs-lg u-mb-sm">Dialog with Backdrop Layout</h2>
       <p class="u-mb-sm">Surround modal dialogs with a backdrop to give them
       visual distinction from page content. The backdrop layout also adds
       scrolling behavior so that dialog content can be accessed in a small
@@ -91,7 +91,7 @@
           <code class="c-code">.l-backdrop</code>
           Backdrop</a>
       </div>
-      <h2 class="u-gamma u-mb-sm">Dialog with Centered Backdrop Layout</h2>
+      <h2 class="u-fs-lg u-mb-sm">Dialog with Centered Backdrop Layout</h2>
       <p class="u-mb-sm">A backdrop with additional positioning CSS to center
       it's contents on the page. The dialog retains its centered position until
       the window shrinks to a small size, at which breakpoints activate to
@@ -116,7 +116,7 @@
           <code class="c-code">.l-backdrop.l-backdrop--center</code>
           Backdrop</a>
       </div>
-      <h2 class="u-gamma u-mb-sm">Close button states</h2>
+      <h2 class="u-fs-lg u-mb-sm">Close button states</h2>
       <section class="c-dialog u-position-relative">
         <h1 class="c-dialog__header"><code class="c-code" dir="ltr">.c-dialog__close</code></h1>
         <button class="c-dialog__close"></button>
@@ -129,12 +129,12 @@
         <h1 class="c-dialog__header"><code class="c-code" dir="ltr">.c-dialog__close.is-focused</code></h1>
         <button class="c-dialog__close is-focused"></button>
       </section>
-      <h2 class="u-gamma u-mb-sm">Animation</h2>
+      <h2 class="u-fs-lg u-mb-sm">Animation</h2>
       <p class="u-mb">Refine the display of modal dialogs by adding
       <code class="c-code">.is-visible</code> to the backdrop and
       <code class="c-code">.is-open</code> to the dialog itself.</p>
       <section class="u-mt-xl" id="playground">
-        <h1 class="c-main__subtitle u-alpha u-mb">Playground</h1>
+        <h1 class="c-main__subtitle u-fs-xl u-mb">Playground</h1>
         <div class="c-playground">
           <div class="c-playground__preview"></div>
 <textarea class="c-playground__code"><a class="c-btn js-dialog js-backdrop"

--- a/demo/pagination/index.html
+++ b/demo/pagination/index.html
@@ -79,7 +79,7 @@
         <li class="c-pagination__page">11</li>
         <li class="c-pagination__page c-pagination__page--next">next</li>
       </ul>
-      <h2 class="u-gamma u-mb">Page Anchors</h2>
+      <h2 class="u-fs-lg u-mb">Page Anchors</h2>
       <p class="u-mb">The pagination component supports using anchor tags
       within page elements.</p>
       <div class="c-playground u-mb-lg">
@@ -92,7 +92,7 @@
   <li class="c-pagination__page c-pagination__page--next"><a href>next</a></li>
 </ul></textarea>
       </div>
-      <h2 class="u-gamma u-mb">Page State</h2>
+      <h2 class="u-fs-lg u-mb">Page State</h2>
       <p class="u-mb">Use the <code class="c-code">.is-*</code> modifier
       classes to manage page state. Note this component removes default
       <code class="c-code">:focus</code> styling. In order to retain
@@ -110,7 +110,7 @@
   <li class="c-pagination__page c-pagination__page--next is-focused">next</li>
 </ul></textarea>
       </div>
-      <h2 class="u-gamma u-mb">Accessible Markup</h2>
+      <h2 class="u-fs-lg u-mb">Accessible Markup</h2>
       <p class="u-mb">Use the following semantic HTML to make the pagination
       component keyboard and screen reader accessible. ARIA attributes are used
       to apply the expected page state styling.</p>
@@ -124,7 +124,7 @@
   <li class="c-pagination__page c-pagination__page--next"><a href>next</a></li>
 </ul></textarea>
       </div>
-      <h2 class="u-gamma u-mb">Layout Rules</h2>
+      <h2 class="u-fs-lg u-mb">Layout Rules</h2>
       <ol class="u-list-style-decimal u-mb u-ml">
         <li class="u-mb-xs">Display a maximum of 9 pages.</li>
         <li class="u-mb-xs">Use

--- a/demo/tables/index.html
+++ b/demo/tables/index.html
@@ -98,7 +98,7 @@
       <code class="c-code">&lt;table&gt;</code> elements.</p>
 
       <div class="u-mb-lg">
-        <h2 class="u-gamma u-mb">Basic Layout</h2>
+        <h2 class="u-fs-lg u-mb">Basic Layout</h2>
         <p class="u-mb">The basic BEM class structure is
         <code class="c-code">.c-table &gt; .c-table__row &gt; .c-table__row__cell</code>
         , which can be used to style a table along with rows and cells.</p>
@@ -128,7 +128,7 @@
       </div>
 
       <div class="u-mb-lg">
-        <h2 class="u-gamma u-mb">Table Modifications</h2>
+        <h2 class="u-fs-lg u-mb">Table Modifications</h2>
         <p class="u-mb">Use the settings menu to modify the styling for the
         tables displayed throughout the page.</p>
         <ul class="u-list-style-disc">
@@ -143,7 +143,7 @@
       </div>
 
       <div class="u-mb-lg">
-        <h2 class="u-gamma u-mb">Row Modifications</h2>
+        <h2 class="u-fs-lg u-mb">Row Modifications</h2>
         <p class="u-mb">Add <code class="c-code">.c-table__row--header</code>
         to style the header row for your table.</p>
         <div class="l-grid u-mb">
@@ -202,7 +202,7 @@
       </div>
 
       <div class="u-mb-lg">
-        <h2 class="u-gamma u-mb">Cell Modifications</h2>
+        <h2 class="u-fs-lg u-mb">Cell Modifications</h2>
         <p class="u-mb">Most table layouts will benefit from the addition of
         <code class="c-code">.c-table__row__cell--truncate</code> to prevent
         cell content from wrapping.</p>
@@ -399,7 +399,7 @@
       </div>
 
       <div class="u-mb-xl">
-        <h2 class="u-gamma u-mb">Table State</h2>
+        <h2 class="u-fs-lg u-mb">Table State</h2>
         <ul>
           <li class="u-mb"><table class="c-table">
             <tr class="c-table__row is-hovered">
@@ -490,7 +490,7 @@
       </div>
 
       <section id="playground">
-        <h1 class="c-main__subtitle u-alpha u-mb">Playground</h1>
+        <h1 class="c-main__subtitle u-fs-xl u-mb">Playground</h1>
         <div class="c-playground">
           <div class="c-playground__preview"></div>
 <textarea class="c-playground__code"><table class="c-table u-bg-white">

--- a/demo/tabs/index.html
+++ b/demo/tabs/index.html
@@ -68,7 +68,7 @@
         components for consistent tab styling. See the Garden React
         <a href="//zendeskgarden.github.io/react-components/tabs/"><code class="c-code">&lt;Tabs&gt;</code></a>
         component for enhanced keyboard and event behavior along with support for dynamic panel content.</p>
-      <h2 class="u-gamma u-mb">Default Layout
+      <h2 class="u-fs-lg u-mb">Default Layout
         <code class="c-code">.c-tab<span class="js-rtl-display u-display-none">.is-rtl</span></code>
       </h2>
       <nav class="c-tab u-mb-lg">
@@ -127,7 +127,7 @@
           id="panel3"
           role="tabpanel">PANEL THREE</p>
       </nav>
-      <h2 class="u-gamma u-mb">Block Layout
+      <h2 class="u-fs-lg u-mb">Block Layout
         <code class="c-code">.c-tab<span class="js-rtl-display u-display-none">.is-rtl</span>.c-tab--block</code>
       </h2>
       <nav class="c-tab c-tab--block u-mb-lg">
@@ -183,7 +183,7 @@
           id="panel3"
           role="tabpanel">PANEL THREE</p>
       </nav>
-      <h2 class="u-gamma u-mb">Tab State</h2>
+      <h2 class="u-fs-lg u-mb">Tab State</h2>
       <nav class="c-tab u-mb-lg">
         <ul class="c-tab__list js-demo" role="tablist">
           <li
@@ -285,7 +285,7 @@
           humblebrag beard ramps intelligentsia knausgaard austin sriracha
           sustainable forage.</p>
       </nav>
-      <h2 class="u-gamma u-mb">Anchor Tabs</h2>
+      <h2 class="u-fs-lg u-mb">Anchor Tabs</h2>
       <nav class="c-tab u-mb-lg">
         <ul class="c-tab__list" role="tablist">
           <li
@@ -377,7 +377,7 @@
       </nav>
 
       <section class="u-mt-lg" id="playground">
-        <h1 class="c-main__subtitle u-alpha u-mb">Playground</h1>
+        <h1 class="c-main__subtitle u-fs-xl u-mb">Playground</h1>
         <div class="c-playground">
           <div class="c-playground__preview"></div>
 <textarea class="c-playground__code"><nav class="c-tab">

--- a/demo/tags/index.html
+++ b/demo/tags/index.html
@@ -79,7 +79,7 @@
       </section>
 
       <section class="u-mb-lg">
-        <h1 class="c-main__subtitle u-alpha u-mb">Shapes</h1>
+        <h1 class="c-main__subtitle u-fs-xl u-mb">Shapes</h1>
         <p class="u-mb">Use pill or round class modifiers to shape a tag.
         Round tags are intended to contain a minimal number of characters.</p>
         <div class="u-mb">
@@ -91,7 +91,7 @@
       </section>
 
       <section class="u-mb-lg">
-        <h1 class="c-main__subtitle u-alpha u-mb">Sizes</h1>
+        <h1 class="c-main__subtitle u-fs-xl u-mb">Sizes</h1>
         <p class="u-mb">Tags may be sized small or large. Note that small tags
         will not display the <i>avatar</i> element (shown below).</p>
         <div class="l-grid u-mb">
@@ -119,7 +119,7 @@
       </section>
 
       <section class="u-mb-lg">
-        <h1 class="c-main__subtitle u-alpha u-mb">Colors</h1>
+        <h1 class="c-main__subtitle u-fs-xl u-mb">Colors</h1>
         <p class="u-mb">Modifiers may be added to override the tag color. The
         component contains colors for each Garden palette hue.</p>
         <div class="l-grid u-mb">
@@ -145,7 +145,7 @@
       </section>
 
       <section class="u-mb-lg">
-        <h1 class="c-main__subtitle u-alpha u-mb">Elements</h1>
+        <h1 class="c-main__subtitle u-fs-xl u-mb">Elements</h1>
         <p class="u-mb">The tag component supports a child <i>remove</i>
         element. An event listener can be attached to this element to remove
         the tag on click or delete keypress. Remember to use a focusable tag
@@ -303,7 +303,7 @@
       </section>
 
       <section class="u-mb-lg">
-        <h1 class="c-main__subtitle u-alpha u-mb">States</h1>
+        <h1 class="c-main__subtitle u-fs-xl u-mb">States</h1>
         <p class="u-mb">Focus states are shown for the tags included in
         Garden. Remember to style an accompanying focus state along with custom
         background color overrides.</p>
@@ -383,7 +383,7 @@
       </section>
 
       <section class="u-mb-lg">
-        <h1 class="c-main__subtitle u-alpha u-mb">Truncation</h1>
+        <h1 class="c-main__subtitle u-fs-xl u-mb">Truncation</h1>
         <p class="u-mb">Tags are designed to display a single line. Use the
         slider below to change the width of the text field container. Text
         within the tags will truncate with an ellipsis based on the available
@@ -437,7 +437,7 @@
       </section>
 
       <section id="playground">
-        <h1 class="c-main__subtitle u-alpha u-mb">Playground</h1>
+        <h1 class="c-main__subtitle u-fs-xl u-mb">Playground</h1>
         <p class="u-mb">
           If you are visualizing the state of a tag with color only (success, failure, etc.)
           you should include additional accessibility messaging relating to the current state.

--- a/demo/tooltips/index.html
+++ b/demo/tooltips/index.html
@@ -152,7 +152,7 @@
         </div>
       </div>
       <section id="playground">
-        <h1 class="c-main__subtitle u-alpha u-mb">Playground</h1>
+        <h1 class="c-main__subtitle u-fs-xl u-mb">Playground</h1>
         <div class="c-playground">
           <div class="c-playground__preview"></div>
 <textarea class="c-playground__code"><div class="c-tooltip c-arrow c-arrow--l u-va-top">Hello World</div>

--- a/demo/utilities/border-radius/index.html
+++ b/demo/utilities/border-radius/index.html
@@ -41,7 +41,7 @@
         <div class="l-grid__item u-1/2">
 
           <div class="u-mb-lg">
-            <h2 class="u-gamma u-mb-sm">Small</h2>
+            <h2 class="u-fs-lg u-mb-sm">Small</h2>
             <ul>
               <li class="u-mb-sm"><code class="u-bg-grey-300 u-br-sm u-ph-xs u-pv-xxs">.u-br-sm</code></li>
               <li class="u-mb-sm"><code class="u-bg-grey-300 u-br-tl-sm u-ph-xs u-pv-xxs">.u-br-tl-sm</code></li>
@@ -56,7 +56,7 @@
           </div>
 
           <div class="u-mb-lg">
-            <h2 class="u-gamma u-mb-sm">Large</h2>
+            <h2 class="u-fs-lg u-mb-sm">Large</h2>
             <ul>
               <li class="u-mb-sm"><code class="u-bg-grey-300 u-br-lg u-ph-xs u-pv-xxs">.u-br-lg</code></li>
               <li class="u-mb-sm"><code class="u-bg-grey-300 u-br-tl-lg u-ph-xs u-pv-xxs">.u-br-tl-lg</code></li>
@@ -71,7 +71,7 @@
           </div>
 
           <div class="u-mb-lg">
-            <h2 class="u-gamma u-mb-sm">Zero</h2>
+            <h2 class="u-fs-lg u-mb-sm">Zero</h2>
             <ul>
               <li class="u-mb-sm"><code class="u-bg-grey-300 u-br u-br-0 u-ph-xs u-pv-xxs">.u-br-0</code></li>
               <li class="u-mb-sm"><code class="u-bg-grey-300 u-br u-br-tl-0 u-ph-xs u-pv-xxs">.u-br-tl-0</code></li>
@@ -89,7 +89,7 @@
         ><div class="l-grid__item u-1/2">
 
           <div class="u-mb-lg">
-            <h2 class="u-gamma u-mb-sm">Medium</h2>
+            <h2 class="u-fs-lg u-mb-sm">Medium</h2>
             <ul>
               <li class="u-mb-sm"><code class="u-bg-grey-300 u-br u-ph-xs u-pv-xxs">.u-br</code></li>
               <li class="u-mb-sm"><code class="u-bg-grey-300 u-br-tl u-ph-xs u-pv-xxs">.u-br-tl</code></li>
@@ -104,7 +104,7 @@
           </div>
 
           <div class="u-mb-lg">
-            <h2 class="u-gamma u-mb-sm">Extra-Large</h2>
+            <h2 class="u-fs-lg u-mb-sm">Extra-Large</h2>
             <ul>
               <li class="u-mb-sm"><code class="u-bg-grey-300 u-br-xl u-ph-xs u-pv-xxs">.u-br-xl</code></li>
               <li class="u-mb-sm"><code class="u-bg-grey-300 u-br-tl-xl u-ph-xs u-pv-xxs">.u-br-tl-xl</code></li>
@@ -119,7 +119,7 @@
           </div>
 
           <div class="u-mb-lg">
-            <h2 class="u-gamma u-mb-sm">Round</h2>
+            <h2 class="u-fs-lg u-mb-sm">Round</h2>
             <code class="u-bg-grey-300 u-br-50% u-display-inline-block u-p">.u-br-50%</code>
           </div>
 

--- a/demo/utilities/color/index.html
+++ b/demo/utilities/color/index.html
@@ -642,7 +642,7 @@
         </div>
       </div>
       <section id="playground">
-        <h1 class="c-main__subtitle u-alpha u-mb">Playground</h1>
+        <h1 class="c-main__subtitle u-fs-xl u-mb">Playground</h1>
         <div class="c-playground">
           <div class="c-playground__preview"></div>
 <textarea class="c-playground__code"><ul>

--- a/demo/utilities/index.html
+++ b/demo/utilities/index.html
@@ -38,7 +38,7 @@
         <code class="c-code">!important</code> to ensure styles are
         overridden.</p>
       <div class="l-wrapper-720">
-        <div class="l-grid l-grid--xxl u-mb-lg u-alpha u-light u-fg-submarine">
+        <div class="l-grid l-grid--xxl u-mb-lg u-fs-xl u-light u-fg-submarine">
           <div class="l-grid__item u-1/2">
             <ul>
               <li><a class="u-fg-inherit u-display-inline-block u-mb-xs" href="border-radius">Border Radius</a></li>
@@ -65,7 +65,7 @@
         </div>
       </div>
       <section id="playground">
-        <h1 class="c-main__subtitle u-alpha u-mb">Playground</h1>
+        <h1 class="c-main__subtitle u-fs-xl u-mb">Playground</h1>
         <div class="c-playground">
           <div class="c-playground__preview"></div>
 <textarea class="c-playground__code"><p class="u-mb-sm">Box Shadow Utility</p>

--- a/demo/utilities/jitterfix/index.html
+++ b/demo/utilities/jitterfix/index.html
@@ -47,23 +47,23 @@
 
       <div class="u-mb-sm">
         <code class="c-code">.u-jitterfix--light</code>
-        <span class="u-ml">[jitterfix]<a class="u-jitterfix u-jitterfix--light u-thin u-kilo" data-text="Thin to Light" href>Thin to Light</a>[jitterfix]</li>
+        <span class="u-ml">[jitterfix]<a class="u-jitterfix u-jitterfix--light u-thin u-fs-xxl" data-text="Thin to Light" href>Thin to Light</a>[jitterfix]</li>
         <span>vs.</span>
-        <span>[jitter]<a class="u-thin u-kilo" href>Thin to Light</a>[jitter]</span>
+        <span>[jitter]<a class="u-thin u-fs-xxl" href>Thin to Light</a>[jitter]</span>
       </div>
 
       <div class="u-mb-sm">
         <code class="c-code">.u-jitterfix--regular</code>
-        <span class="u-ml">[jitterfix]<a class="u-jitterfix u-jitterfix--regular u-light u-kilo" data-text="Light to Regular" href>Light to Regular</a>[jitterfix]</li>
+        <span class="u-ml">[jitterfix]<a class="u-jitterfix u-jitterfix--regular u-light u-fs-xxl" data-text="Light to Regular" href>Light to Regular</a>[jitterfix]</li>
         <span>vs.</span>
-        <span>[jitter]<a class="u-light u-kilo" href>Light to Regular</a>[jitter]</span>
+        <span>[jitter]<a class="u-light u-fs-xxl" href>Light to Regular</a>[jitter]</span>
       </div>
 
       <div class="u-mb-sm">
         <code class="c-code">.u-jitterfix--semibold</code>
-        <span class="u-ml">[jitterfix]<a class="u-jitterfix u-jitterfix--semibold u-regular u-kilo" data-text="Regular to Semibold" href>Regular to Semibold</a>[jitterfix]</li>
+        <span class="u-ml">[jitterfix]<a class="u-jitterfix u-jitterfix--semibold u-regular u-fs-xxl" data-text="Regular to Semibold" href>Regular to Semibold</a>[jitterfix]</li>
         <span>vs.</span>
-        <span>[jitter]<a class="u-regular u-kilo" href>Regular to Semibold</a>[jitter]</span>
+        <span>[jitter]<a class="u-regular u-fs-xxl" href>Regular to Semibold</a>[jitter]</span>
       </div>
     </div>
   </main>

--- a/demo/utilities/spacing/index.html
+++ b/demo/utilities/spacing/index.html
@@ -37,7 +37,7 @@
         margins and padding based on Garden spacing variables. Snippets below
         demonstrate utility stying.</p>
 
-      <h2 class="u-gamma u-mb">Margins</h2>
+      <h2 class="u-fs-lg u-mb">Margins</h2>
       <div class="u-ml">
 
         <div class="u-mb">
@@ -588,7 +588,7 @@
 
       </div>
 
-      <h2 class="u-gamma u-mb">Padding</h2>
+      <h2 class="u-fs-lg u-mb">Padding</h2>
       <div class="u-ml">
 
         <div class="u-mb">

--- a/demo/utilities/typography/index.html
+++ b/demo/utilities/typography/index.html
@@ -62,416 +62,141 @@
     <h1 class="c-main__title">Utilities: Typography</h1>
     <div class="c-main__body">
       <p class="u-mb">Garden's
-        <a href="//zendeskgarden.github.io/css-bedrock/">bedrock</a>
+        <a href="//zendeskgarden.github.io/css-components/bedrock/">bedrock</a>
         resets apply a system font to page HTML. If not using bedrock, you can
         achieve the same result by using the
         <code class="c-code">.u-font-family-system</code> utility (as this page
         does) or by leveraging Garden
         <a href="https://github.com/zendeskgarden/css-components/tree/master/packages/variables">CSS variables</a>
-        to set this same system font stack in your code. Utility font sizes are
-        based on a
-        <a href="http://www.modularscale.com/?14&px&1.125">1.125 modular scale</a>.
-        Base line height is 20px and a 20 unit vertical rhythm is suggested,
-        but not enforced.</p>
+        to set this same system font stack in your code. Base font size is 14px
+        and line height is 20px.</p>
 
       <p class="u-mb u-ta-center">
-        <a href="#nano">Nano</a>
+        <a href="#small">Small</a>
         <span>•</span>
-        <a href="#micro">Micro</a>
+        <a href="#medium">Medium</a>
         <span>•</span>
-        <a href="#milli">Milli</a>
+        <a href="#large">Large</a>
         <span>•</span>
+        <a href="#xl">Extra-Large</a>
         <span>•</span>
+        <a href="#xxl">XXL</a>
         <span>•</span>
-        <a href="#zeta">Zeta</a>
-        <span>•</span>
-        <a href="#epsilon">Epsilon</a>
-        <span>•</span>
-        <a href="#delta">Delta</a>
-        <span>•</span>
-        <a href="#gamma">Gamma</a>
-        <span>•</span>
-        <a href="#beta">Beta</a>
-        <span>•</span>
-        <a href="#alpha">Alpha</a>
-        <span>•</span>
-        <span>•</span>
-        <span>•</span>
-        <a href="#kilo">Kilo</a>
-        <span>•</span>
-        <a href="#mega">Mega</a>
-        <span>•</span>
-        <a href="#giga">Giga</a>
+        <a href="#xxxl">XXXL</a>
       </p>
 
-      <h2 class="u-gamma u-mb">Standard Sizes</h2>
-
-      <h3 class="u-delta u-mb"><span id="zeta">Zeta</span>
-        <code class="c-code">.u-zeta</code>
+      <h3 class="u-fs-lg u-mb"><span id="small">Small</span>
+        <code class="c-code">.u-fs-sm</code>
         <span>(12px)</span></h3>
-      <ul class="u-zeta u-mb-lg">
-        <li class="u-thin u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">THIN</span>
-          <code class="c-code">.u-thin</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
-        <li class="u-light u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">LIGHT</span>
-          <code class="c-code">.u-light</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
+      <ul class="u-fs-sm u-mb-lg">
         <li class="u-regular u-mb-sm">
           <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">REGULAR</span>
           <code class="c-code">.u-regular</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
+          <p class="js-sample u-lh-sm"></p>
+          <p><i class="js-sample u-lh-sm"></i></p>
         </li>
         <li class="u-semibold u-mb-sm">
           <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">SEMIBOLD</span>
           <code class="c-code">.u-semibold</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
+          <p class="js-sample u-lh-sm"></p>
+          <p><i class="js-sample u-lh-sm"></i></p>
         </li>
       </ul>
 
-      <h3 class="u-delta u-mb"><span id="epsilon">Epsilon</span>
-        <code class="c-code">.u-epsilon</code>
+      <h3 class="u-fs-lg u-mb"><span id="medium">Medium</span>
+        <code class="c-code">.u-fs-md</code>
         <span>(14px)</span></h3>
-      <ul class="u-epsilon u-mb-lg">
-        <li class="u-thin u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">THIN</span>
-          <code class="c-code">.u-thin</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
-        <li class="u-light u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">LIGHT</span>
-          <code class="c-code">.u-light</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
+      <ul class="u-fs-md u-mb-lg">
         <li class="u-regular u-mb-sm">
           <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">REGULAR</span>
           <code class="c-code">.u-regular</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
+          <p class="js-sample u-lh-md"></p>
+          <p><i class="js-sample u-lh-md"></i></p>
         </li>
         <li class="u-semibold u-mb-sm">
           <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">SEMIBOLD</span>
           <code class="c-code">.u-semibold</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
+          <p class="js-sample u-lh-md"></p>
+          <p><i class="js-sample u-lh-md"></i></p>
         </li>
       </ul>
 
-      <h3 class="u-delta u-mb"><span id="delta">Delta</span>
-        <code class="c-code">.u-delta</code>
-        <span>(16px)</span></h3>
-      <ul class="u-delta u-mb-lg">
-        <li class="u-thin u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">THIN</span>
-          <code class="c-code">.u-thin</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
-        <li class="u-light u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">LIGHT</span>
-          <code class="c-code">.u-light</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
-        <li class="u-regular u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">REGULAR</span>
-          <code class="c-code">.u-regular</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
-        <li class="u-semibold u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">SEMIBOLD</span>
-          <code class="c-code">.u-semibold</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
-      </ul>
-
-      <h3 class="u-delta u-mb"><span id="gamma">Gamma</span>
-        <code class="c-code">.u-gamma</code>
+      <h3 class="u-fs-lg u-mb"><span id="large">Large</span>
+        <code class="c-code">.u-fs-lg</code>
         <span>(18px)</span></h3>
-      <ul class="u-gamma u-mb-lg">
-        <li class="u-thin u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">THIN</span>
-          <code class="c-code">.u-thin</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
-        <li class="u-light u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">LIGHT</span>
-          <code class="c-code">.u-light</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
+      <ul class="u-fs-lg u-mb-lg">
         <li class="u-regular u-mb-sm">
           <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">REGULAR</span>
           <code class="c-code">.u-regular</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
+          <p class="js-sample u-lh-lg"></p>
+          <p><i class="js-sample u-lh-lg"></i></p>
         </li>
         <li class="u-semibold u-mb-sm">
           <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">SEMIBOLD</span>
           <code class="c-code">.u-semibold</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
+          <p class="js-sample u-lh-lg"></p>
+          <p><i class="js-sample u-lh-lg"></i></p>
         </li>
       </ul>
 
-      <h3 class="u-delta u-mb"><span id="beta">Beta</span>
-        <code class="c-code">.u-beta</code>
-        <span>(20px)</span></h3>
-      <ul class="u-beta u-mb-lg">
-        <li class="u-thin u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">THIN</span>
-          <code class="c-code">.u-thin</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
-        <li class="u-light u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">LIGHT</span>
-          <code class="c-code">.u-light</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
-        <li class="u-regular u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">REGULAR</span>
-          <code class="c-code">.u-regular</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
-        <li class="u-semibold u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">SEMIBOLD</span>
-          <code class="c-code">.u-semibold</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
-      </ul>
-
-      <h3 class="u-delta u-mb"><span id="alpha">Alpha</span>
-        <code class="c-code">.u-alpha</code>
+      <h3 class="u-fs-lg u-mb"><span id="xl">Extra-Large</span>
+        <code class="c-code">.u-fs-xl</code>
         <span>(22px)</span></h3>
-      <ul class="u-alpha u-mb-lg">
-        <li class="u-thin u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">THIN</span>
-          <code class="c-code">.u-thin</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
-        <li class="u-light u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">LIGHT</span>
-          <code class="c-code">.u-light</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
+      <ul class="u-fs-xl u-mb-lg">
         <li class="u-regular u-mb-sm">
           <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">REGULAR</span>
           <code class="c-code">.u-regular</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
+          <p class="js-sample u-lh-xl"></p>
+          <p><i class="js-sample u-lh-xl"></i></p>
         </li>
         <li class="u-semibold u-mb-sm">
           <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">SEMIBOLD</span>
           <code class="c-code">.u-semibold</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
+          <p class="js-sample u-lh-xl"></p>
+          <p><i class="js-sample u-lh-xl"></i></p>
         </li>
       </ul>
 
-      <h2 class="u-gamma u-mb">Extreme Sizes</h2>
-
-      <h3 class="u-delta u-mb"><span id="nano">Nano</span>
-        <code class="c-code">.u-nano</code>
-        <span>(9px)</span></h3>
-      <ul class="u-nano u-mb-lg">
-        <li class="u-thin u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">THIN</span>
-          <code class="c-code">.u-thin</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
-        <li class="u-light u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">LIGHT</span>
-          <code class="c-code">.u-light</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
+      <h3 class="u-fs-lg u-mb"><span id="xxl">XXL</span>
+        <code class="c-code">.u-fs-xxl</code>
+        <span>(26px)</span></h3>
+      <ul class="u-fs-xxl u-mb-lg">
         <li class="u-regular u-mb-sm">
           <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">REGULAR</span>
           <code class="c-code">.u-regular</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
+          <p class="js-sample u-lh-xxl"></p>
+          <p><i class="js-sample u-lh-xxl"></i></p>
         </li>
         <li class="u-semibold u-mb-sm">
           <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">SEMIBOLD</span>
           <code class="c-code">.u-semibold</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
+          <p class="js-sample u-lh-xxl"></p>
+          <p><i class="js-sample u-lh-xxl"></i></p>
         </li>
       </ul>
 
-      <h3 class="u-delta u-mb"><span id="micro">Micro</span>
-        <code class="c-code">.u-micro</code>
-        <span>(10px)</span></h3>
-      <ul class="u-micro u-mb-lg">
-        <li class="u-thin u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">THIN</span>
-          <code class="c-code">.u-thin</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
-        <li class="u-light u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">LIGHT</span>
-          <code class="c-code">.u-light</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
-        <li class="u-regular u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">REGULAR</span>
-          <code class="c-code">.u-regular</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
-        <li class="u-semibold u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">SEMIBOLD</span>
-          <code class="c-code">.u-semibold</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
-      </ul>
-
-      <h3 class="u-delta u-mb"><span id="milli">Milli</span>
-        <code class="c-code">.u-milli</code>
-        <span>(11px)</span></h3>
-      <ul class="u-milli u-mb-lg">
-        <li class="u-thin u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">THIN</span>
-          <code class="c-code">.u-thin</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
-        <li class="u-light u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">LIGHT</span>
-          <code class="c-code">.u-light</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
-        <li class="u-regular u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">REGULAR</span>
-          <code class="c-code">.u-regular</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
-        <li class="u-semibold u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">SEMIBOLD</span>
-          <code class="c-code">.u-semibold</code>
-          <p class="js-sample"></p>
-          <p><i class="js-sample"></i></p>
-        </li>
-      </ul>
-
-      <h3 class="u-delta u-mb"><span id="kilo">Kilo</span>
-        <code class="c-code">.u-kilo</code>
-        <span>(25px)</span></h3>
-      <ul class="u-kilo u-mb-lg">
-        <li class="u-thin u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">THIN</span>
-          <code class="c-code">.u-thin</code>
-          <p class="js-sample u-line-height-lg"></p>
-          <p><i class="js-sample u-line-height-lg"></i></p>
-        </li>
-        <li class="u-light u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">LIGHT</span>
-          <code class="c-code">.u-light</code>
-          <p class="js-sample u-line-height-lg"></p>
-          <p><i class="js-sample u-line-height-lg"></i></p>
-        </li>
-        <li class="u-regular u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">REGULAR</span>
-          <code class="c-code">.u-regular</code>
-          <p class="js-sample u-line-height-lg"></p>
-          <p><i class="js-sample u-line-height-lg"></i></p>
-        </li>
-        <li class="u-semibold u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">SEMIBOLD</span>
-          <code class="c-code">.u-semibold</code>
-          <p class="js-sample u-line-height-lg"></p>
-          <p><i class="js-sample u-line-height-lg"></i></p>
-        </li>
-      </ul>
-
-      <h3 class="u-delta u-mb"><span id="mega">Mega</span>
-        <code class="c-code">.u-mega</code>
-        <span>(28px)</span></h3>
-      <ul class="u-mega u-mb-lg">
-        <li class="u-thin u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">THIN</span>
-          <code class="c-code">.u-thin</code>
-          <p class="js-sample u-line-height-lg"></p>
-          <p><i class="js-sample u-line-height-lg"></i></p>
-        </li>
-        <li class="u-light u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">LIGHT</span>
-          <code class="c-code">.u-light</code>
-          <p class="js-sample u-line-height-lg"></p>
-          <p><i class="js-sample u-line-height-lg"></i></p>
-        </li>
-        <li class="u-regular u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">REGULAR</span>
-          <code class="c-code">.u-regular</code>
-          <p class="js-sample u-line-height-lg"></p>
-          <p><i class="js-sample u-line-height-lg"></i></p>
-        </li>
-        <li class="u-semibold u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">SEMIBOLD</span>
-          <code class="c-code">.u-semibold</code>
-          <p class="js-sample u-line-height-lg"></p>
-          <p><i class="js-sample u-line-height-lg"></i></p>
-        </li>
-      </ul>
-
-      <h3 class="u-delta u-mb"><span id="giga">Giga</span>
-        <code class="c-code">.u-giga</code>
+      <h3 class="u-fs-lg u-mb"><span id="xxxl">XXXL</span>
+        <code class="c-code">.u-fs-xxxl</code>
         <span>(36px)</span></h3>
-      <ul class="u-giga u-mb-lg">
-        <li class="u-thin u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">THIN</span>
-          <code class="c-code">.u-thin</code>
-          <p class="js-sample u-line-height-xl"></p>
-          <p><i class="js-sample u-line-height-xl"></i></p>
-        </li>
-        <li class="u-light u-mb-sm">
-          <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">LIGHT</span>
-          <code class="c-code">.u-light</code>
-          <p class="js-sample u-line-height-xl"></p>
-          <p><i class="js-sample u-line-height-xl"></i></p>
-        </li>
+      <ul class="u-fs-xxxl u-mb-lg">
         <li class="u-regular u-mb-sm">
           <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">REGULAR</span>
           <code class="c-code">.u-regular</code>
-          <p class="js-sample u-line-height-xl"></p>
-          <p><i class="js-sample u-line-height-xl"></i></p>
+          <p class="js-sample u-lh-xxxl"></p>
+          <p><i class="js-sample u-lh-xxxl"></i></p>
         </li>
         <li class="u-semibold u-mb-sm">
           <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">SEMIBOLD</span>
           <code class="c-code">.u-semibold</code>
-          <p class="js-sample u-line-height-xl"></p>
-          <p><i class="js-sample u-line-height-xl"></i></p>
+          <p class="js-sample u-lh-xxxl"></p>
+          <p><i class="js-sample u-lh-xxxl"></i></p>
         </li>
       </ul>
       <section id="playground">
-        <h1 class="c-main__subtitle u-alpha u-mb">Playground</h1>
+        <h1 class="c-main__subtitle u-fs-xl u-mb">Playground</h1>
         <div class="c-playground">
           <div class="c-playground__preview"></div>
-<textarea class="c-playground__code"><pre class="u-font-family-inherit u-gamma">é - accent acute
+<textarea class="c-playground__code"><pre class="u-font-family-inherit u-fs-lg">é - accent acute
 è - accent grave
 ê - circumflex
 ë - umlaut or diaerisis

--- a/demo/utilities/vertical-align/index.html
+++ b/demo/utilities/vertical-align/index.html
@@ -41,7 +41,7 @@
         <div class="l-grid__item u-1/4">
           <code class="c-code">.u-va-top</code>
         </div
-        ><p class="l-grid__item u-3/4 u-bc-grey-400 u-border-v u-giga">
+        ><p class="l-grid__item u-3/4 u-bc-grey-400 u-border-v u-fs-xxxl">
           <span class="u-bg-red-500 u-display-inline-block u-p-xs u-va-top"></span>
           <span class="u-bg-red-500 u-display-inline-block u-p-xs u-va-top"></span>
           <span class="u-bg-red-500 u-display-inline-block u-p-xs u-va-top"></span>
@@ -56,7 +56,7 @@
         <div class="l-grid__item u-1/4">
           <code class="c-code">.u-va-text-top</code>
         </div
-        ><p class="l-grid__item u-3/4 u-bc-grey-400 u-border-v u-giga">
+        ><p class="l-grid__item u-3/4 u-bc-grey-400 u-border-v u-fs-xxxl">
           <span class="u-bg-red-500 u-display-inline-block u-p-xs u-va-text-top"></span>
           <span class="u-bg-red-500 u-display-inline-block u-p-xs u-va-text-top"></span>
           <span class="u-bg-red-500 u-display-inline-block u-p-xs u-va-text-top"></span>
@@ -71,7 +71,7 @@
         <div class="l-grid__item u-1/4">
           <code class="c-code">.u-va-super</code>
         </div
-        ><p class="l-grid__item u-3/4 u-bc-grey-400 u-border-v u-giga">
+        ><p class="l-grid__item u-3/4 u-bc-grey-400 u-border-v u-fs-xxxl">
           <span class="u-bg-red-500 u-display-inline-block u-p-xs u-va-super"></span>
           <span class="u-bg-red-500 u-display-inline-block u-p-xs u-va-super"></span>
           <span class="u-bg-red-500 u-display-inline-block u-p-xs u-va-super"></span>
@@ -86,7 +86,7 @@
         <div class="l-grid__item u-1/4">
           <code class="c-code">.u-va-middle</code>
         </div
-        ><p class="l-grid__item u-3/4 u-bc-grey-400 u-border-v u-giga">
+        ><p class="l-grid__item u-3/4 u-bc-grey-400 u-border-v u-fs-xxxl">
           <span class="u-bg-red-500 u-display-inline-block u-p-xs u-va-middle"></span>
           <span class="u-bg-red-500 u-display-inline-block u-p-xs u-va-middle"></span>
           <span class="u-bg-red-500 u-display-inline-block u-p-xs u-va-middle"></span>
@@ -101,7 +101,7 @@
         <div class="l-grid__item u-1/4">
           <code class="c-code">.u-va-baseline</code>
         </div
-        ><p class="l-grid__item u-3/4 u-bc-grey-400 u-border-v u-giga">
+        ><p class="l-grid__item u-3/4 u-bc-grey-400 u-border-v u-fs-xxxl">
           <span class="u-bg-red-500 u-display-inline-block u-p-xs u-va-baseline"></span>
           <span class="u-bg-red-500 u-display-inline-block u-p-xs u-va-baseline"></span>
           <span class="u-bg-red-500 u-display-inline-block u-p-xs u-va-baseline"></span>
@@ -116,7 +116,7 @@
         <div class="l-grid__item u-1/4">
           <code class="c-code">.u-va-sub</code>
         </div
-        ><p class="l-grid__item u-3/4 u-bc-grey-400 u-border-v u-giga">
+        ><p class="l-grid__item u-3/4 u-bc-grey-400 u-border-v u-fs-xxxl">
           <span class="u-bg-red-500 u-display-inline-block u-p-xs u-va-sub"></span>
           <span class="u-bg-red-500 u-display-inline-block u-p-xs u-va-sub"></span>
           <span class="u-bg-red-500 u-display-inline-block u-p-xs u-va-sub"></span>
@@ -131,7 +131,7 @@
         <div class="l-grid__item u-1/4">
           <code class="c-code">.u-va-text-bottom</code>
         </div
-        ><p class="l-grid__item u-3/4 u-bc-grey-400 u-border-v u-giga">
+        ><p class="l-grid__item u-3/4 u-bc-grey-400 u-border-v u-fs-xxxl">
           <span class="u-bg-red-500 u-display-inline-block u-p-xs u-va-text-bottom"></span>
           <span class="u-bg-red-500 u-display-inline-block u-p-xs u-va-text-bottom"></span>
           <span class="u-bg-red-500 u-display-inline-block u-p-xs u-va-text-bottom"></span>
@@ -146,7 +146,7 @@
         <div class="l-grid__item u-1/4">
           <code class="c-code">.u-va-bottom</code>
         </div
-        ><p class="l-grid__item u-3/4 u-bc-grey-400 u-border-v u-giga">
+        ><p class="l-grid__item u-3/4 u-bc-grey-400 u-border-v u-fs-xxxl">
           <span class="u-bg-red-500 u-display-inline-block u-p-xs u-va-bottom"></span>
           <span class="u-bg-red-500 u-display-inline-block u-p-xs u-va-bottom"></span>
           <span class="u-bg-red-500 u-display-inline-block u-p-xs u-va-bottom"></span>
@@ -161,7 +161,7 @@
         <div class="l-grid__item u-1/4">
           <code class="c-code">.u-va-inherit</code>
         </div
-        ><p class="l-grid__item u-3/4 u-bc-grey-400 u-border-v u-giga u-va-middle">
+        ><p class="l-grid__item u-3/4 u-bc-grey-400 u-border-v u-fs-xxxl u-va-middle">
           <span class="u-bg-red-500 u-display-inline-block u-p-xs u-va-inherit"></span>
           <span class="u-bg-red-500 u-display-inline-block u-p-xs u-va-inherit"></span>
           <span class="u-bg-red-500 u-display-inline-block u-p-xs u-va-inherit"></span>

--- a/packages/.template/demo/index.html
+++ b/packages/.template/demo/index.html
@@ -65,7 +65,7 @@
     <div class="c-main__body">
       <p class="c-{{component}} u-mb-lg">Hello World!</p>
       <section id="playground">
-        <h1 class="c-main__subtitle u-alpha u-mb">Playground</h1>
+        <h1 class="c-main__subtitle u-fs-xl u-mb">Playground</h1>
         <div class="c-playground">
           <div class="c-playground__preview"></div>
           <textarea class="c-playground__code"><p class="c-{{component}}">Hello World!</p></textarea>

--- a/packages/buttons/src/_base.css
+++ b/packages/buttons/src/_base.css
@@ -2,7 +2,7 @@
 @import '_variables';
 
 :root {
-  --zd-btn-font-size: var(--zd-font-size-epsilon);
+  --zd-btn-font-size: var(--zd-font-size-md);
   --zd-btn-font-weight: var(--zd-font-weight-regular);
   --zd-btn-background-color: transparent;
   --zd-btn-border-radius: 4px;
@@ -15,12 +15,12 @@
     box-shadow .1s ease-in-out,
     background-color .25s ease-in-out,
     color .25s ease-in-out;
-  --zd-btn--lg-font-size: var(--zd-font-size-epsilon);
+  --zd-btn--lg-font-size: var(--zd-font-size-md);
   --zd-btn--lg-line-height: 46px;
   --zd-btn--lg-padding: calc(27 / 14 * 1em);
   --zd-btn--lg-min-width: calc(calc(86 / 14 * 1em) + calc(var(--zd-btn--lg-padding) * 2));
   --zd-btn--pill-border-radius: 100px;
-  --zd-btn--sm-font-size: var(--zd-font-size-zeta);
+  --zd-btn--sm-font-size: var(--zd-font-size-sm);
   --zd-btn--sm-line-height: 30px;
   --zd-btn--sm-padding: calc(27 / 12 * 1em);
   --zd-btn--sm-min-width: calc(calc(46 / 12 * 1em) + calc(var(--zd-btn--sm-padding) * 2));

--- a/packages/callouts/src/_base.css
+++ b/packages/callouts/src/_base.css
@@ -6,7 +6,7 @@
   --zd-callout-border: 1px solid var(--zd-callout-border-color);
   --zd-callout-border-radius: 4px;
   --zd-callout-color: var(--zd-color-grey-600);
-  --zd-callout-font-size: var(--zd-font-size-epsilon);
+  --zd-callout-font-size: var(--zd-font-size-md);
   --zd-callout-line-height: calc(20 / 14);
   --zd-callout-padding-horizontal: var(--zd-spacing-xl);
   --zd-callout-padding: var(--zd-spacing) var(--zd-callout-padding-horizontal);

--- a/packages/callouts/src/_close.css
+++ b/packages/callouts/src/_close.css
@@ -7,7 +7,7 @@
   --zd-callout__close-transition: background-color .1s ease-in-out;
   --zd-callout__close-focused-background-color: color-mod(var(--zd-color-grey-600) alpha(15%));
   --zd-callout__close-hovered-background-image: svg-load('14/remove.svg', color: var(--zd-color-grey-800));
-  --zd-callout__close__icon-background-size: var(--zd-font-size-gamma);
+  --zd-callout__close__icon-background-size: 18px;
   --zd-callout__close__icon-transition: opacity .25s ease-in-out;
   --zd-callout--error__close-background-image: svg-load('14/remove.svg', color: var(--zd-color-red-500));
   --zd-callout--error__close-focused-background-color: color-mod(var(--zd-color-red-600) alpha(15%));

--- a/packages/chrome/src/_base.css
+++ b/packages/chrome/src/_base.css
@@ -6,7 +6,7 @@
   --zd-chrome-min-height: 100vh;
   --zd-chrome__body-color: var(--zd-color-grey-100);
   --zd-chrome__body__content-color: var(--zd-color-grey-800);
-  --zd-chrome__body__content-font-size: var(--zd-font-size-epsilon);
+  --zd-chrome__body__content-font-size: var(--zd-font-size-md);
   --zd-chrome__body__content-height: calc(100% - var(--zd-chrome__body__header-height));
   --zd-chrome__body__content-line-height: calc(20 / 14);
   --zd-chrome__body__content__main-background-color: var(--zd-color-white);

--- a/packages/chrome/src/_header.css
+++ b/packages/chrome/src/_header.css
@@ -7,7 +7,7 @@
   --zd-chrome__body__header-border-color: var(--zd-color-grey-300);
   --zd-chrome__body__header-border-bottom: 1px solid var(--zd-chrome__body__header-border-color);
   --zd-chrome__body__header-color: var(--zd-color-grey-600);
-  --zd-chrome__body__header-font-size: var(--zd-font-size-epsilon);
+  --zd-chrome__body__header-font-size: var(--zd-font-size-md);
   --zd-chrome__body__header-height: var(--zd-chrome__nav__item-height);
   --zd-chrome__body__header-padding-horizontal: 4px;
   --zd-chrome__body__header-padding: 0 var(--zd-chrome__body__header-padding-horizontal);

--- a/packages/chrome/src/_nav.css
+++ b/packages/chrome/src/_nav.css
@@ -4,7 +4,7 @@
 
 :root {
   --zd-chrome__nav-width: 60px;
-  --zd-chrome__nav-font-size: var(--zd-font-size-epsilon);
+  --zd-chrome__nav-font-size: var(--zd-font-size-md);
   --zd-chrome__nav__fab-background-color: var(--zd-color-kale-400);
   --zd-chrome__nav__fab-box-shadow:
     0 6px 12px 0

--- a/packages/chrome/src/_subnav.css
+++ b/packages/chrome/src/_subnav.css
@@ -5,7 +5,7 @@
 :root {
   --zd-chrome__subnav-background-color: var(--zd-color-kale-800);
   --zd-chrome__subnav-color: var(--zd-color-white);
-  --zd-chrome__subnav-font-size: var(--zd-font-size-epsilon);
+  --zd-chrome__subnav-font-size: var(--zd-font-size-md);
   --zd-chrome__subnav-min-width: 180px;
   --zd-chrome__subnav-padding: 30px 20px;
   --zd-chrome__subnav__item-border-radius: 4px;

--- a/packages/forms/src/_checkbox/_base.css
+++ b/packages/forms/src/_checkbox/_base.css
@@ -5,7 +5,7 @@
   --zd-chk-background-color: var(--zd-color-white);
   --zd-chk-border: 1px solid var(--zd-forms-border-color);
   --zd-chk-border-radius: 4px;
-  --zd-chk-size: var(--zd-font-size-epsilon);
+  --zd-chk-size: var(--zd-font-size-md);
   --zd-chk-transition:
     border-color .25s ease-in-out,
     box-shadow .1s ease-in-out,

--- a/packages/forms/src/_checkbox/_toggle.css
+++ b/packages/forms/src/_checkbox/_toggle.css
@@ -14,7 +14,7 @@
     color .25s ease-in-out;
   --zd-chk--toggle-width: var(--zd-spacing-xl);
   --zd-chk--toggle__label-padding: calc(var(--zd-chk--toggle-width) + var(--zd-chk__label-spacing));
-  --zd-chk--toggle__message-background-position: calc(var(--zd-chk--toggle-width) - var(--zd-font-size-epsilon));
+  --zd-chk--toggle__message-background-position: calc(var(--zd-chk--toggle-width) - var(--zd-font-size-md));
 }
 
 .c-chk__label--toggle,

--- a/packages/forms/src/_text/_base.css
+++ b/packages/forms/src/_text/_base.css
@@ -6,7 +6,7 @@
   --zd-txt__input-border-radius: 4px;
   --zd-txt__input-color: var(--zd-color-grey-800);
   --zd-txt__input-color-placeholder: var(--zd-color-grey-400);
-  --zd-txt__input-font-size: var(--zd-font-size-epsilon);
+  --zd-txt__input-font-size: var(--zd-font-size-md);
   --zd-txt__input-line-height: calc(18 / 14);
   --zd-txt__input-height: var(--zd-spacing-xl);
   --zd-txt__input-padding-horizontal: calc(16 / 14 * 1em);
@@ -59,7 +59,7 @@
 
 .c-txt__input::-ms-browse {
   border-radius: calc(var(--zd-txt__input-border-radius) / 2);
-  font-size: var(--zd-font-size-zeta);
+  font-size: var(--zd-font-size-sm);
 }
 
 .c-txt__input::-ms-clear,

--- a/packages/forms/src/_variables.css
+++ b/packages/forms/src/_variables.css
@@ -14,12 +14,12 @@
   --zd-forms-success-color: var(--zd-color-green-400);
   --zd-forms-warning-color: var(--zd-color-yellow-400);
   --zd-input__hint-color: var(--zd-color-grey-600);
-  --zd-input__hint-font-size: var(--zd-font-size-epsilon);
+  --zd-input__hint-font-size: var(--zd-font-size-md);
   --zd-input__label-color: var(--zd-color-grey-800);
-  --zd-input__label-font-size: var(--zd-font-size-epsilon);
+  --zd-input__label-font-size: var(--zd-font-size-md);
   --zd-input__label-font-weight: var(--zd-font-weight-semibold);
   --zd-input__message-color: var(--zd-color-grey-700);
-  --zd-input__message-font-size: var(--zd-font-size-zeta);
+  --zd-input__message-font-size: var(--zd-font-size-sm);
   --zd-input__message--error-background-image: svg-load('14/error-fill.svg', color: var(--zd-color-red-500));
   --zd-input__message--error-color: var(--zd-color-red-600);
   --zd-input__message--success-background-image: svg-load('14/checkmark-fill.svg', color: var(--zd-color-green-500));

--- a/packages/menus/src/_base.css
+++ b/packages/menus/src/_base.css
@@ -8,7 +8,7 @@
   --zd-menu-box-shadow:
     0 20px 30px 0
     color-mod(var(--zd-color-kale-600) alpha(15%));
-  --zd-menu-font-size: var(--zd-font-size-epsilon);
+  --zd-menu-font-size: var(--zd-font-size-md);
   --zd-menu-font-weight: var(--zd-font-weight-regular);
   --zd-menu-min-width: 180px;
   --zd-menu-padding: 8px 0;

--- a/packages/menus/src/_item.css
+++ b/packages/menus/src/_item.css
@@ -19,7 +19,7 @@
   --zd-menu__item--header-font-weight: var(--zd-font-weight-semibold);
   --zd-menu__item--header__icon-top: calc(calc(var(--zd-menu__item--icon-height) - var(--zd-menu__item--icon-background-size)) / 2);
   --zd-menu__item--header__icon-left: calc(calc(var(--zd-menu__item--icon-width) - var(--zd-menu__item--icon-background-size)) / 2);
-  --zd-menu__item--icon-background-size: var(--zd-font-size-epsilon);
+  --zd-menu__item--icon-background-size: var(--zd-font-size-md);
   --zd-menu__item--icon-height: calc(20px + calc(var(--zd-menu__item-padding-vertical) * 2));
   --zd-menu__item--icon-width: var(--zd-menu__item-padding-horizontal);
   --zd-menu__item--icon-transition: opacity .1s ease-in-out;
@@ -40,7 +40,7 @@
   --zd-menu--sm__item--media__figure-margin: calc(var(--zd-menu__item--media__figure-margin) / 2);
   --zd-menu--sm__item--media--icon-height: calc(var(--zd-menu--sm__item--media__figure-size) + calc(var(--zd-menu--sm__item-padding-vertical) * 2));
   --zd-menu__item__meta-color: var(--zd-color-grey-600);
-  --zd-menu__item__meta-font-size: var(--zd-font-size-zeta);
+  --zd-menu__item__meta-font-size: var(--zd-font-size-sm);
   --zd-menu__item__meta-line-height: calc(16 / 12);
 }
 

--- a/packages/modals/src/_body.css
+++ b/packages/modals/src/_body.css
@@ -2,7 +2,7 @@
 
 :root {
   --zd-dialog__body-color: var(--zd-color-grey-800);
-  --zd-dialog__body-font-size: var(--zd-font-size-epsilon);
+  --zd-dialog__body-font-size: var(--zd-font-size-md);
   --zd-dialog__body-line-height: calc(20 / 14);
   --zd-dialog__body-padding: var(--zd-spacing) var(--zd-spacing-xl) var(--zd-spacing-xl);
   --zd-dialog--large__body-padding: var(--zd-spacing) var(--zd-spacing-xl);

--- a/packages/modals/src/_header.css
+++ b/packages/modals/src/_header.css
@@ -3,7 +3,7 @@
 :root {
   --zd-dialog__header-border-bottom: 1px solid var(--zd-color-grey-200);
   --zd-dialog__header-color: var(--zd-color-grey-800);
-  --zd-dialog__header-font-size: var(--zd-font-size-epsilon);
+  --zd-dialog__header-font-size: var(--zd-font-size-md);
   --zd-dialog__header-font-weight: var(--zd-font-weight-semibold);
   --zd-dialog__header-line-height: calc(20 / 14);
   --zd-dialog__header-padding: var(--zd-spacing) var(--zd-spacing-xl);

--- a/packages/pagination/src/_base.css
+++ b/packages/pagination/src/_base.css
@@ -3,7 +3,7 @@
 :root {
   --zd-pagination__page-border-radius: 4px;
   --zd-pagination__page-color: var(--zd-color-grey-600);
-  --zd-pagination__page-font-size: var(--zd-font-size-epsilon);
+  --zd-pagination__page-font-size: var(--zd-font-size-md);
   --zd-pagination__page-line-height: calc(32 / 14);
   --zd-pagination__page-margin: 4px;
   --zd-pagination__page-max-width: calc(var(--zd-pagination__page-size) * 2);
@@ -13,7 +13,7 @@
     background .25s ease-in-out,
     box-shadow .1s ease-in-out,
     color .25s ease-in-out;
-  --zd-pagination__page--gap-font-size: var(--zd-font-size-delta);
+  --zd-pagination__page--gap-font-size: 16px;
   --zd-pagination__page--gap-margin-top: calc(var(--zd-pagination__page-font-size) - var(--zd-pagination__page--gap-font-size));
   --zd-pagination__page--next-background-image: svg-load('14/next.svg', color: var(--zd-color-grey-500));
   --zd-pagination__page--previous-background-image: svg-load('14/previous.svg', color: var(--zd-color-grey-500));

--- a/packages/tables/src/_base.css
+++ b/packages/tables/src/_base.css
@@ -2,13 +2,13 @@
 
 :root {
   --zd-table-font-color: var(--zd-color-grey-800);
-  --zd-table-font-size: var(--zd-font-size-epsilon);
+  --zd-table-font-size: var(--zd-font-size-md);
   --zd-table-line-height: calc(20 / 14);
   --zd-table__row-border: 1px solid;
   --zd-table__row-border-bottom: var(--zd-table__row-border) var(--zd-color-grey-200);
   --zd-table__row-height: 40px;
   --zd-table__row-transition: background-color .1s ease-in-out;
-  --zd-table__row--group-font-size: var(--zd-font-size-zeta);
+  --zd-table__row--group-font-size: var(--zd-font-size-sm);
   --zd-table__row--group-height: 32px;
   --zd-table__row--group-line-height: calc(20 / 12);
   --zd-table__row--group__cell-padding: 6px 10px;

--- a/packages/tabs/src/_base.css
+++ b/packages/tabs/src/_base.css
@@ -4,7 +4,7 @@
   --zd-tab__list-border-color: var(--zd-color-grey-300);
   --zd-tab__list-border-width: 1px;
   --zd-tab__list-color: var(--zd-color-grey-600);
-  --zd-tab__list-font-size: var(--zd-font-size-epsilon);
+  --zd-tab__list-font-size: var(--zd-font-size-md);
   --zd-tab__list-line-height: 20px;
   --zd-tab__list-margin-bottom: var(--zd-spacing);
   --zd-tab__list__item-border-width: 3px;

--- a/packages/tags/src/_base.css
+++ b/packages/tags/src/_base.css
@@ -6,7 +6,7 @@
   --zd-tag-background-color: var(--zd-color-grey-200);
   --zd-tag-border-radius: 2px;
   --zd-tag-color: var(--zd-color-grey-700);
-  --zd-tag-font-size: var(--zd-font-size-zeta);
+  --zd-tag-font-size: var(--zd-font-size-sm);
   --zd-tag-font-weight: var(--zd-font-weight-semibold);
   --zd-tag-height: var(--zd-spacing);
   --zd-tag-line-height: calc(20 / 12);

--- a/packages/tags/src/_remove.css
+++ b/packages/tags/src/_remove.css
@@ -13,7 +13,7 @@
   --zd-tag__remove-size: var(--zd-spacing);
   --zd-tag__remove-transition: opacity .25s ease-in-out;
   --zd-tag__remove-hovered-opacity: .9;
-  --zd-tag--lg__remove-background-size: var(--zd-font-size-delta);
+  --zd-tag--lg__remove-background-size: 16px;
   --zd-tag--lg__remove-size: 30px;
   --zd-tag--lg__remove-margin: calc(var(--zd-tag--lg-padding-horizontal) * -1);
   --zd-tag--color__remove-background-image: svg-load('14/remove.svg', color: var(--zd-tag--color-color));

--- a/packages/tooltips/src/_base.css
+++ b/packages/tooltips/src/_base.css
@@ -7,23 +7,23 @@
     0 4px 8px 0
     color-mod(var(--zd-color-kale-600) alpha(15%));
   --zd-tooltip-color: var(--zd-color-white);
-  --zd-tooltip-font-size: var(--zd-font-size-zeta);
+  --zd-tooltip-font-size: var(--zd-font-size-sm);
   --zd-tooltip-font-weight: var(--zd-font-weight-regular);
   --zd-tooltip-line-height: calc(20 / 12);
   --zd-tooltip-padding: 0 1em;
   --zd-tooltip__arrow-font-size: 7px;
   --zd-tooltip--extra-large-border-radius: 4px;
-  --zd-tooltip--extra-large-font-size: var(--zd-font-size-epsilon);
+  --zd-tooltip--extra-large-font-size: var(--zd-font-size-md);
   --zd-tooltip--extra-large-line-height: calc(20 / 14);
   --zd-tooltip--extra-large-max-width: 460px;
   --zd-tooltip--extra-large-padding: var(--zd-spacing-xl);
-  --zd-tooltip--extra-large__arrow-font-size: var(--zd-font-size-delta);
+  --zd-tooltip--extra-large__arrow-font-size: 16px;
   --zd-tooltip--large-border-radius: var(--zd-tooltip--extra-large-border-radius);
   --zd-tooltip--large-font-size: var(--zd-tooltip--extra-large-font-size);
   --zd-tooltip--large-line-height: var(--zd-tooltip--extra-large-line-height);
   --zd-tooltip--large-max-width: 270px;
   --zd-tooltip--large-padding: var(--zd-spacing);
-  --zd-tooltip--large__arrow-font-size: var(--zd-font-size-zeta);
+  --zd-tooltip--large__arrow-font-size: var(--zd-font-size-sm);
   --zd-tooltip--medium-border-radius: var(--zd-tooltip--large-border-radius);
   --zd-tooltip--medium-line-height: calc(16 / 12);
   --zd-tooltip--medium-max-width: 140px;

--- a/packages/utilities/src/font-size.css
+++ b/packages/utilities/src/font-size.css
@@ -9,7 +9,7 @@
 
 /* stylelint-disable declaration-no-important */
 
-/* Font sizes */
+/* Font Sizes */
 
 .u-fs-sm { font-size: var(--zd-font-size-sm) !important; }
 
@@ -23,7 +23,7 @@
 
 .u-fs-xxxl { font-size: var(--zd-font-size-xxxl) !important; }
 
-/* Font sizes (deprecated) */
+/* Font Sizes (deprecated) */
 
 .u-giga { font-size: var(--zd-font-size-giga) !important; }
 

--- a/packages/utilities/src/font-size.css
+++ b/packages/utilities/src/font-size.css
@@ -5,28 +5,47 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
+@import '@zendeskgarden/css-variables';
+
 /* stylelint-disable declaration-no-important */
-.u-giga { font-size: 36px !important; }
 
-.u-mega { font-size: 28px !important; }
+/* Font sizes */
 
-.u-kilo { font-size: 25px !important; }
+.u-fs-sm { font-size: var(--zd-font-size-sm) !important; }
 
-.u-alpha { font-size: 22px !important; }
+.u-fs-md { font-size: var(--zd-font-size-md) !important; }
 
-.u-beta { font-size: 20px !important; }
+.u-fs-lg { font-size: var(--zd-font-size-lg) !important; }
 
-.u-gamma { font-size: 18px !important; }
+.u-fs-xl { font-size: var(--zd-font-size-xl) !important; }
 
-.u-delta { font-size: 16px !important; }
+.u-fs-xxl { font-size: var(--zd-font-size-xxl) !important; }
 
-.u-epsilon { font-size: 14px !important; }
+.u-fs-xxxl { font-size: var(--zd-font-size-xxxl) !important; }
 
-.u-zeta { font-size: 12px !important; }
+/* Font sizes (deprecated) */
 
-.u-milli { font-size: 11px !important; }
+.u-giga { font-size: var(--zd-font-size-giga) !important; }
 
-.u-micro { font-size: 10px !important; }
+.u-mega { font-size: var(--zd-font-size-mega) !important; }
 
-.u-nano { font-size: 9px !important; }
+.u-kilo { font-size: var(--zd-font-size-kilo) !important; }
+
+.u-alpha { font-size: var(--zd-font-size-alpha) !important; }
+
+.u-beta { font-size: var(--zd-font-size-beta) !important; }
+
+.u-gamma { font-size: var(--zd-font-size-gamma) !important; }
+
+.u-delta { font-size: var(--zd-font-size-delta) !important; }
+
+.u-epsilon { font-size: var(--zd-font-size-epsilon) !important; }
+
+.u-zeta { font-size: var(--zd-font-size-zeta) !important; }
+
+.u-milli { font-size: var(--zd-font-size-milli) !important; }
+
+.u-micro { font-size: var(--zd-font-size-micro) !important; }
+
+.u-nano { font-size: var(--zd-font-size-nano) !important; }
 /* stylelint-enable declaration-no-important */

--- a/packages/utilities/src/index.css
+++ b/packages/utilities/src/index.css
@@ -16,6 +16,7 @@
 @import 'font-size';
 @import 'font-weight';
 @import 'jitterfix';
+@import 'line-height';
 @import 'list-style';
 @import 'opacity';
 @import 'position';

--- a/packages/utilities/src/line-height.css
+++ b/packages/utilities/src/line-height.css
@@ -1,0 +1,25 @@
+/*!
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+@import '@zendeskgarden/css-variables';
+
+/* stylelint-disable declaration-no-important */
+
+/* Line Heights (to be paired with corresponding font sizes) */
+
+.u-lh-sm { line-height: var(--zd-line-height-sm) !important; }
+
+.u-lh-md { line-height: var(--zd-line-height-md) !important; }
+
+.u-lh-lg { line-height: var(--zd-line-height-lg) !important; }
+
+.u-lh-xl { line-height: var(--zd-line-height-xl) !important; }
+
+.u-lh-xxl { line-height: var(--zd-line-height-xxl) !important; }
+
+.u-lh-xxxl { line-height: var(--zd-line-height-xxxl) !important; }
+/* stylelint-enable declaration-no-important */

--- a/packages/variables/src/_font-size.js
+++ b/packages/variables/src/_font-size.js
@@ -5,9 +5,17 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-/* csswizardry.com/2012/02/pragmatic-practical-font-sizing-in-css
- * www.modularscale.com/?14&px&1.125 */
-const retVal = {
+let retVal = {
+  sm: '12px',
+  md: '14px',
+  lg: '18px',
+  xl: '22px',
+  xxl: '26px',
+  xxxl: '36px'
+};
+
+/* Deprecated sizes */
+retVal = Object.assign(retVal, {
   /* Larger than H1 */
   giga: '36px',
   mega: '28px',
@@ -25,6 +33,6 @@ const retVal = {
   milli: '11px',
   micro: '10px',
   nano: '9px'
-};
+});
 
 module.exports = retVal;

--- a/packages/variables/src/_font-size.js
+++ b/packages/variables/src/_font-size.js
@@ -17,17 +17,17 @@ let retVal = {
 /* Deprecated sizes */
 retVal = Object.assign(retVal, {
   /* Larger than H1 */
-  giga: '36px',
+  giga: retVal['xxxl'],
   mega: '28px',
   kilo: '25px',
 
   /* H1-H6 */
-  alpha: '22px',
+  alpha: retVal['xl'],
   beta: '20px',
-  gamma: '18px',
+  gamma: retVal['lg'],
   delta: '16px',
-  epsilon: '14px',
-  zeta: '12px',
+  epsilon: retVal['md'],
+  zeta: retVal['sm'],
 
   /* Smaller than H6 */
   milli: '11px',

--- a/packages/variables/src/_line-height.js
+++ b/packages/variables/src/_line-height.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright Zendesk, Inc.
+ *
+ * Use of this source code is governed under the Apache License, Version 2.0
+ * found at http://www.apache.org/licenses/LICENSE-2.0.
+ */
+
+const retVal = {
+  sm: '16px',
+  md: '20px',
+  lg: '24px',
+  xl: '28px',
+  xxl: '32px',
+  xxxl: '44px'
+};
+
+module.exports = retVal;

--- a/packages/variables/src/index.js
+++ b/packages/variables/src/index.js
@@ -9,6 +9,7 @@ const color = require('./_color');
 const fontFamily = require('./_font-family');
 const fontSize = require('./_font-size');
 const fontWeight = require('./_font-weight');
+const lineHeight = require('./_line-height');
 const spacing = require('./_spacing');
 
 module.exports = {
@@ -16,5 +17,6 @@ module.exports = {
   'font-family': fontFamily,
   'font-size': fontSize,
   'font-weight': fontWeight,
+  'line-height': lineHeight,
   spacing
 };


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

New `font-size` variables/classes:
* `--zd-font-size-sm` / `.u-fs-sm` (12px)
* `--zd-font-size-md` / `.u-fs-md` (14px)
* `--zd-font-size-lg` / `.u-fs-lg` (18px)
* `--zd-font-size-xl` / `.u-fs-xl` (22px)
* `--zd-font-size-xxl` / `.u-fs-xxl` (26px)
* `--zd-font-size-xxxl` / `.u-fs-xxxl` (36px)

New `line-height` variables/classes:
* `--zd-line-height-sm` / `.u-lh-sm` (16px)
* `--zd-line-height-md` / `.u-lh-md` (20px)
* `--zd-line-height-lg` / `.u-lh-lg` (24px)
* `--zd-line-height-xl` / `.u-lh-xl` (28px)
* `--zd-line-height-xxl` / `.u-lh-xxl` (32px)
* `--zd-line-height-xxxl` / `.u-lh-xxxl` (44px)

## Detail

Demo page: https://garden.zendesk.com/css-components/utilities/typography/

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
