### PR TITLE
fix(forms): checkbox workaround for invalid `postcss-custom-selectors` transform spacing

### DIFF
--- a/packages/forms/src/_checkbox/_state.css
+++ b/packages/forms/src/_checkbox/_state.css
@@ -31,8 +31,9 @@
   background-image: var(--zd-chk-indeterminate-background-image);
 }
 
-:--chk-checked-enabled::before,
-:--chk-indeterminate-enabled::before {
+/* HACK [jtz] until postcss/postcss-custom-selectors#40 is fixed */
+/* stylelint-disable-next-line selector-list-comma-space-after */
+:--chk-checked-enabled::before,:--chk-indeterminate-enabled::before {
   border-color: var(--zd-chk-checked-border-color);
   background-color: var(--zd-chk-checked-background-color);
 }
@@ -53,8 +54,9 @@
   background-color: var(--zd-chk-active-background-color);
 }
 
-:--chk-checked-active::before,
-:--chk-indeterminate-active::before {
+/* HACK [jtz] until postcss/postcss-custom-selectors#40 is fixed */
+/* stylelint-disable-next-line selector-list-comma-space-after */
+:--chk-checked-active::before,:--chk-indeterminate-active::before {
   border-color: var(--zd-chk-checked-active-border-color);
   background-color: var(--zd-chk-checked-active-background-color);
 }

--- a/packages/forms/src/custom.css
+++ b/packages/forms/src/custom.css
@@ -19,8 +19,9 @@
   --zd-range--custom-track-background-image: linear-gradient(var(--zd-forms--custom-accent-color), var(--zd-forms--custom-accent-color));
 }
 
-:--chk-checked-enabled.c-chk__label--custom::before,
-:--chk-indeterminate-enabled.c-chk__label--custom::before {
+/* HACK [jtz] until postcss/postcss-custom-selectors#40 is fixed */
+/* stylelint-disable selector-list-comma-space-after, max-line-length */
+:--chk-checked-enabled.c-chk__label--custom::before,:--chk-indeterminate-enabled.c-chk__label--custom::before {
   border-color: var(--zd-forms--custom-accent-color);
   background-color: var(--zd-forms--custom-accent-color);
 }
@@ -38,11 +39,12 @@
   border-color: var(--zd-forms--custom-accent-color);
 }
 
-:--chk-checked-active.c-chk__label--custom::before,
-:--chk-indeterminate-active.c-chk__label--custom::before {
+/* HACK [jtz] until postcss/postcss-custom-selectors#40 is fixed */
+:--chk-checked-active.c-chk__label--custom::before,:--chk-indeterminate-active.c-chk__label--custom::before {
   border-color: var(--zd-forms--custom-accent-color-active);
   background-color: var(--zd-forms--custom-accent-color-active);
 }
+/* stylelint-enable selector-list-comma-space-after, max-line-length */
 
 /* stylelint-disable selector-pseudo-element-no-unknown */
 


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Extra spaces added to compiled CSS are throwing off `indeterminate` checkbox styling, along with the more subtle "active" state.

## Detail

See https://github.com/postcss/postcss-custom-selectors/issues/40 for details.

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
