### PR TITLE
feat(avatars): Add new 40px size and rename other sizes

### DIFF
--- a/demo/avatars/index.html
+++ b/demo/avatars/index.html
@@ -73,44 +73,66 @@
         <li class="l-grid u-mb-sm">
           <div class="l-flag l-grid__item u-1/2">
             <div class="l-flag__figure">
-              <figure class="c-avatar c-avatar--small">
+              <figure class="c-avatar c-avatar--xs">
                 <img alt="user" src="images/ma.png">
               </figure>
             </div>
             <div class="l-flag__body">
-              <code class="c-code u-ml-sm">.c-avatar.c-avatar--small</code>
+              <code class="c-code u-ml-sm">.c-avatar.c-avatar--xs</code>
             </div>
           </div
           ><div class="l-flag l-grid__item u-1/2">
             <div class="l-flag__figure">
-              <figure class="c-avatar c-avatar--small c-avatar--system">
+              <figure class="c-avatar c-avatar--xs c-avatar--system">
                 <img alt="system" src="images/system.png">
               </figure>
             </div>
             <div class="l-flag__body">
-              <code class="c-code u-ml-sm">.c-avatar.c-avatar--small.c-avatar--system</code>
+              <code class="c-code u-ml-sm">.c-avatar.c-avatar--xs.c-avatar--system</code>
             </div>
           </div>
         </li>
         <li class="l-grid u-mb-sm">
           <div class="l-flag l-grid__item u-1/2">
             <div class="l-flag__figure">
-              <figure class="c-avatar c-avatar--large">
+              <figure class="c-avatar c-avatar--sm">
                 <img alt="user" src="images/ma.png">
               </figure>
             </div>
             <div class="l-flag__body">
-              <code class="c-code u-ml-sm">.c-avatar.c-avatar--large</code>
+              <code class="c-code u-ml-sm">.c-avatar.c-avatar--sm</code>
             </div>
           </div
           ><div class="l-flag l-grid__item u-1/2">
             <div class="l-flag__figure">
-              <figure class="c-avatar c-avatar--large c-avatar--system">
+              <figure class="c-avatar c-avatar--sm c-avatar--system">
                 <img alt="system" src="images/system.png">
               </figure>
             </div>
             <div class="l-flag__body">
-              <code class="c-code u-ml-sm">.c-avatar.c-avatar--large.c-avatar--system</code>
+              <code class="c-code u-ml-sm">.c-avatar.c-avatar--sm.c-avatar--system</code>
+            </div>
+          </div>
+        </li>
+        <li class="l-grid u-mb-sm">
+          <div class="l-flag l-grid__item u-1/2">
+            <div class="l-flag__figure">
+              <figure class="c-avatar c-avatar--lg">
+                <img alt="user" src="images/ma.png">
+              </figure>
+            </div>
+            <div class="l-flag__body">
+              <code class="c-code u-ml-sm">.c-avatar.c-avatar--lg</code>
+            </div>
+          </div
+          ><div class="l-flag l-grid__item u-1/2">
+            <div class="l-flag__figure">
+              <figure class="c-avatar c-avatar--lg c-avatar--system">
+                <img alt="system" src="images/system.png">
+              </figure>
+            </div>
+            <div class="l-flag__body">
+              <code class="c-code u-ml-sm">.c-avatar.c-avatar--lg.c-avatar--system</code>
             </div>
           </div>
         </li>
@@ -122,22 +144,44 @@
           <li class="l-grid u-mb-sm">
             <div class="l-flag l-grid__item u-1/2">
               <div class="l-flag__figure">
-                <figure class="c-avatar c-avatar--small is-disabled">
+                <figure class="c-avatar c-avatar--xs is-disabled">
                   <img alt="user" src="images/jz.png">
                 </figure>
               </div>
               <div class="l-flag__body">
-                <code class="c-code u-ml-sm">.c-avatar.c-avatar--small.is-disabled</code>
+                <code class="c-code u-ml-sm">.c-avatar.c-avatar--xs.is-disabled</code>
               </div>
             </div
             ><div class="l-flag l-grid__item u-1/2">
               <div class="l-flag__figure">
-                <figure class="c-avatar c-avatar--small c-avatar--system is-disabled">
+                <figure class="c-avatar c-avatar--xs c-avatar--system is-disabled">
                   <img alt="system" src="images/system.png">
                 </figure>
               </div>
               <div class="l-flag__body">
-                <code class="c-code u-ml-sm">.c-avatar.c-avatar--small.c-avatar--system.is-disabled</code>
+                <code class="c-code u-ml-sm">.c-avatar.c-avatar--xs.c-avatar--system.is-disabled</code>
+              </div>
+            </div>
+          </li>
+          <li class="l-grid u-mb-sm">
+            <div class="l-flag l-grid__item u-1/2">
+              <div class="l-flag__figure">
+                <figure class="c-avatar c-avatar--sm is-disabled">
+                  <img alt="user" src="images/jz.png">
+                </figure>
+              </div>
+              <div class="l-flag__body">
+                <code class="c-code u-ml-sm">.c-avatar.c-avatar--sm.is-disabled</code>
+              </div>
+            </div
+            ><div class="l-flag l-grid__item u-1/2">
+              <div class="l-flag__figure">
+                <figure class="c-avatar c-avatar--sm c-avatar--system is-disabled">
+                  <img alt="system" src="images/system.png">
+                </figure>
+              </div>
+              <div class="l-flag__body">
+                <code class="c-code u-ml-sm">.c-avatar.c-avatar--sm.c-avatar--system.is-disabled</code>
               </div>
             </div>
           </li>
@@ -166,22 +210,22 @@
           <li class="l-grid u-mb-sm">
             <div class="l-flag l-grid__item u-1/2">
               <div class="l-flag__figure">
-                <figure class="c-avatar c-avatar--large is-disabled">
+                <figure class="c-avatar c-avatar--lg is-disabled">
                   <img alt="user" src="images/jz.png">
                 </figure>
               </div>
               <div class="l-flag__body">
-                <code class="c-code u-ml-sm">.c-avatar.c-avatar--large.is-disabled</code>
+                <code class="c-code u-ml-sm">.c-avatar.c-avatar--lg.is-disabled</code>
               </div>
             </div
             ><div class="l-flag l-grid__item u-1/2">
               <div class="l-flag__figure">
-                <figure class="c-avatar c-avatar--large c-avatar--system is-disabled">
+                <figure class="c-avatar c-avatar--lg c-avatar--system is-disabled">
                   <img alt="system" src="images/system.png">
                 </figure>
               </div>
               <div class="l-flag__body">
-                <code class="c-code u-ml-sm">.c-avatar.c-avatar--large.c-avatar--system.is-disabled</code>
+                <code class="c-code u-ml-sm">.c-avatar.c-avatar--lg.c-avatar--system.is-disabled</code>
               </div>
             </div>
           </li>

--- a/packages/avatars/src/_base.css
+++ b/packages/avatars/src/_base.css
@@ -3,8 +3,8 @@
 :root {
   --zd-avatar-border: 1px transparent solid;
   --zd-avatar-border-radius: 50%;
-  --zd-avatar-size: 34px;
   --zd-avatar-transition: background-color .3s;
+  --zd-avatar-size: 40px;
   --zd-avatar__img-background-color: var(--zd-color-white);
   --zd-avatar__img-border: 1px solid var(--zd-color-grey-300) solid;
   --zd-avatar__img-border-radius: 50%;

--- a/packages/avatars/src/_size.css
+++ b/packages/avatars/src/_size.css
@@ -2,17 +2,23 @@
 
 :root {
   --zd-avatar--large-border-width: 2px;
-  --zd-avatar--large-size: 52px;
-  --zd-avatar--small-size: 26px;
+  --zd-avatar--xs-size: 24px;
+  --zd-avatar--sm-size: 32px;
+  --zd-avatar--lg-size: 48px;
 }
 
-.c-avatar--large {
+.c-avatar--lg {
   border-width: var(--zd-avatar--large-border-width);
-  width: var(--zd-avatar--large-size);
-  height: var(--zd-avatar--large-size);
+  width: var(--zd-avatar--lg-size);
+  height: var(--zd-avatar--lg-size);
 }
 
-.c-avatar--small {
-  width: var(--zd-avatar--small-size);
-  height: var(--zd-avatar--small-size);
+.c-avatar--sm {
+  width: var(--zd-avatar--sm-size);
+  height: var(--zd-avatar--sm-size);
+}
+
+.c-avatar--xs {
+  width: var(--zd-avatar--xs-size);
+  height: var(--zd-avatar--xs-size);
 }


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "fix(buttons):
     increase specificity for disabled state". the title informs the
     semantic version bump if this PR is merged. -->

- [x] **BREAKING CHANGE?** 

Default size has changed to new 40px size and older sizes have had their names changed

## Description

Introduce a new default 40px size avatar and change other sizes to base-4 system.

![image](https://user-images.githubusercontent.com/143402/48876241-309a9980-ee51-11e8-9d62-abcebd4786fe.png)

## Detail

### New sizes
| Size | px |
|-----------|----|
| xs | 24px |
| sm | 32px |
| default | 40px |
| lg | 48px |

### Old sizes
| Size | px |
|------|----|
| small | 26px |
| default | 34px |
| large | 52px |

Pre-published: https://garden.zendesk.com/css-components/avatars/

## Checklist

* [ ] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [ ] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [ ] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [ ] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
