### PR TITLE
docs(chrome): corrects hierarchy and syntax

### DIFF
--- a/packages/chrome/README.md
+++ b/packages/chrome/README.md
@@ -31,9 +31,9 @@ Component CSS provides styling for the following basic page structure
       <button class="c-chrome__body__header__item">...</button>
       <!-- additional header items -->
     </header>
-  </div>
-  <div class="c-chrome__body__content">
-    <main class="c-chrome__body__content__main">
+    <div class="c-chrome__body__content">
+      <main class="c-chrome__body__content__main"></main>
+    </div>
   </div>
 </body>
 ```


### PR DESCRIPTION
## Description

`.c-chrome__body__content` should be a child of `c-chrome__body` and `main` tags are not self-closing.