### PR TITLE
fix(breadcrumbs): improve `li` > `a` styling

### DIFF
--- a/packages/breadcrumbs/src/_item.css
+++ b/packages/breadcrumbs/src/_item.css
@@ -26,6 +26,10 @@
   content: '';
 }
 
+.c-breadcrumb__item > :any-link {
+  white-space: inherit;
+}
+
 .c-breadcrumb.is-rtl .c-breadcrumb__item::before {
   transform: rotate(180deg);
 }

--- a/packages/breadcrumbs/src/_state.css
+++ b/packages/breadcrumbs/src/_state.css
@@ -7,3 +7,7 @@
 .c-breadcrumb__item.is-current {
   color: var(--zd-breadcrumb__item--current-color);
 }
+
+.c-breadcrumb__item.is-current > :any-link {
+  color: inherit;
+}


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Currently when `.c-btn__anchor` is embedded in `.c-breadcrumb__item` the `<a>` tag no longer inherits `white-space: no-wrap` and (in the non-Zendesk design) case where the anchor is under the `.is-current` item, it fails to inherit the muted color. This change fixes these issues.

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
