### PR TITLE
fix(tables): adjust `.c-table__row__cell__overflow` trigger size

### DIFF
--- a/demo/tables/index.html
+++ b/demo/tables/index.html
@@ -132,8 +132,6 @@
         <p class="u-mb">Use the settings menu to modify the styling for the
         tables displayed throughout the page.</p>
         <ul class="u-list-style-disc">
-          <li class="u-mb-sm">Toggle "Dark Mode" to view
-            <code class="c-code">.c-table--dark</code> styling.</li>
           <li class="u-mb-sm">Toggle "RTL" to add the
             <code class="c-code">.is-rtl</code> table class.</li>
           <li class="u-mb-sm">Select "Display Density" to apply either

--- a/demo/tables/index.html
+++ b/demo/tables/index.html
@@ -95,7 +95,9 @@
     <div class="c-main__body">
       <p class="u-mb">The <code class="c-code">.c-table</code> components are
       intended to provide consistent styling for HTML
-      <code class="c-code">&lt;table&gt;</code> elements.</p>
+      <code class="c-code">&lt;table&gt;</code> elements. See the Garden React
+      <a href="//zendeskgarden.github.io/react-components/tables/">tables</a>
+      package for enhanced keyboard and event behavior.</p>
 
       <div class="u-mb-lg">
         <h2 class="u-fs-lg u-mb">Basic Layout</h2>

--- a/packages/tables/src/_overflow.css
+++ b/packages/tables/src/_overflow.css
@@ -1,23 +1,18 @@
 :root {
   --zd-table__row__cell__overflow-background-image: svg-load('26/ellipsis.svg', color: var(--zd-color-grey-600));
   --zd-table__row__cell__overflow-size: 2em;
-  --zd-table__row__cell__overflow-top: calc(calc(var(--zd-table__row-height) / 2) - 1em);
+  --zd-table__row__cell__overflow-margin-top: calc(calc(var(--zd-table__row-height) / 2) - 1em);
   --zd-table__row__cell__overflow-transition:
     opacity .25s ease-in-out,
     background-color .1s ease-in-out;
   --zd-table__row__cell__overflow-focused-background-color: color-mod(var(--zd-color-grey-600) alpha(15%));
   --zd-table__row__cell__overflow-hovered-background-image: svg-load('26/ellipsis.svg', color: var(--zd-color-grey-800));
-  --zd-table__row--header__cell__overflow-top: calc(calc(var(--zd-table__row--header-height) / 2) - 1em);
-  --zd-table--lg__row__cell__overflow-top: calc(calc(var(--zd-table--lg__row-height) / 2) - 1em);
-  --zd-table--sm__row__cell__overflow-top: calc(calc(var(--zd-table--sm__row-height) / 2) - 1em);
-  --zd-table--lg__row--header__cell__overflow-top: calc(calc(var(--zd-table--lg__row--header-height) / 2) - 1em);
-  --zd-table--sm__row--header__cell__overflow-top: calc(calc(var(--zd-table--sm__row--header-height) / 2) - 1em);
-  --zd-table__row__cell--overflow__menu-top: calc(calc(var(--zd-table__row-height) / 2 + 1px) + 1em);
-  --zd-table__row--header__cell--overflow__menu-top: calc(calc(var(--zd-table__row--header-height) / 2 + 1px) + 1em);
-  --zd-table--lg__row__cell--overflow__menu-top: calc(calc(var(--zd-table--lg__row-height) / 2 + 1px) + 1em);
-  --zd-table--sm__row__cell--overflow__menu-top: calc(calc(var(--zd-table--sm__row-height) / 2 + 1px) + 1em);
-  --zd-table--lg__row--header__cell--overflow__menu-top: calc(calc(var(--zd-table--lg__row--header-height) / 2 + 1px) + 1em);
-  --zd-table--sm__row--header__cell--overflow__menu-top: calc(calc(var(--zd-table--sm__row--header-height) / 2 + 1px) + 1em);
+  --zd-table__row--header__cell__overflow-margin-bottom: calc(calc(var(--zd-table__row--header-height) / 2) - 1em);
+  --zd-table--lg__row__cell__overflow-margin-top: calc(calc(var(--zd-table--lg__row-height) / 2) - 1em);
+  --zd-table--sm__row__cell__overflow-margin-top: calc(calc(var(--zd-table--sm__row-height) / 2) - 1em);
+  --zd-table--lg__row--header__cell__overflow-margin-bottom: calc(calc(var(--zd-table--lg__row--header-height) / 2) - 1em);
+  --zd-table--sm__row--header__cell__overflow-margin-bottom: calc(calc(var(--zd-table--sm__row--header-height) / 2) - 1em);
+  --zd-table__row__cell--overflow__menu-top: calc(var(--zd-table__row__cell__overflow-size) + 1px);
 }
 
 .c-table__row__cell--overflow {
@@ -33,12 +28,13 @@
   position: relative;
   transition: var(--zd-table__row__cell__overflow-transition);
   z-index: 0;
+  margin-top: var(--zd-table__row__cell__overflow-margin-top);
   border: none; /* [1] */
   background-color: transparent; /* [1] */
   cursor: pointer;
   padding: 0; /* [1] */
   width: 100%;
-  height: 100%;
+  height: var(--zd-table__row__cell__overflow-size);
   text-decoration: none; /* [2] */
   font-size: inherit; /* [1] */
 }
@@ -46,7 +42,7 @@
 .c-table__row__cell__overflow::before,
 .c-table__row__cell__overflow::after {
   position: absolute;
-  top: var(--zd-table__row__cell__overflow-top);
+  top: 0;
   right: 0;
   left: 0;
   transform: rotate(90deg);
@@ -69,19 +65,17 @@
   background-image: var(--zd-table__row__cell__overflow-hovered-background-image);
 }
 
-.c-table__row--header .c-table__row__cell__overflow::before,
-.c-table__row--header .c-table__row__cell__overflow::after {
-  top: var(--zd-table__row--header__cell__overflow-top);
+.c-table__row--header .c-table__row__cell__overflow {
+  margin-top: 0;
+  margin-bottom: var(--zd-table__row--header__cell__overflow-margin-bottom);
 }
 
-.c-table--lg .c-table__row__cell__overflow::before,
-.c-table--lg .c-table__row__cell__overflow::after {
-  top: var(--zd-table--lg__row__cell__overflow-top);
+.c-table--lg .c-table__row__cell__overflow {
+  margin-top: var(--zd-table--lg__row__cell__overflow-margin-top);
 }
 
-.c-table--sm .c-table__row__cell__overflow::before,
-.c-table--sm .c-table__row__cell__overflow::after {
-  top: var(--zd-table--sm__row__cell__overflow-top);
+.c-table--sm .c-table__row__cell__overflow {
+  margin-top: var(--zd-table--sm__row__cell__overflow-margin-top);
 }
 
 @custom-selector :--table__row__cell__overflow-hovered
@@ -124,41 +118,17 @@
   opacity: 0;
 }
 
-.c-table--lg .c-table__row--header .c-table__row__cell__overflow::before,
-.c-table--lg .c-table__row--header .c-table__row__cell__overflow::after {
-  top: var(--zd-table--lg__row--header__cell__overflow-top);
+.c-table--lg .c-table__row--header .c-table__row__cell__overflow {
+  margin-top: 0;
+  margin-bottom: var(--zd-table--lg__row--header__cell__overflow-margin-bottom);
 }
 
-.c-table--sm .c-table__row--header .c-table__row__cell__overflow::before,
-.c-table--sm .c-table__row--header .c-table__row__cell__overflow::after {
-  top: var(--zd-table--sm__row--header__cell__overflow-top);
+.c-table--sm .c-table__row--header .c-table__row__cell__overflow {
+  margin-top: 0;
+  margin-bottom: var(--zd-table--sm__row--header__cell__overflow-margin-bottom);
 }
 
 .c-table__row__cell--overflow .c-menu {
   top: var(--zd-table__row__cell--overflow__menu-top);
   right: calc(100% - var(--zd-table__row__cell__overflow-size));
 }
-
-.c-table__row--header .c-table__row__cell--overflow .c-menu {
-  top: var(--zd-table__row--header__cell--overflow__menu-top);
-}
-
-.c-table--lg .c-table__row__cell--overflow .c-menu {
-  top: var(--zd-table--lg__row__cell--overflow__menu-top);
-}
-
-.c-table--sm .c-table__row__cell--overflow .c-menu {
-  top: var(--zd-table--sm__row__cell--overflow__menu-top);
-}
-
-/* stylelint-disable max-line-length, selector-max-compound-selectors, selector-max-specificity */
-
-.c-table--lg .c-table__row--header .c-table__row__cell--overflow .c-menu {
-  top: var(--zd-table--lg__row--header__cell--overflow__menu-top);
-}
-
-.c-table--sm .c-table__row--header .c-table__row__cell--overflow .c-menu {
-  top: var(--zd-table--sm__row--header__cell--overflow__menu-top);
-}
-
-/* stylelint-enable max-line-length, selector-max-compound-selectors, selector-max-specificity */


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

A 100% row height click area for the overflow trigger is unintuitive and makes menu component positioning unmanageable. With a fixed height of `2em`, a separate React menu component can be reliably positioned at `calc(2em + 1px)` from the top of the overflow element – regardless of table row size. 

## Detail

Demo is prepublished for review at https://garden.zendesk.com/css-components/tables/

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
