### PR TITLE
fix(chrome): bump `c-chrome__nav__item` height

### DIFF
--- a/packages/chrome/src/_nav.css
+++ b/packages/chrome/src/_nav.css
@@ -24,7 +24,7 @@
   --zd-chrome__nav__fab-hovered-background-color: color-mod(var(--zd-chrome__nav__fab-background-color) lightness(+10%));
   --zd-chrome__nav__fab__icon-size: 20px;
   --zd-chrome__nav__fab__text-margin: 0 4px;
-  --zd-chrome__nav__item-height: 50px;
+  --zd-chrome__nav__item-height: 52px;
   --zd-chrome__nav__item-opacity: .6;
   --zd-chrome__nav__item-padding-horizontal: calc(calc(var(--zd-chrome__nav-width) - var(--zd-chrome__nav__item__icon-size)) / 4);
   --zd-chrome__nav__item-padding-vertical: calc(calc(var(--zd-chrome__nav__item-height) - var(--zd-chrome__nav__item__icon-size)) / 2);


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

...from 50px to 52px to honor base-4 sizing.

## Detail

Demo pre-published for review https://garden.zendesk.com/css-components/chrome/

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
