### PR TITLE
fix(buttons|modals): prevent modal footer item overflow

### DIFF
--- a/demo/modals/index.html
+++ b/demo/modals/index.html
@@ -258,7 +258,12 @@
     tincidunt id purus vel posuere.</p>
   </div>
   <footer class="c-dialog__footer">
-    <button class="c-dialog__footer__item c-btn c-btn--primary js-close">OK</button>
+    <div class="c-dialog__footer__item">
+      <button class="c-btn c-btn--basic js-close">Cancel</button>
+    </div>
+    <div class="c-dialog__footer__item">
+      <button class="c-btn c-btn--primary js-close">OK</button>
+    </div>
   </footer>
 </section></textarea>
         </div>
@@ -285,8 +290,12 @@
     gastropub. Austin quinoa butcher, everyday carry echo park sartorial
     VHS.</p>
     <footer class="c-dialog__footer">
-      <code class="c-dialog__footer__item c-code" dir="ltr">.c-dialog__footer</code
-      ><button class="c-dialog__footer__item c-btn c-btn--primary js-close">OK</button>
+      <div class="c-dialog__footer__item">
+        <code class="c-code" dir="ltr">.c-dialog__footer</code>
+      </div>
+      <div class="c-dialog__footer__item">
+        <button class="c-btn c-btn--primary js-close">OK</button>
+      </div>
     </footer>
   </section>
 
@@ -325,8 +334,12 @@
       mlkshk hexagon.</p>
     </div>
     <footer class="c-dialog__footer">
-      <button class="c-dialog__footer__item c-btn c-btn--basic js-close">Cancel</button
-      ><button class="c-dialog__footer__item c-btn c-btn--primary js-close">OK</button>
+      <div class="c-dialog__footer__item">
+        <button class="c-btn c-btn--basic js-close">Cancel</button>
+      </div>
+      <div class="c-dialog__footer__item">
+        <button class="c-btn c-btn--primary js-close">OK</button>
+      </div>
     </footer>
   </section>
 
@@ -348,8 +361,12 @@
     bitters, blog letterpress pinterest vegan dreamcatcher. Selvage meh lomo
     90's, crucifix banjo seitan knausgaard kitsch salvia actually bespoke.</p>
     <footer class="c-dialog__footer">
-      <button class="c-dialog__footer__item c-btn c-btn--basic js-close">Cancel</button
-      ><button class="c-dialog__footer__item c-btn c-btn--primary js-close">OK</button>
+      <div class="c-dialog__footer__item">
+        <button class="c-btn c-btn--basic js-close">Cancel</button>
+      </div>
+      <div class="c-dialog__footer__item">
+        <button class="c-btn c-btn--primary js-close">OK</button>
+      </div>
     </footer>
   </section>
 
@@ -387,8 +404,12 @@
       mlkshk hexagon.</p>
     </div>
     <footer class="c-dialog__footer">
-      <button class="c-dialog__footer__item c-btn c-btn--basic js-close">Cancel</button
-      ><button class="c-dialog__footer__item c-btn c-btn--primary js-close">OK</button>
+      <div class="c-dialog__footer__item">
+        <button class="c-btn c-btn--basic js-close">Cancel</button>
+      </div>
+      <div class="c-dialog__footer__item">
+        <button class="c-btn c-btn--primary js-close">OK</button>
+      </div>
     </footer>
   </section>
 

--- a/packages/buttons/src/_base.css
+++ b/packages/buttons/src/_base.css
@@ -26,10 +26,9 @@
   --zd-btn--sm-min-width: calc(calc(46 / 12 * 1em) + calc(var(--zd-btn--sm-padding) * 2));
 }
 
-/* 1. IE inner spacing fix.
- * 2. Anchor tag reset.
- * 3. Override for <input> & <button> elements.
- * 4. FF <input type="submit" fix. */
+/* 1. Anchor tag reset.
+ * 2. Override for <input> & <button> elements.
+ * 3. FF <input type="submit" fix. */
 
 .c-btn {
   display: inline-block;
@@ -41,14 +40,15 @@
   cursor: pointer;
   padding: 0 var(--zd-btn-padding);
   min-width: var(--zd-btn-min-width);
-  overflow: visible; /* [1] */
+  overflow: hidden;
   vertical-align: middle;
   text-align: center;
-  text-decoration: none; /* [2] */
+  text-decoration: none; /* [1] */
+  text-overflow: ellipsis;
   line-height: var(--zd-btn-line-height);
   white-space: nowrap;
   color: var(--zd-btn-color);
-  font-family: inherit; /* [3] */
+  font-family: inherit; /* [2] */
   font-size: var(--zd-btn-font-size);
   font-weight: var(--zd-btn-font-weight);
   -webkit-font-smoothing: subpixel-antialiased;
@@ -57,7 +57,7 @@
   -webkit-touch-callout: none;
 }
 
-.c-btn::-moz-focus-inner { /* [4] */
+.c-btn::-moz-focus-inner { /* [3] */
   border: 0;
   padding: 0;
 }

--- a/packages/modals/src/_footer.css
+++ b/packages/modals/src/_footer.css
@@ -2,7 +2,7 @@
 
 :root {
   --zd-dialog__footer-padding: 0 var(--zd-spacing-xl) 32px;
-  --zd-dialog__footer__btn-margin: 20px;
+  --zd-dialog__footer__item-margin: 20px;
   --zd-dialog--large__footer-padding: 32px var(--zd-spacing-xl);
   --zd-dialog--large__footer-border-top: var(--zd-dialog__header-border-bottom);
 }
@@ -20,10 +20,22 @@
 }
 
 .c-dialog__footer__item {
-  margin-left: var(--zd-dialog__footer__btn-margin);
+  display: flex;
+  margin-left: var(--zd-dialog__footer__item-margin);
+  min-width: 0;
+}
+
+.c-dialog__footer__item:first-child {
+  margin-left: 0;
 }
 
 .c-dialog.is-rtl .c-dialog__footer__item {
-  margin-right: var(--zd-dialog__footer__btn-margin);
+  margin-right: var(--zd-dialog__footer__item-margin);
   margin-left: 0;
 }
+
+/* stylelint-disable selector-max-specificity */
+.c-dialog.is-rtl .c-dialog__footer__item:first-child {
+  margin-right: 0;
+}
+/* stylelint-enable selector-max-specificity */


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

* Update `.c-btn` to use `text-overflow: ellipsis`.
* Update `.c-dialog__footer__item` display flex with `min-width: 0`.

## Detail

Demo published for review https://garden.zendesk.com/css-components/modals/ (use Playground to test).

### Before

![screen shot 2018-09-19 at 13 09 34](https://user-images.githubusercontent.com/143773/46984863-5e473280-d09c-11e8-800a-9e3d47cc1d24.png)

### After

<img width="813" alt="screen shot 2018-10-15 at 5 05 23 pm" src="https://user-images.githubusercontent.com/143773/46984894-8f276780-d09c-11e8-90a9-004bc6ab8ee8.png">

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
