### PR TITLE
fix(menus): update item indentation

### DIFF
--- a/demo/menus/index.html
+++ b/demo/menus/index.html
@@ -115,7 +115,6 @@
           <div class="l-grid__item u-1/2">
             <ul class="c-menu u-opacity-opaque u-visibility-visible u-position-static">
               <li class="c-menu__item c-menu__item--header">Using <code class="c-code">ul &gt; li</code></li>
-              <li class="c-menu__separator">
               <li class="c-menu__item">Option One</li>
               <li class="c-menu__item">Option Two</li>
               <li class="c-menu__item">Option Three</li>
@@ -124,7 +123,6 @@
           ><div class="l-grid__item u-1/2">
             <nav class="c-menu u-opacity-opaque u-visibility-visible u-position-static">
               <div class="c-menu__item c-menu__item--header">Using <code class="c-code">nav &gt; a</code></div>
-              <div class="c-menu__separator"></div>
               <a class="c-menu__item" href>Link One</a>
               <a class="c-menu__item" href>Link Two</a>
               <a class="c-menu__item" href>Link Three</a>
@@ -229,11 +227,11 @@
               <li class="c-menu__separator">
               <li class="c-menu__item c-menu__item--header"><span dir="ltr">.c-menu__item--header</span></li>
               <li class="c-menu__separator">
-              <li class="c-menu__item c-menu__item--header">
+              <li class="c-menu__item c-menu__item--header c-menu__item--header--icon">
                 <svg class="c-menu__item--header__icon u-fg-grey-700">
                   <use xlink:href="../index.svg#zd-svg-icon-14-info">
                 </svg>
-                <span dir="ltr">&gt; .c-menu__item--header__icon</span>
+                <span dir="ltr">.c-menu__item--header--icon</span>
               </li>
               <li class="c-menu__separator">
               <li class="c-menu__item c-menu__item--next" tabindex="0"><span dir="ltr">.c-menu__item--next</span></li>
@@ -316,7 +314,6 @@
           <div class="c-playground__preview"></div>
 <textarea class="c-playground__code"><ul class="c-menu u-opacity-opaque u-visibility-visible u-position-static" role="menu">
   <li class="c-menu__item c-menu__item--header">The Beatles</li>
-  <li class="c-menu__separator" role="separator">
   <li class="c-menu__item c-menu__item--media" role="menuitem">
     <img class="c-menu__item--media__figure u-br-50%" src="http://placeskull.com/32/32/37B8AF">
     <div class="c-menu__item--media__body">

--- a/packages/menus/src/_item.css
+++ b/packages/menus/src/_item.css
@@ -5,7 +5,7 @@
 :root {
   --zd-menu__item-color: var(--zd-color-grey-800);
   --zd-menu__item-line-height: calc(20 / 14);
-  --zd-menu__item-padding-horizontal: 24px;
+  --zd-menu__item-padding-horizontal: 32px;
   --zd-menu__item-padding-vertical: 10px;
   --zd-menu__item-padding: var(--zd-menu__item-padding-vertical) var(--zd-menu__item-padding-horizontal);
   --zd-menu__item-transition: box-shadow .1s ease-in-out;
@@ -17,8 +17,9 @@
     calc(50% + var(--zd-menu__item--checked-background-offset)) / 10px
     svg-load('14/checkmark-lg.svg', color: var(--zd-menu-accent-color));
   --zd-menu__item--header-font-weight: var(--zd-font-weight-semibold);
+  --zd-menu__item--header-padding-horizontal: 16px;
   --zd-menu__item--header__icon-top: calc(calc(var(--zd-menu__item--icon-height) - var(--zd-menu__item--icon-background-size)) / 2);
-  --zd-menu__item--header__icon-left: calc(calc(var(--zd-menu__item--icon-width) - var(--zd-menu__item--icon-background-size)) / 2);
+  --zd-menu__item--header__icon-left: 14px;
   --zd-menu__item--icon-background-size: var(--zd-font-size-md);
   --zd-menu__item--icon-height: calc(20px + calc(var(--zd-menu__item-padding-vertical) * 2));
   --zd-menu__item--icon-width: var(--zd-menu__item-padding-horizontal);
@@ -28,12 +29,13 @@
   --zd-menu__item--media__figure-size: 32px;
   --zd-menu__item--next-background-image: svg-load('14/next.svg', color: var(--zd-color-grey-600));
   --zd-menu__item--previous-background-image: svg-load('14/previous.svg', color: var(--zd-menu-accent-color));
-  --zd-menu--sm__item-padding-horizontal: 20px;
+  --zd-menu--sm__item-padding-horizontal: 24px;
   --zd-menu--sm__item-padding-vertical: 6px;
   --zd-menu--sm__item-padding: var(--zd-menu--sm__item-padding-vertical) var(--zd-menu--sm__item-padding-horizontal);
   --zd-menu--sm__item--checked-background-size: 9px;
+  --zd-menu--sm__item--header-padding-horizontal: 12px;
   --zd-menu--sm__item--header__icon-top: calc(calc(var(--zd-menu--sm__item--icon-height) - var(--zd-menu__item--icon-background-size)) / 2);
-  --zd-menu--sm__item--header__icon-left: calc(calc(var(--zd-menu--sm__item--icon-width) - var(--zd-menu__item--icon-background-size)) / 2);
+  --zd-menu--sm__item--header__icon-left: 6px;
   --zd-menu--sm__item--icon-height: calc(20px + calc(var(--zd-menu--sm__item-padding-vertical) * 2));
   --zd-menu--sm__item--icon-width: var(--zd-menu--sm__item-padding-horizontal);
   --zd-menu--sm__item--media__figure-size: 24px;
@@ -99,7 +101,12 @@
   font-weight: var(--zd-menu__item--header-font-weight);
 }
 
-.c-menu__item .c-menu__item--header__icon {
+.c-menu__item.c-menu__item--header:not(.c-menu__item--header--icon) {
+  padding-right: var(--zd-menu__item--header-padding-horizontal);
+  padding-left: var(--zd-menu__item--header-padding-horizontal);
+}
+
+.c-menu__item--header--icon .c-menu__item--header__icon {
   position: absolute;
   top: var(--zd-menu__item--header__icon-top);
   left: var(--zd-menu__item--header__icon-left);
@@ -107,24 +114,27 @@
   height: var(--zd-menu__item--icon-background-size);
 }
 
-.c-menu--sm .c-menu__item .c-menu__item--header__icon {
+.c-menu--sm .c-menu__item--header:not(.c-menu__item--header--icon) {
+  padding-right: var(--zd-menu--sm__item--header-padding-horizontal);
+  padding-left: var(--zd-menu--sm__item--header-padding-horizontal);
+}
+
+.c-menu--sm .c-menu__item--header--icon .c-menu__item--header__icon {
   top: var(--zd-menu--sm__item--header__icon-top);
   left: var(--zd-menu--sm__item--header__icon-left);
 }
 
-.c-menu.is-rtl .c-menu__item--header__icon {
+/* stylelint-disable selector-max-specificity */
+.c-menu.is-rtl .c-menu__item--header--icon .c-menu__item--header__icon {
   right: var(--zd-menu__item--header__icon-left);
   left: auto;
 }
 
-.c-menu--sm.is-rtl .c-menu__item--header__icon {
+.c-menu--sm.is-rtl .c-menu__item--header--icon .c-menu__item--header__icon {
   right: var(--zd-menu--sm__item--header__icon-left);
   left: auto;
 }
-
-.c-menu__item.c-menu__item--previous {
-  text-align: center;
-}
+/* stylelint-enable selector-max-specificity */
 
 .c-menu__item:--menu-checked::before,
 .c-menu__item.c-menu__item--add::before,


### PR DESCRIPTION
- [x] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Garden designs have been updated and call for menu items to appear nested below associated header elements.

* Added: `.c-menu__item--header--icon` needed to prepare the header element for receiving a child `.c-menu__item--header__icon` element (this is a breaking addition now required for icon-styled header elements).
* Updated: increased horizontal padding for `.c-menu__item` from 24px to 32px (small sized menu items increase from 20px to 24px).
* Updated: `.c-menu__item--header__icon` position adjusted accordingly.

## Detail

### Previous layout
![screen shot 2018-09-18 at 2 00 53 pm](https://user-images.githubusercontent.com/143773/45716296-610d4100-bb4b-11e8-9ba2-3fd0d9977bfb.png)

### Updated layout
![screen shot 2018-09-18 at 2 01 09 pm](https://user-images.githubusercontent.com/143773/45716309-68344f00-bb4b-11e8-974b-bf6a72f55e33.png)


## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
