### PR TITLE
fix(breadcrumbs): chevron separator positioning

### DIFF
--- a/packages/breadcrumbs/src/_item.css
+++ b/packages/breadcrumbs/src/_item.css
@@ -6,7 +6,7 @@
     var(--zd-breadcrumb__item-background-image);
   --zd-breadcrumb__item-background-image: svg-load('14/next.svg', color: var(--zd-color-grey-400));
   --zd-breadcrumb__item-background-margin: 0 calc(8 / 14 * 1em);
-  --zd-breadcrumb__item-background-size: 1em;
+  --zd-breadcrumb__item-background-width: 1em;
   --zd-breadcrumb__item-line-height: calc(20 / 14);
 }
 
@@ -20,9 +20,9 @@
   display: inline-block;
   margin: var(--zd-breadcrumb__item-background-margin);
   background: var(--zd-breadcrumb__item-background);
-  width: var(--zd-breadcrumb__item-background-size);
-  height: var(--zd-breadcrumb__item-background-size);
-  vertical-align: middle;
+  width: var(--zd-breadcrumb__item-background-width);
+  height: 100%;
+  vertical-align: top;
   content: '';
 }
 


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

### Before

<img width="339" alt="screen shot 2018-11-29 at 10 08 28 am" src="https://user-images.githubusercontent.com/143773/49242208-1287e880-f3bf-11e8-8eb8-00c4f89cd8ae.png">

### After

<img width="350" alt="screen shot 2018-11-29 at 10 11 16 am" src="https://user-images.githubusercontent.com/143773/49242319-49f69500-f3bf-11e8-8d65-245698688e1c.png">

## Detail

fix needed for https://github.com/zendeskgarden/react-components/pull/215

Demo pre-published for review at https://garden.zendesk.com/css-components/breadcrumbs/.

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
