### PR TITLE
feat(variables|utilities): add `sell-gold` color

### DIFF
--- a/demo/utilities/color/index.html
+++ b/demo/utilities/color/index.html
@@ -60,7 +60,7 @@
       <div class="l-grid l-grid-sm u-mb-lg">
         <div class="l-grid__item u-1/8 u-mb">
           <figure class="c-swatch">
-            <div class="c-swatch__color u-bg-apple-green">
+            <div class="c-swatch__color u-bg-support-green">
               <svg class="c-swatch__color__product">
                 <use xlink:href="../../index.svg#zd-svg-icon-26-relationshape-support">
                   <title>Support Green</title>
@@ -68,14 +68,14 @@
               </svg>
             </div>
             <figcaption class="c-swatch__info">
-              <bold class="c-swatch__info__name">apple green</bold>
+              <bold class="c-swatch__info__name">support-green</bold>
               <span class="c-swatch__info__hex">78a300</span>
             </figcaption>
           </figure>
         </div
         ><div class="l-grid__item u-1/8 u-mb">
           <figure class="c-swatch">
-            <div class="c-swatch__color u-bg-verdigris">
+            <div class="c-swatch__color u-bg-message-green">
               <svg class="c-swatch__color__product">
                 <use xlink:href="../../index.svg#zd-svg-icon-26-relationshape-message">
                   <title>Message Green</title>
@@ -83,14 +83,14 @@
               </svg>
             </div>
             <figcaption class="c-swatch__info">
-              <bold class="c-swatch__info__name">verdigris</bold>
+              <bold class="c-swatch__info__name">message-green</bold>
               <span class="c-swatch__info__hex">37b8af</span>
             </figcaption>
           </figure>
         </div
         ><div class="l-grid__item u-1/8 u-mb">
           <figure class="c-swatch">
-            <div class="c-swatch__color u-bg-pelorous">
+            <div class="c-swatch__color u-bg-explore-blue">
               <svg class="c-swatch__color__product">
                 <use xlink:href="../../index.svg#zd-svg-icon-26-relationshape-explore">
                   <title>Explore Blue</title>
@@ -98,14 +98,14 @@
               </svg>
             </div>
             <figcaption class="c-swatch__info">
-              <bold class="c-swatch__info__name">pelorous</bold>
+              <bold class="c-swatch__info__name">explore-blue</bold>
               <span class="c-swatch__info__hex">30aabc</span>
             </figcaption>
           </figure>
         </div
         ><div class="l-grid__item u-1/8 u-mb">
           <figure class="c-swatch">
-            <div class="c-swatch__color u-bg-mandy">
+            <div class="c-swatch__color u-bg-guide-pink">
               <svg class="c-swatch__color__product">
                 <use xlink:href="../../index.svg#zd-svg-icon-26-relationshape-guide">
                   <title>Guide Pink</title>
@@ -113,29 +113,14 @@
               </svg>
             </div>
             <figcaption class="c-swatch__info">
-              <bold class="c-swatch__info__name">mandy</bold>
+              <bold class="c-swatch__info__name">guide-pink</bold>
               <span class="c-swatch__info__hex">eb4962</span>
             </figcaption>
           </figure>
         </div
         ><div class="l-grid__item u-1/8 u-mb">
           <figure class="c-swatch">
-            <div class="c-swatch__color u-bg-persimmon">
-              <svg class="c-swatch__color__product">
-                <use xlink:href="../../index.svg#zd-svg-icon-26-inbox">
-                  <title>Inbox Orange</title>
-                </use>
-              </svg>
-            </div>
-            <figcaption class="c-swatch__info">
-              <bold class="c-swatch__info__name">persimmon</bold>
-              <span class="c-swatch__info__hex">ff6d5a</span>
-            </figcaption>
-          </figure>
-        </div
-        ><div class="l-grid__item u-1/8 u-mb">
-          <figure class="c-swatch">
-            <div class="c-swatch__color u-bg-flamingo">
+            <div class="c-swatch__color u-bg-connect-red">
               <svg class="c-swatch__color__product">
                 <use xlink:href="../../index.svg#zd-svg-icon-26-relationshape-connect">
                   <title>Connect Red</title>
@@ -143,14 +128,14 @@
               </svg>
             </div>
             <figcaption class="c-swatch__info">
-              <bold class="c-swatch__info__name">flamingo</bold>
+              <bold class="c-swatch__info__name">connect-red</bold>
               <span class="c-swatch__info__hex">eb6651</span>
             </figcaption>
           </figure>
         </div
         ><div class="l-grid__item u-1/8 u-mb">
           <figure class="c-swatch">
-            <div class="c-swatch__color u-bg-sea-buckthorn">
+            <div class="c-swatch__color u-bg-chat-orange">
               <svg class="c-swatch__color__product">
                 <use xlink:href="../../index.svg#zd-svg-icon-26-relationshape-chat">
                   <title>Chat Orange</title>
@@ -158,14 +143,14 @@
               </svg>
             </div>
             <figcaption class="c-swatch__info">
-              <bold class="c-swatch__info__name">sea buckthorn</bold>
+              <bold class="c-swatch__info__name">chat-orange</bold>
               <span class="c-swatch__info__hex">f79a3e</span>
             </figcaption>
           </figure>
         </div
         ><div class="l-grid__item u-1/8 u-mb">
           <figure class="c-swatch">
-            <div class="c-swatch__color u-bg-golden-dream">
+            <div class="c-swatch__color u-bg-talk-yellow">
               <svg class="c-swatch__color__product">
                 <use xlink:href="../../index.svg#zd-svg-icon-26-relationshape-talk">
                   <title>Talk Yellow</title>
@@ -173,8 +158,23 @@
               </svg>
             </div>
             <figcaption class="c-swatch__info">
-              <bold class="c-swatch__info__name">golden dream</bold>
+              <bold class="c-swatch__info__name">talk-yellow</bold>
               <span class="c-swatch__info__hex">efc93d</span>
+            </figcaption>
+          </figure>
+        </div
+        ><div class="l-grid__item u-1/8 u-mb">
+          <figure class="c-swatch">
+            <div class="c-swatch__color u-bg-sell-gold">
+              <svg class="c-swatch__color__product">
+                <use xlink:href="../../index.svg#zd-svg-icon-26-inbox">
+                  <title>Inbox Orange</title>
+                </use>
+              </svg>
+            </div>
+            <figcaption class="c-swatch__info">
+              <bold class="c-swatch__info__name">sell-gold</bold>
+              <span class="c-swatch__info__hex">d4ae5e</span>
             </figcaption>
           </figure>
         </div>

--- a/demo/utilities/color/index.html
+++ b/demo/utilities/color/index.html
@@ -167,7 +167,7 @@
           <figure class="c-swatch">
             <div class="c-swatch__color u-bg-sell-gold">
               <svg class="c-swatch__color__product">
-                <use xlink:href="../../index.svg#zd-svg-icon-26-inbox">
+                <use xlink:href="../../index.svg#zd-svg-icon-26-relationshape-sell">
                   <title>Inbox Orange</title>
                 </use>
               </svg>

--- a/demo/utilities/index.html
+++ b/demo/utilities/index.html
@@ -38,7 +38,7 @@
         <code class="c-code">!important</code> to ensure styles are
         overridden.</p>
       <div class="l-wrapper-720">
-        <div class="l-grid l-grid--xxl u-mb-lg u-fs-xl u-light u-fg-submarine">
+        <div class="l-grid l-grid--xxl u-mb-lg u-fs-xl u-light u-fg-kale-300">
           <div class="l-grid__item u-1/2">
             <ul>
               <li><a class="u-fg-inherit u-display-inline-block u-mb-xs" href="border-radius">Border Radius</a></li>
@@ -69,16 +69,16 @@
         <div class="c-playground">
           <div class="c-playground__preview"></div>
 <textarea class="c-playground__code"><p class="u-mb-sm">Box Shadow Utility</p>
-<div class="u-bg-pelorous u-bs-none u-mb u-p-sm" style="box-shadow: 0 0 0 4px">
+<div class="u-bg-explore-blue u-bs-none u-mb u-p-sm" style="box-shadow: 0 0 0 4px">
   <code class="c-code">.u-bs-none</code>
 </div>
 
 <p class="u-mb-sm">Opacity Utility</p>
-<div class="u-bg-verdigris u-opacity-opaque u-mb u-p-sm" style="opacity: 0">
+<div class="u-bg-message-green u-opacity-opaque u-mb u-p-sm" style="opacity: 0">
   <code class="c-code">.u-opacity-opaque</code>
 </div>
 <div class="u-bc-grey-700 u-border" style="border-style: dotted !important">
-  <div class="u-bg-sea-buckthorn u-opacity-transparent u-p-sm" style="opacity: 1">
+  <div class="u-bg-chat-orange u-opacity-transparent u-p-sm" style="opacity: 1">
     <code class="c-code">.u-opacity-transparent</code>
   </div>
 </div></textarea>

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@zendeskgarden/eslint-config": "7.0.8",
     "@zendeskgarden/stylelint-config": "9.0.7",
-    "@zendeskgarden/svg-icons": "4.4.5",
+    "@zendeskgarden/svg-icons": "4.5.0",
     "babel-eslint": "10.0.1",
     "chalk": "2.4.1",
     "cssnano": "4.1.7",

--- a/packages/utilities/src/color.css
+++ b/packages/utilities/src/color.css
@@ -121,21 +121,21 @@
 
 /* Background Colors (product) */
 
-.u-bg-apple-green { background-color: var(--zd-color-apple-green) !important; }
+.u-bg-chat-orange { background-color: var(--zd-color-chat-orange) !important; }
 
-.u-bg-flamingo { background-color: var(--zd-color-flamingo) !important; }
+.u-bg-connect-red { background-color: var(--zd-color-connect-red) !important; }
 
-.u-bg-golden-dream { background-color: var(--zd-color-golden-dream) !important; }
+.u-bg-explore-blue { background-color: var(--zd-color-explore-blue) !important; }
 
-.u-bg-mandy { background-color: var(--zd-color-mandy) !important; }
+.u-bg-guide-pink { background-color: var(--zd-color-guide-pink) !important; }
 
-.u-bg-pelorous { background-color: var(--zd-color-pelorous) !important; }
+.u-bg-message-green { background-color: var(--zd-color-message-green) !important; }
 
-.u-bg-persimmon { background-color: var(--zd-color-persimmon) !important; }
+.u-bg-sell-gold { background-color: var(--zd-color-sell-gold) !important; }
 
-.u-bg-sea-buckthorn { background-color: var(--zd-color-sea-buckthorn) !important; }
+.u-bg-support-green { background-color: var(--zd-color-support-green) !important; }
 
-.u-bg-verdigris { background-color: var(--zd-color-verdigris) !important; }
+.u-bg-talk-yellow { background-color: var(--zd-color-talk-yellow) !important; }
 
 /* Background Colors (deprecated) */
 
@@ -144,6 +144,8 @@
 .u-bg-aluminum { background-color: var(--zd-color-aluminum) !important; }
 
 .u-bg-anti-flash-white { background-color: var(--zd-color-anti-flash-white) !important; }
+
+.u-bg-apple-green { background-color: var(--zd-color-apple-green) !important; }
 
 .u-bg-apricot { background-color: var(--zd-color-apricot) !important; }
 
@@ -167,7 +169,11 @@
 
 .u-bg-dark-gray { background-color: var(--zd-color-dark-gray) !important; }
 
+.u-bg-flamingo { background-color: var(--zd-color-flamingo) !important; }
+
 .u-bg-gainsboro { background-color: var(--zd-color-gainsboro) !important; }
+
+.u-bg-golden-dream { background-color: var(--zd-color-golden-dream) !important; }
 
 .u-bg-iron { background-color: var(--zd-color-iron) !important; }
 
@@ -176,6 +182,8 @@
 .u-bg-light-crimson { background-color: var(--zd-color-light-crimson) !important; }
 
 .u-bg-magic-mint { background-color: var(--zd-color-magic-mint) !important; }
+
+.u-bg-mandy { background-color: var(--zd-color-mandy) !important; }
 
 .u-bg-marigold { background-color: var(--zd-color-marigold) !important; }
 
@@ -193,9 +201,13 @@
 
 .u-bg-pale-turquoise { background-color: var(--zd-color-pale-turquoise) !important; }
 
+.u-bg-pelorous { background-color: var(--zd-color-pelorous) !important; }
+
 .u-bg-perano { background-color: var(--zd-color-perano) !important; }
 
 .u-bg-persian-green { background-color: var(--zd-color-persian-green) !important; }
+
+.u-bg-persimmon { background-color: var(--zd-color-persimmon) !important; }
 
 .u-bg-pink-orange { background-color: var(--zd-color-pink-orange) !important; }
 
@@ -206,6 +218,8 @@
 .u-bg-razzmatazz { background-color: var(--zd-color-razzmatazz) !important; }
 
 .u-bg-saffron-mango { background-color: var(--zd-color-saffron-mango) !important; }
+
+.u-bg-sea-buckthorn { background-color: var(--zd-color-sea-buckthorn) !important; }
 
 .u-bg-shamrock { background-color: var(--zd-color-shamrock) !important; }
 
@@ -218,6 +232,8 @@
 .u-bg-submarine { background-color: var(--zd-color-submarine) !important; }
 
 .u-bg-ultramarine-blue { background-color: var(--zd-color-ultramarine-blue) !important; }
+
+.u-bg-verdigris { background-color: var(--zd-color-verdigris) !important; }
 
 .u-bg-viking { background-color: var(--zd-color-viking) !important; }
 
@@ -333,21 +349,21 @@
 
 /* Foreground Colors (product) */
 
-.u-fg-apple-green { color: var(--zd-color-apple-green) !important; }
+.u-fg-chat-orange { color: var(--zd-color-chat-orange) !important; }
 
-.u-fg-flamingo { color: var(--zd-color-flamingo) !important; }
+.u-fg-connect-red { color: var(--zd-color-connect-red) !important; }
 
-.u-fg-golden-dream { color: var(--zd-color-golden-dream) !important; }
+.u-fg-explore-blue { color: var(--zd-color-explore-blue) !important; }
 
-.u-fg-mandy { color: var(--zd-color-mandy) !important; }
+.u-fg-guide-pink { color: var(--zd-color-guide-pink) !important; }
 
-.u-fg-pelorous { color: var(--zd-color-pelorous) !important; }
+.u-fg-message-green { color: var(--zd-color-message-green) !important; }
 
-.u-fg-persimmon { color: var(--zd-color-persimmon) !important; }
+.u-fg-sell-gold { color: var(--zd-color-sell-gold) !important; }
 
-.u-fg-sea-buckthorn { color: var(--zd-color-sea-buckthorn) !important; }
+.u-fg-support-green { color: var(--zd-color-support-green) !important; }
 
-.u-fg-verdigris { color: var(--zd-color-verdigris) !important; }
+.u-fg-talk-yellow { color: var(--zd-color-talk-yellow) !important; }
 
 /* Foreground Colors (deprecated) */
 
@@ -356,6 +372,8 @@
 .u-fg-aluminum { color: var(--zd-color-aluminum) !important; }
 
 .u-fg-anti-flash-white { color: var(--zd-color-anti-flash-white) !important; }
+
+.u-fg-apple-green { color: var(--zd-color-apple-green) !important; }
 
 .u-fg-apricot { color: var(--zd-color-apricot) !important; }
 
@@ -379,7 +397,11 @@
 
 .u-fg-dark-gray { color: var(--zd-color-dark-gray) !important; }
 
+.u-fg-flamingo { color: var(--zd-color-flamingo) !important; }
+
 .u-fg-gainsboro { color: var(--zd-color-gainsboro) !important; }
+
+.u-fg-golden-dream { color: var(--zd-color-golden-dream) !important; }
 
 .u-fg-iron { color: var(--zd-color-iron) !important; }
 
@@ -388,6 +410,8 @@
 .u-fg-light-crimson { color: var(--zd-color-light-crimson) !important; }
 
 .u-fg-magic-mint { color: var(--zd-color-magic-mint) !important; }
+
+.u-fg-mandy { color: var(--zd-color-mandy) !important; }
 
 .u-fg-marigold { color: var(--zd-color-marigold) !important; }
 
@@ -405,9 +429,13 @@
 
 .u-fg-pale-turquoise { color: var(--zd-color-pale-turquoise) !important; }
 
+.u-fg-pelorous { color: var(--zd-color-pelorous) !important; }
+
 .u-fg-perano { color: var(--zd-color-perano) !important; }
 
 .u-fg-persian-green { color: var(--zd-color-persian-green) !important; }
+
+.u-fg-persimmon { color: var(--zd-color-persimmon) !important; }
 
 .u-fg-pink-orange { color: var(--zd-color-pink-orange) !important; }
 
@@ -418,6 +446,8 @@
 .u-fg-razzmatazz { color: var(--zd-color-razzmatazz) !important; }
 
 .u-fg-saffron-mango { color: var(--zd-color-saffron-mango) !important; }
+
+.u-fg-sea-buckthorn { color: var(--zd-color-sea-buckthorn) !important; }
 
 .u-fg-shamrock { color: var(--zd-color-shamrock) !important; }
 
@@ -430,6 +460,8 @@
 .u-fg-submarine { color: var(--zd-color-submarine) !important; }
 
 .u-fg-ultramarine-blue { color: var(--zd-color-ultramarine-blue) !important; }
+
+.u-fg-verdigris { color: var(--zd-color-verdigris) !important; }
 
 .u-fg-viking { color: var(--zd-color-viking) !important; }
 
@@ -547,21 +579,21 @@
 
 /* Border Colors (product) */
 
-.u-bc-apple-green { border-color: var(--zd-color-apple-green) !important; }
+.u-bc-chat-orange { border-color: var(--zd-color-chat-orange) !important; }
 
-.u-bc-flamingo { border-color: var(--zd-color-flamingo) !important; }
+.u-bc-connect-red { border-color: var(--zd-color-connect-red) !important; }
 
-.u-bc-golden-dream { border-color: var(--zd-color-golden-dream) !important; }
+.u-bc-explore-blue { border-color: var(--zd-color-explore-blue) !important; }
 
-.u-bc-mandy { border-color: var(--zd-color-mandy) !important; }
+.u-bc-guide-pink { border-color: var(--zd-color-guide-pink) !important; }
 
-.u-bc-pelorous { border-color: var(--zd-color-pelorous) !important; }
+.u-bc-message-green { border-color: var(--zd-color-message-green) !important; }
 
-.u-bc-persimmon { border-color: var(--zd-color-persimmon) !important; }
+.u-bc-sell-gold { border-color: var(--zd-color-sell-gold) !important; }
 
-.u-bc-sea-buckthorn { border-color: var(--zd-color-sea-buckthorn) !important; }
+.u-bc-support-green { border-color: var(--zd-color-support-green) !important; }
 
-.u-bc-verdigris { border-color: var(--zd-color-verdigris) !important; }
+.u-bc-talk-yellow { border-color: var(--zd-color-talk-yellow) !important; }
 
 /* Border Colors (deprecated) */
 
@@ -570,6 +602,8 @@
 .u-bc-aluminum { border-color: var(--zd-color-aluminum) !important; }
 
 .u-bc-anti-flash-white { border-color: var(--zd-color-anti-flash-white) !important; }
+
+.u-bc-apple-green { border-color: var(--zd-color-apple-green) !important; }
 
 .u-bc-apricot { border-color: var(--zd-color-apricot) !important; }
 
@@ -593,7 +627,11 @@
 
 .u-bc-dark-gray { border-color: var(--zd-color-dark-gray) !important; }
 
+.u-bc-flamingo { border-color: var(--zd-color-flamingo) !important; }
+
 .u-bc-gainsboro { border-color: var(--zd-color-gainsboro) !important; }
+
+.u-bc-golden-dream { border-color: var(--zd-color-golden-dream) !important; }
 
 .u-bc-iron { border-color: var(--zd-color-iron) !important; }
 
@@ -602,6 +640,8 @@
 .u-bc-light-crimson { border-color: var(--zd-color-light-crimson) !important; }
 
 .u-bc-magic-mint { border-color: var(--zd-color-magic-mint) !important; }
+
+.u-bc-mandy { border-color: var(--zd-color-mandy) !important; }
 
 .u-bc-marigold { border-color: var(--zd-color-marigold) !important; }
 
@@ -619,9 +659,13 @@
 
 .u-bc-pale-turquoise { border-color: var(--zd-color-pale-turquoise) !important; }
 
+.u-bc-pelorous { border-color: var(--zd-color-pelorous) !important; }
+
 .u-bc-perano { border-color: var(--zd-color-perano) !important; }
 
 .u-bc-persian-green { border-color: var(--zd-color-persian-green) !important; }
+
+.u-bc-persimmon { border-color: var(--zd-color-persimmon) !important; }
 
 .u-bc-pink-orange { border-color: var(--zd-color-pink-orange) !important; }
 
@@ -632,6 +676,8 @@
 .u-bc-razzmatazz { border-color: var(--zd-color-razzmatazz) !important; }
 
 .u-bc-saffron-mango { border-color: var(--zd-color-saffron-mango) !important; }
+
+.u-bc-sea-buckthorn { border-color: var(--zd-color-sea-buckthorn) !important; }
 
 .u-bc-shamrock { border-color: var(--zd-color-shamrock) !important; }
 
@@ -644,6 +690,8 @@
 .u-bc-submarine { border-color: var(--zd-color-submarine) !important; }
 
 .u-bc-ultramarine-blue { border-color: var(--zd-color-ultramarine-blue) !important; }
+
+.u-bc-verdigris { border-color: var(--zd-color-verdigris) !important; }
 
 .u-bc-viking { border-color: var(--zd-color-viking) !important; }
 

--- a/packages/variables/src/_color.js
+++ b/packages/variables/src/_color.js
@@ -58,12 +58,23 @@ let retVal = {
   'white': { r: 255, g: 255, b: 255 }
 };
 
+/* Product colors */
+retVal = Object.assign(retVal, {
+  'chat-orange': { r: 247, g: 154, b: 62 },
+  'connect-red': { r: 235, g: 102, b: 81 },
+  'explore-blue': { r: 48, g: 170, b: 188 },
+  'guide-pink': { r: 235, g: 73, b: 98 },
+  'message-green': { r: 55, g: 184, b: 175 },
+  'sell-gold': { r: 212, g: 174, b: 94 },
+  'support-green': { r: 120, g: 163, b: 0 },
+  'talk-yellow': { r: 239, g: 201, b: 61 }
+});
+
 /* Deprecated colors */
 retVal = Object.assign(retVal, {
   'affair': { r: 115, g: 73, b: 136 },
   'aluminum': { r: 153, g: 153, b: 153 },
   'anti-flash-white': { r: 243, g: 243, b: 243 },
-  'apple-green': { r: 120, g: 163, b: 0 },
   'apricot': { r: 255, g: 202, b: 179 },
   'blue-chalk': { r: 229, g: 214, b: 237 },
   'buff': { r: 246, g: 222, b: 134 },
@@ -85,9 +96,8 @@ retVal = Object.assign(retVal, {
   'denim': { r: 20, g: 110, b: 170 },
   'east-side': { r: 176, g: 131, b: 200 },
   'festival': { r: 242, g: 206, b: 74 },
-  'flamingo': { r: 235, g: 102, b: 81 },
   'gainsboro': { r: 221, g: 221, b: 221 },
-  'golden-dream': { r: 239, g: 201, b: 61 },
+  'inbox-orange': { r: 255, g: 109, b: 90 },
   'indian-red': { r: 207, g: 100, b: 92 },
   'iron': { r: 204, g: 204, b: 204 },
   'jonquil': { r: 255, g: 221, b: 95 },
@@ -99,7 +109,6 @@ retVal = Object.assign(retVal, {
   'mabel': { r: 204, g: 227, b: 236 },
   'magic-mint': { r: 170, g: 243, b: 196 },
   'malibu': { r: 94, g: 187, b: 222 },
-  'mandy': { r: 235, g: 73, b: 98 },
   'marigold': { r: 255, g: 200, b: 0 },
   'maya-blue': { r: 97, g: 184, b: 255 },
   'monsoon': { r: 119, g: 119, b: 119 },
@@ -113,11 +122,9 @@ retVal = Object.assign(retVal, {
   'palatinate-blue': { r: 20, g: 56, b: 247 },
   'pale-turquoise': { r: 175, g: 243, b: 238 },
   'patterns-blue': { r: 210, g: 238, b: 249 },
-  'pelorous': { r: 48, g: 170, b: 188 },
   'perano': { r: 166, g: 179, b: 255 },
   'perfume': { r: 202, g: 172, b: 218 },
   'persian-green': { r: 3, g: 179, b: 167 },
-  'persimmon': { r: 255, g: 109, b: 90 },
   'petite-orchid': { r: 223, g: 151, b: 146 },
   'picasso': { r: 255, g: 232, b: 148 },
   'pink-orange': { r: 255, g: 148, b: 102 },
@@ -127,7 +134,6 @@ retVal = Object.assign(retVal, {
   'regent-st-blue': { r: 154, g: 199, b: 216 },
   'remy': { r: 247, g: 206, b: 203 },
   'saffron-mango': { r: 250, g: 193, b: 87 },
-  'sea-buckthorn': { r: 247, g: 154, b: 62 },
   'shamrock': { r: 69, g: 217, b: 123 },
   'silver-sand': { r: 187, g: 187, b: 187 },
   'sky-blue': { r: 120, g: 205, b: 236 },
@@ -137,33 +143,28 @@ retVal = Object.assign(retVal, {
   'terra-cotta': { r: 232, g: 108, b: 100 },
   'titan-white': { r: 220, g: 209, b: 225 },
   'ultramarine-blue': { r: 94, g: 118, b: 255 },
-  'verdigris': { r: 55, g: 184, b: 175 },
   'viking': { r: 95, g: 212, b: 204 },
   'wewak': { r: 239, g: 157, b: 151 },
   'white-smoke': { r: 248, g: 248, b: 248 }
 });
 
-/* Aliases */
-retVal = Object.assign(retVal, {
-  'chat-orange': retVal['sea-buckthorn'],
-  'connect-red': retVal['flamingo'],
-  'explore-blue': retVal['pelorous'],
-  'guide-pink': retVal['mandy'],
-  'inbox-orange': retVal['persimmon'],
-  'message-green': retVal['verdigris'],
-  'support-green': retVal['apple-green'],
-  'talk-yellow': retVal['golden-dream']
-});
-
 /* Deprecated aliases */
 retVal = Object.assign(retVal, {
   'algae': retVal['kale-700'],
+  'apple-green': retVal['support-green'],
   'breaker-bay': retVal['kale-400'],
   'daintree': retVal['kale-800'],
+  'flamingo': retVal['connect-red'],
+  'golden-dream': retVal['talk-yellow'],
+  'mandy': retVal['guide-pink'],
+  'pelorous': retVal['explore-blue'],
+  'persimmon': retVal['inbox-orange'],
   'promo-orange': retVal['orange-peel'],
+  'sea-buckthorn': retVal['chat-orange'],
   'sherpa-blue': retVal['kale-600'],
   'submarine': retVal['kale-300'],
-  'zendesk-green': retVal['apple-green']
+  'verdigris': retVal['message-green'],
+  'zendesk-green': retVal['support-green']
 });
 
 module.exports = retVal;

--- a/yarn.lock
+++ b/yarn.lock
@@ -849,10 +849,10 @@
   resolved "https://registry.yarnpkg.com/@zendeskgarden/stylelint-config/-/stylelint-config-9.0.7.tgz#af4ed545d9e0a13d6182e6753b1666e957ea8089"
   integrity sha512-XdG3AqzwmIJxkQ9z463t3ltRbcD/zaC8JChegNsYz2oS5tBeNgtIIxoEc6CaAZyRE3joeANC5hfyjF7lJt9ghw==
 
-"@zendeskgarden/svg-icons@4.4.5":
-  version "4.4.5"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-4.4.5.tgz#53000ded0abc53670a4ccd6522c46b6b86815bd7"
-  integrity sha512-ckf67NyL9pZY1atXhAxYS8PfOFbaA+PwD0iqWaci6A6REVNFbPpsXWPV+H6DynE/ZAPK6o4NiJ/pHgqslCFCmg==
+"@zendeskgarden/svg-icons@4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-4.5.0.tgz#7527776987b7bde77c192e95481617a826f51716"
+  integrity sha512-Av+NNqB+MeyzneYzBAOG4147LKoI8ci80j1cIlGeHM1mzqgNR5hLhC3/V2EttcoteZyh/uTH0oBi+eDSw7vZow==
 
 JSONStream@^1.0.4, JSONStream@^1.3.4:
   version "1.3.4"


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

...along with product color utility classes:

* `chat-orange`
* `connect-red`
* `explore-blue`
* `guide-pink`
* `message-green`
* `support-green`
* `talk-yellow`

## Detail

Demo pre-published for review: https://garden.zendesk.com/css-components/utilities/color/

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
