### PR TITLE
fix(menus): remove `box-shadow` on `.c-menu__item.is-focused`

### DIFF
--- a/packages/menus/src/_item.css
+++ b/packages/menus/src/_item.css
@@ -8,7 +8,6 @@
   --zd-menu__item-padding-horizontal: 32px;
   --zd-menu__item-padding-vertical: 10px;
   --zd-menu__item-padding: var(--zd-menu__item-padding-vertical) var(--zd-menu__item-padding-horizontal);
-  --zd-menu__item-transition: box-shadow .1s ease-in-out;
   --zd-menu__item--add-background-image: svg-load('14/plus.svg', color: var(--zd-menu-accent-color));
   --zd-menu__item--add-color: var(--zd-menu-accent-color);
   --zd-menu__item--checked-background-offset: 10%;
@@ -52,7 +51,6 @@
 .c-menu__item {
   display: block;
   position: relative; /* [1] */
-  transition: var(--zd-menu__item-transition);
   z-index: 0; /* [2] */
   cursor: pointer;
   padding: var(--zd-menu__item-padding);

--- a/packages/menus/src/_item.css
+++ b/packages/menus/src/_item.css
@@ -27,7 +27,7 @@
   --zd-menu__item--media__figure-margin: 8px;
   --zd-menu__item--media__figure-size: 32px;
   --zd-menu__item--next-background-image: svg-load('14/next.svg', color: var(--zd-color-grey-600));
-  --zd-menu__item--previous-background-image: svg-load('14/previous.svg', color: var(--zd-menu-accent-color));
+  --zd-menu__item--previous-background-image: svg-load('14/previous.svg', color: var(--zd-color-grey-600));
   --zd-menu--sm__item-padding-horizontal: 24px;
   --zd-menu--sm__item-padding-vertical: 6px;
   --zd-menu--sm__item-padding: var(--zd-menu--sm__item-padding-vertical) var(--zd-menu--sm__item-padding-horizontal);

--- a/packages/menus/src/_state.css
+++ b/packages/menus/src/_state.css
@@ -11,10 +11,6 @@
   --zd-menu__item-disabled--checked-background-image: svg-load('14/checkmark-lg.svg', color: var(--zd-menu__item-disabled-color));
   --zd-menu__item-disabled--next-background-image: svg-load('14/next.svg', color: var(--zd-menu__item-disabled-color));
   --zd-menu__item-disabled--previous-background-image: svg-load('14/previous.svg', color: var(--zd-menu__item-disabled-color));
-  --zd-menu__item-focused-box-shadow-color: color-mod(var(--zd-menu-accent-color) alpha(35%));
-  --zd-menu__item-focused-box-shadow:
-    inset 0 3px 0 var(--zd-menu__item-focused-box-shadow-color),
-    inset 0 -3px 0 var(--zd-menu__item-focused-box-shadow-color);
   --zd-menu__item-hovered-background-color: var(--zd-menu-accent-color-hovered);
 }
 
@@ -30,14 +26,9 @@
 
 .c-menu__item:--menu-focused {
   outline: none;
-  box-shadow: var(--zd-menu__item-focused-box-shadow);
 }
 
 /* stylelint-disable selector-max-specificity */
-.c-menu .c-menu__item:--menu-active:--menu-focused {
-  box-shadow: none;
-}
-
 .c-menu .c-menu__item:--menu-disabled {
   cursor: default;
   color: var(--zd-menu__item-disabled-color);
@@ -46,10 +37,6 @@
 .c-menu .c-menu__item:--menu-disabled:--menu-hovered,
 .c-menu .c-menu__item:--menu-disabled:--menu-focused {
   background-color: inherit;
-}
-
-.c-menu .c-menu__item:--menu-disabled:--menu-focused {
-  box-shadow: none;
 }
 
 .c-menu .c-menu__item:--menu-checked:--menu-disabled::before {

--- a/packages/menus/src/custom.css
+++ b/packages/menus/src/custom.css
@@ -13,29 +13,19 @@
   --zd-menu--custom__item--add-color: var(--zd-menu--custom-accent-color);
   --zd-menu--custom__item--add-background-image: svg-load('14/plus.svg', color: var(--zd-menu--custom-accent-color));
   --zd-menu--custom__item--icon-background-image: svg-load('14/checkmark-lg.svg', color: var(--zd-menu--custom-accent-color));
-  --zd-menu--custom__item--next-background-image: svg-load('14/next.svg', color: var(--zd-menu--custom-accent-color));
-  --zd-menu--custom__item--previous-background-image: svg-load('14/previous.svg', color: var(--zd-menu--custom-accent-color));
   --zd-menu--custom__item-hovered-background-color: color-mod(var(--zd-menu--custom-accent-color) alpha(15%));
 }
 
-.c-menu--custom .c-menu__item::before {
+.c-menu--custom .c-menu__item:--menu-checked::before {
   background-image: var(--zd-menu--custom__item--icon-background-image);
 }
 
-.c-menu--custom .c-menu__item.c-menu__item--add {
+.c-menu--custom .c-menu__item--add:not(:--menu-disabled) {
   color: var(--zd-menu--custom__item--add-color);
 }
 
 .c-menu--custom .c-menu__item.c-menu__item--add::before {
   background-image: var(--zd-menu--custom__item--add-background-image);
-}
-
-.c-menu--custom .c-menu__item.c-menu__item--next::before {
-  background-image: var(--zd-menu--custom__item--next-background-image);
-}
-
-.c-menu--custom .c-menu__item.c-menu__item--previous::before {
-  background-image: var(--zd-menu--custom__item--previous-background-image);
 }
 
 .c-menu--custom .c-menu__item:--menu-hovered,

--- a/packages/menus/src/custom.css
+++ b/packages/menus/src/custom.css
@@ -15,10 +15,6 @@
   --zd-menu--custom__item--icon-background-image: svg-load('14/checkmark-lg.svg', color: var(--zd-menu--custom-accent-color));
   --zd-menu--custom__item--next-background-image: svg-load('14/next.svg', color: var(--zd-menu--custom-accent-color));
   --zd-menu--custom__item--previous-background-image: svg-load('14/previous.svg', color: var(--zd-menu--custom-accent-color));
-  --zd-menu--custom__item-focused-box-shadow-color: color-mod(var(--zd-menu--custom-accent-color) alpha(35%));
-  --zd-menu--custom__item-focused-box-shadow:
-    inset 0 3px 0 var(--zd-menu--custom__item-focused-box-shadow-color),
-    inset 0 -3px 0 var(--zd-menu--custom__item-focused-box-shadow-color);
   --zd-menu--custom__item-hovered-background-color: color-mod(var(--zd-menu--custom-accent-color) alpha(15%));
 }
 
@@ -45,8 +41,4 @@
 .c-menu--custom .c-menu__item:--menu-hovered,
 .c-menu--custom .c-menu__item:--menu-focused {
   background-color: var(--zd-menu--custom__item-hovered-background-color);
-}
-
-.c-menu--custom .c-menu__item:--menu-focused {
-  box-shadow: var(--zd-menu--custom__item-focused-box-shadow);
 }


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Focus behavior for menu items should be both stylistically and behaviorally interchangeable with hover. i.e. remove focus on hover; remove hover on focus. Only one menu item should ever receive focus or hover at a time.

## Detail

Demo prepublished for review https://garden.zendesk.com/css-components/menus/

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
