### PR TITLE
fix(forms): correct margins for `.c-txt__input--media` RTL layout

### DIFF
--- a/demo/forms/text/index.html
+++ b/demo/forms/text/index.html
@@ -187,7 +187,7 @@
                 <use xlink:href="../../index.svg#zd-svg-icon-14-credit-card">
               </svg>
             </div>
-            <input class="c-txt__input c-txt__input--bare c-txt__input--media__body" id="txt-media" placeholder="c-txt__input.c-txt__input--media" type="text">
+            <input class="c-txt__input c-txt__input--bare c-txt__input--media__body" id="txt-media" placeholder=".c-txt__input.c-txt__input--media" type="text">
             <div class="c-txt__input--media__figure">
               <svg>
                 <use xlink:href="../../index.svg#zd-svg-icon-14-search">

--- a/packages/forms/src/_text/_media.css
+++ b/packages/forms/src/_text/_media.css
@@ -28,10 +28,12 @@
 .c-txt__input--media__figure:first-child,
 .is-rtl .c-txt__input--media__figure:last-child {
   margin-right: var(--zd-txt__input--media__figure-margin);
+  margin-left: 0;
 }
 
 .c-txt__input--media__figure:last-child,
 .is-rtl .c-txt__input--media__figure:first-child {
+  margin-right: 0;
   margin-left: var(--zd-txt__input--media__figure-margin);
 }
 /* stylelint-enable no-descending-specificity */


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

:man_facepalming:

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
