### PR TITLE
fix(modals): header/footer remain fixed as body content scrolls

### DIFF
--- a/packages/modals/src/_body.css
+++ b/packages/modals/src/_body.css
@@ -14,6 +14,8 @@
   display: block;
   margin: 0; /* [1] */
   padding: var(--zd-dialog__body-padding);
+  height: 100%;
+  overflow: auto;
   line-height: var(--zd-dialog__body-line-height);
   color: var(--zd-dialog__body-color);
   font-size: var(--zd-dialog__body-font-size);


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Headers and footers should remain visible even if body content overflows the modal container.

## Detail

Published for review https://garden.zendesk.com/css-components/modals/

### Before

![before](https://user-images.githubusercontent.com/143773/47172794-44d30000-d2c1-11e8-8498-d486d635dd29.gif)

### After

![after](https://user-images.githubusercontent.com/143773/47172819-4e5c6800-d2c1-11e8-8e1a-fd8d81d092b1.gif)

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
