### PR TITLE
fix(modals): prevent body overflow on to footer

### DIFF
--- a/demo/modals/index.html
+++ b/demo/modals/index.html
@@ -244,7 +244,7 @@
     porttitor aliquet risus, tincidunt pulvinar odio sodales id. Maecenas ut
     ipsum ultrices, condimentum purus a, dignissim risus. Quisque in lorem ut
     metus pharetra pharetra.</p>
-    <p class="u-mb-sm">Nunc ut diam ut diam ultrices venenatis in at risus.
+    <p>Nunc ut diam ut diam ultrices venenatis in at risus.
     Quisque nisl nibh, interdum eu purus eget, faucibus faucibus magna. Sed
     posuere, tellus vitae bibendum pretium, elit turpis ullamcorper leo, sit
     amet mollis eros est at urna. Aenean placerat sapien sed libero lobortis

--- a/packages/modals/src/_body.css
+++ b/packages/modals/src/_body.css
@@ -23,7 +23,7 @@
 }
 
 .c-dialog__body:last-child {
-  padding-bottom: 40px;
+  padding-bottom: var(--zd-dialog__body--last-child-padding);
 }
 
 .c-dialog--large .c-dialog__body {

--- a/packages/modals/src/_body.css
+++ b/packages/modals/src/_body.css
@@ -4,7 +4,8 @@
   --zd-dialog__body-color: var(--zd-color-grey-800);
   --zd-dialog__body-font-size: var(--zd-font-size-md);
   --zd-dialog__body-line-height: calc(20 / 14);
-  --zd-dialog__body-padding: var(--zd-spacing) var(--zd-spacing-xl) var(--zd-spacing-xl);
+  --zd-dialog__body-padding: var(--zd-spacing) var(--zd-spacing-xl) 0;
+  --zd-dialog__body--last-child-padding: var(--zd-dialog__footer-padding-top);
   --zd-dialog--large__body-padding: var(--zd-spacing) var(--zd-spacing-xl);
 }
 
@@ -19,6 +20,10 @@
   line-height: var(--zd-dialog__body-line-height);
   color: var(--zd-dialog__body-color);
   font-size: var(--zd-dialog__body-font-size);
+}
+
+.c-dialog__body:last-child {
+  padding-bottom: 40px;
 }
 
 .c-dialog--large .c-dialog__body {

--- a/packages/modals/src/_footer.css
+++ b/packages/modals/src/_footer.css
@@ -1,7 +1,8 @@
 @import '@zendeskgarden/css-variables';
 
 :root {
-  --zd-dialog__footer-padding: 0 var(--zd-spacing-xl) 32px;
+  --zd-dialog__footer-padding-top: var(--zd-spacing-xl);
+  --zd-dialog__footer-padding: var(--zd-dialog__footer-padding-top) var(--zd-spacing-xl) 32px;
   --zd-dialog__footer__item-margin: 20px;
   --zd-dialog--large__footer-padding: 32px var(--zd-spacing-xl);
   --zd-dialog--large__footer-border-top: var(--zd-dialog__header-border-bottom);


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Modal layout (default size; long body content) broke with #132. This PR adjusts padding to prevent that.

## Detail

### Before

<img width="557" alt="screen shot 2018-10-18 at 4 58 47 pm" src="https://user-images.githubusercontent.com/143773/47190612-44555c00-d2f7-11e8-9659-cd63ef4ae8e9.png">

### After

<img width="559" alt="screen shot 2018-10-18 at 4 59 36 pm" src="https://user-images.githubusercontent.com/143773/47190618-4a4b3d00-d2f7-11e8-8cba-a73947a4a685.png">

## Checklist

* [ ] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [ ] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [ ] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [ ] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
