### PR TITLE
fix(forms): apply consistent padding to .c-txt__input--media

### DIFF
--- a/packages/forms/src/_text/_media.css
+++ b/packages/forms/src/_text/_media.css
@@ -1,15 +1,12 @@
 :root {
   --zd-txt__input--media__figure-color: var(--zd-color-grey-400);
-  --zd-txt__input--media__figure-margin-start: calc(var(--zd-txt__input-padding-horizontal));
-  --zd-txt__input--media__figure-margin-end: calc(var(--zd-txt__input-padding-horizontal) * (3 / 4));
+  --zd-txt__input--media__figure-margin: calc(var(--zd-txt__input-padding-horizontal) * (3 / 4));
   --zd-txt__input--media__figure-size: 1em;
 }
 
 .c-txt__input--media {
   display: flex;
   align-items: baseline;
-  padding-right: 0;
-  padding-left: 0;
 }
 
 .c-txt__input--media__body {
@@ -28,15 +25,13 @@
 }
 
 /* stylelint-disable no-descending-specificity */
-.c-txt__input--media__figure:first-of-type,
-.is-rtl .c-txt__input--media__figure:last-of-type {
-  margin-right: var(--zd-txt__input--media__figure-margin-end);
-  margin-left: var(--zd-txt__input--media__figure-margin-start);
+.c-txt__input--media__figure:first-child,
+.is-rtl .c-txt__input--media__figure:last-child {
+  margin-right: var(--zd-txt__input--media__figure-margin);
 }
 
-.c-txt__input--media__figure:last-of-type,
-.is-rtl .c-txt__input--media__figure:first-of-type {
-  margin-right: var(--zd-txt__input--media__figure-margin-start);
-  margin-left: var(--zd-txt__input--media__figure-margin-end);
+.c-txt__input--media__figure:last-child,
+.is-rtl .c-txt__input--media__figure:first-child {
+  margin-left: var(--zd-txt__input--media__figure-margin);
 }
 /* stylelint-enable no-descending-specificity */


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

... regardless of inclusion of optional `.c-txt__input--media__figure` start/end components.

## Detail

### Before

<img width="211" alt="screen shot 2018-10-22 at 3 07 45 pm" src="https://user-images.githubusercontent.com/143773/47322346-707d1f80-d60c-11e8-9fe7-3d16139b7771.png">

### After

<img width="208" alt="screen shot 2018-10-22 at 3 08 11 pm" src="https://user-images.githubusercontent.com/143773/47322366-7f63d200-d60c-11e8-9089-1e9927c74396.png">

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
