### PR TITLE
fix(menus): Support top & left animations

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "printWidth": 100,
+  "singleQuote": true
+}

--- a/demo/arrows/index.html
+++ b/demo/arrows/index.html
@@ -19,6 +19,11 @@
   .c-arrow.u-visibility-visible:before,
   .c-arrow.u-visibility-visible:after { display: inline-block !important; }
   .u-z-index-0 { z-index: 0 !important; }
+
+  .menu-container {
+    transform: translateZ(0);
+    position: absolute;
+  }
   </style>
 </head>
 <body>
@@ -45,20 +50,22 @@
             <use xlink:href="../index.svg#zd-svg-icon-14-chevron">
           </svg>
         </a>
-        <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
-          <li class="c-menu__item" role="menuitem">
-            <fieldset class="c-chk">
-              <input checked class="c-chk__input js-border" id="nav.ctl.border" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.border">Show Border</label>
-            </fieldset>
-          </li>
-          <li class="c-menu__item" role="menuitem">
-            <fieldset class="c-chk">
-              <input checked class="c-chk__input js-box-shadow" id="nav.ctl.box-shadow" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.box-shadow">Show Box Shadow</label>
-            </fieldset>
-          </li>
-        </ul>
+        <div class="menu-container u-1/1">
+          <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
+            <li class="c-menu__item" role="menuitem">
+              <fieldset class="c-chk">
+                <input checked class="c-chk__input js-border" id="nav.ctl.border" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.border">Show Border</label>
+              </fieldset>
+            </li>
+            <li class="c-menu__item" role="menuitem">
+              <fieldset class="c-chk">
+                <input checked class="c-chk__input js-box-shadow" id="nav.ctl.box-shadow" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.box-shadow">Show Box Shadow</label>
+              </fieldset>
+            </li>
+          </ul>
+        </div>
       </li>
     </ul>
   </header>

--- a/demo/buttons/index.html
+++ b/demo/buttons/index.html
@@ -16,6 +16,16 @@
   <link href="index.css" rel="stylesheet">
   <link href="custom.css" rel="stylesheet">
   <link href="../utilities/index.css" rel="stylesheet">
+  <style>
+  .menu-container .c-menu {
+    position: relative;
+  }
+
+  .menu-container {
+    transform: translateZ(0);
+    position: absolute;
+  }
+  </style>
 </head>
 <body>
   <header class="c-header">
@@ -41,20 +51,22 @@
             <use xlink:href="../index.svg#zd-svg-icon-14-chevron" />
           </svg>
         </a>
-        <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
-          <li class="c-menu__item" role="menuitem">
-            <fieldset class="c-chk">
-              <input class="c-chk__input js-rtl" id="nav.ctl.rtl" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.rtl">RTL</label>
-            </fieldset>
-          </li>
-          <li class="c-menu__item" role="menuitem">
-            <fieldset class="c-chk">
-              <input class="c-chk__input js-custom" id="nav.ctl.custom" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.custom">Custom</label>
-            </fieldset>
-          </li>
-        </ul>
+        <div class="menu-container u-1/1">
+          <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
+            <li class="c-menu__item" role="menuitem">
+              <fieldset class="c-chk">
+                <input class="c-chk__input js-rtl" id="nav.ctl.rtl" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.rtl">RTL</label>
+              </fieldset>
+            </li>
+            <li class="c-menu__item" role="menuitem">
+              <fieldset class="c-chk">
+                <input class="c-chk__input js-custom" id="nav.ctl.custom" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.custom">Custom</label>
+              </fieldset>
+            </li>
+          </ul>
+        </div>
       </li>
     </ul>
   </header>
@@ -220,13 +232,13 @@
       </p>
       <div class="l-btn-group u-mb-lg">
         <button class="c-btn">Split Button</button
-        ><button class="c-btn c-btn--icon js-menu">
+        ><button class="c-btn c-btn--icon js-menu js-menu--split">
           <svg class="c-btn__icon">
             <use xlink:href="../index.svg#zd-svg-icon-14-chevron">
           </svg>
         </button>
-        <div class="u-position-relative">
-          <ul aria-hidden="true" class="c-menu c-menu--up" role="menu" style="bottom:44px">
+        <div class="menu-container u-1/1">
+          <ul aria-hidden="true" class="c-menu c-menu--up" role="menu">
             <li class="c-menu__item" role="menuitem">One</li>
             <li class="c-menu__item is-selected" role="menuitem">Two</li>
             <li class="c-menu__item" role="menuitem">Three</li>

--- a/demo/chrome/index.html
+++ b/demo/chrome/index.html
@@ -22,6 +22,11 @@
   .c-chrome--demo { height: 300px !important; }
 
   .u-list-style-disc { padding-left: 20px; }
+
+  .menu-container {
+    transform: translateZ(0);
+    position: absolute;
+  }
   </style>
 </head>
 <body>
@@ -48,20 +53,22 @@
             <use xlink:href="../index.svg#zd-svg-icon-14-chevron" />
           </svg>
         </a>
-        <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
-          <li class="c-menu__item" role="menuitem">
-            <fieldset class="c-chk">
-              <input class="c-chk__input js-rtl" id="nav.ctl.rtl" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.rtl">RTL</label>
-            </fieldset>
-          </li>
-          <li class="c-menu__item" role="menuitem">
-            <fieldset class="c-chk">
-              <input class="c-chk__input js-custom" id="nav.ctl.custom" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.custom">Custom</label>
-            </fieldset>
-          </li>
-        </ul>
+        <div class="menu-container u-1/1">
+          <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
+            <li class="c-menu__item" role="menuitem">
+              <fieldset class="c-chk">
+                <input class="c-chk__input js-rtl" id="nav.ctl.rtl" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.rtl">RTL</label>
+              </fieldset>
+            </li>
+            <li class="c-menu__item" role="menuitem">
+              <fieldset class="c-chk">
+                <input class="c-chk__input js-custom" id="nav.ctl.custom" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.custom">Custom</label>
+              </fieldset>
+            </li>
+          </ul>
+        </div>
       </li>
     </ul>
   </header>
@@ -502,14 +509,16 @@
                     <use xlink:href="../index.svg#zd-svg-icon-14-plus" />
                   </svg>
                   <span class="c-chrome__body__header__item__text">Add</span>
-                  <ul aria-hidden="true" class="c-menu c-menu--down c-arrow c-arrow--tl" style="top:calc(100% + 4px);left:0">
-                    <li class="c-menu__item c-menu__item--header" role="menuitem">New</li>
-                    <li class="c-menu__separator" role="separator">
-                    <li class="c-menu__item" role="menuitem">Ticket</li>
-                    <li class="c-menu__item" role="menuitem">User</li>
-                    <li class="c-menu__item" role="menuitem">Organization</li>
-                    <li class="c-menu__item" role="menuitem">Search</li>
-                  </ul>
+                  <div class="menu-container u-1/1">
+                    <ul aria-hidden="true" class="c-menu c-menu--down c-arrow c-arrow--tl" style="left:0">
+                      <li class="c-menu__item c-menu__item--header" role="menuitem">New</li>
+                      <li class="c-menu__separator" role="separator">
+                      <li class="c-menu__item" role="menuitem">Ticket</li>
+                      <li class="c-menu__item" role="menuitem">User</li>
+                      <li class="c-menu__item" role="menuitem">Organization</li>
+                      <li class="c-menu__item" role="menuitem">Search</li>
+                    </ul>
+                  </div>
                 </button>
                 <div class="c-chrome__body__header__item c-chrome__body__header__item--max-x"></div>
                 <button class="c-chrome__body__header__item">
@@ -523,51 +532,55 @@
                     <use xlink:href="../index.svg#zd-svg-icon-14-menu-tray" />
                   </svg>
                   <span class="c-chrome__body__header__item__text is-clipped">Products</span>
-                  <ul aria-hidden="true" class="c-menu c-menu--down c-arrow c-arrow--tr" style="top:calc(100% + 4px);right:-4px">
-                    <li class="c-menu__item c-menu__item--media u-fg-apple-green" role="menuitem">
-                      <svg class="c-menu__item--media__figure">
-                        <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-support" />
-                      </svg>
-                      <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Support</div>
-                    </li>
-                    <li class="c-menu__item c-menu__item--media u-fg-mandy" role="menuitem">
-                      <svg class="c-menu__item--media__figure">
-                        <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-guide" />
-                      </svg>
-                      <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Guide</div>
-                    </li>
-                    <li class="c-menu__item c-menu__item--media u-fg-sea-buckthorn" role="menuitem">
-                      <svg class="c-menu__item--media__figure">
-                        <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-chat" />
-                      </svg>
-                      <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Chat</div>
-                    </li>
-                    <li class="c-menu__item c-menu__item--media u-fg-golden-dream" role="menuitem">
-                      <svg class="c-menu__item--media__figure">
-                        <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-talk" />
-                      </svg>
-                      <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Talk</div>
-                    </li>
-                  </ul>
+                  <div class="menu-container u-1/1">
+                    <ul aria-hidden="true" class="c-menu c-menu--down c-arrow c-arrow--tr" style="right:-4px">
+                      <li class="c-menu__item c-menu__item--media u-fg-apple-green" role="menuitem">
+                        <svg class="c-menu__item--media__figure">
+                          <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-support" />
+                        </svg>
+                        <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Support</div>
+                      </li>
+                      <li class="c-menu__item c-menu__item--media u-fg-mandy" role="menuitem">
+                        <svg class="c-menu__item--media__figure">
+                          <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-guide" />
+                        </svg>
+                        <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Guide</div>
+                      </li>
+                      <li class="c-menu__item c-menu__item--media u-fg-sea-buckthorn" role="menuitem">
+                        <svg class="c-menu__item--media__figure">
+                          <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-chat" />
+                        </svg>
+                        <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Chat</div>
+                      </li>
+                      <li class="c-menu__item c-menu__item--media u-fg-golden-dream" role="menuitem">
+                        <svg class="c-menu__item--media__figure">
+                          <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-talk" />
+                        </svg>
+                        <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Talk</div>
+                      </li>
+                    </ul>
+                  </div>
                 </button>
                 <button class="c-chrome__body__header__item c-chrome__body__header__item--round">
                   <img alt="Helpy Helperton" class="c-chrome__body__header__item__icon" src="http://placeskull.com/22/22/78A300/37/0">
                   <span class="c-chrome__body__header__item__text is-clipped">User</span>
-                  <ul aria-hidden="true" class="c-menu c-menu--down c-arrow c-arrow--tr" style="top:calc(100% + 4px);right:-4px">
-                    <li class="c-menu__item c-menu__item--media" role="menuitem">
-                      <img class="c-menu__item--media__figure u-br-50%" src="http://placeskull.com/32/32/78A300/37/0">
-                      <div class="c-menu__item--media__body">
-                        <div class="u-truncate" title="Helpy Helperton">Helpy Helperton</div>
-                        <span class="c-menu__item__meta">View profile</span>
-                      </div>
-                    </li>
-                    <li class="c-menu__separator" role="separator">
-                    <li class="c-menu__item" role="menuitem">Help</li>
-                    <li class="c-menu__item" role="menuitem">Settings</li>
-                    <li class="c-menu__item" role="menuitem">About</li>
-                    <li class="c-menu__separator" role="separator">
-                    <li class="c-menu__item" role="menuitem">Sign out</li>
-                  </ul>
+                  <div class="menu-container u-1/1">
+                    <ul aria-hidden="true" class="c-menu c-menu--down c-arrow c-arrow--tr" style="right:-4px">
+                      <li class="c-menu__item c-menu__item--media" role="menuitem">
+                        <img class="c-menu__item--media__figure u-br-50%" src="http://placeskull.com/32/32/78A300/37/0">
+                        <div class="c-menu__item--media__body">
+                          <div class="u-truncate" title="Helpy Helperton">Helpy Helperton</div>
+                          <span class="c-menu__item__meta">View profile</span>
+                        </div>
+                      </li>
+                      <li class="c-menu__separator" role="separator">
+                      <li class="c-menu__item" role="menuitem">Help</li>
+                      <li class="c-menu__item" role="menuitem">Settings</li>
+                      <li class="c-menu__item" role="menuitem">About</li>
+                      <li class="c-menu__separator" role="separator">
+                      <li class="c-menu__item" role="menuitem">Sign out</li>
+                    </ul>
+                  </div>
                 </button>
               </header>
             </div>
@@ -593,51 +606,55 @@
                     <use xlink:href="../index.svg#zd-svg-icon-14-menu-tray" />
                   </svg>
                   <span class="c-chrome__body__header__item__text is-clipped">Products</span>
-                  <ul aria-hidden="true" class="c-menu c-menu--down c-arrow c-arrow--tr" style="top:calc(100% + 4px);right:-4px">
-                    <li class="c-menu__item c-menu__item--media u-fg-apple-green" role="menuitem">
-                      <svg class="c-menu__item--media__figure">
-                        <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-support" />
-                      </svg>
-                      <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Support</div>
-                    </li>
-                    <li class="c-menu__item c-menu__item--media u-fg-mandy" role="menuitem">
-                      <svg class="c-menu__item--media__figure">
-                        <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-guide" />
-                      </svg>
-                      <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Guide</div>
-                    </li>
-                    <li class="c-menu__item c-menu__item--media u-fg-sea-buckthorn" role="menuitem">
-                      <svg class="c-menu__item--media__figure">
-                        <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-chat" />
-                      </svg>
-                      <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Chat</div>
-                    </li>
-                    <li class="c-menu__item c-menu__item--media u-fg-golden-dream" role="menuitem">
-                      <svg class="c-menu__item--media__figure">
-                        <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-talk" />
-                      </svg>
-                      <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Talk</div>
-                    </li>
-                  </ul>
+                  <div class="menu-container u-1/1">
+                    <ul aria-hidden="true" class="c-menu c-menu--down c-arrow c-arrow--tr" style="right:-4px">
+                      <li class="c-menu__item c-menu__item--media u-fg-apple-green" role="menuitem">
+                        <svg class="c-menu__item--media__figure">
+                          <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-support" />
+                        </svg>
+                        <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Support</div>
+                      </li>
+                      <li class="c-menu__item c-menu__item--media u-fg-mandy" role="menuitem">
+                        <svg class="c-menu__item--media__figure">
+                          <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-guide" />
+                        </svg>
+                        <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Guide</div>
+                      </li>
+                      <li class="c-menu__item c-menu__item--media u-fg-sea-buckthorn" role="menuitem">
+                        <svg class="c-menu__item--media__figure">
+                          <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-chat" />
+                        </svg>
+                        <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Chat</div>
+                      </li>
+                      <li class="c-menu__item c-menu__item--media u-fg-golden-dream" role="menuitem">
+                        <svg class="c-menu__item--media__figure">
+                          <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-talk" />
+                        </svg>
+                        <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Talk</div>
+                      </li>
+                    </ul>
+                  </div>
                 </button>
                 <button class="c-chrome__body__header__item c-chrome__body__header__item--round">
                   <img alt="Helpy Helperton" class="c-chrome__body__header__item__icon" src="http://placeskull.com/22/22/F79A3E/13/0">
                   <span class="c-chrome__body__header__item__text is-clipped">User</span>
-                  <ul aria-hidden="true" class="c-menu c-menu--down c-arrow c-arrow--tr" style="top:calc(100% + 4px);right:-4px">
-                    <li class="c-menu__item c-menu__item--media" role="menuitem">
-                      <img class="c-menu__item--media__figure u-br-50%" src="http://placeskull.com/32/32/F79A3E/13/0">
-                      <div class="c-menu__item--media__body">
-                        <div class="u-truncate" title="Helpy Helperton">Helpy Helperton</div>
-                        <span class="c-menu__item__meta">View profile</span>
-                      </div>
-                    </li>
-                    <li class="c-menu__separator" role="separator">
-                    <li class="c-menu__item" role="menuitem">Help</li>
-                    <li class="c-menu__item" role="menuitem">Settings</li>
-                    <li class="c-menu__item" role="menuitem">About</li>
-                    <li class="c-menu__separator" role="separator">
-                    <li class="c-menu__item" role="menuitem">Sign out</li>
-                  </ul>
+                  <div class="menu-container u-1/1">
+                    <ul aria-hidden="true" class="c-menu c-menu--down c-arrow c-arrow--tr" style="right:-4px">
+                      <li class="c-menu__item c-menu__item--media" role="menuitem">
+                        <img class="c-menu__item--media__figure u-br-50%" src="http://placeskull.com/32/32/F79A3E/13/0">
+                        <div class="c-menu__item--media__body">
+                          <div class="u-truncate" title="Helpy Helperton">Helpy Helperton</div>
+                          <span class="c-menu__item__meta">View profile</span>
+                        </div>
+                      </li>
+                      <li class="c-menu__separator" role="separator">
+                      <li class="c-menu__item" role="menuitem">Help</li>
+                      <li class="c-menu__item" role="menuitem">Settings</li>
+                      <li class="c-menu__item" role="menuitem">About</li>
+                      <li class="c-menu__separator" role="separator">
+                      <li class="c-menu__item" role="menuitem">Sign out</li>
+                    </ul>
+                  </div>
                 </button>
               </header>
             </div>
@@ -668,62 +685,68 @@
                   <svg class="c-chrome__body__header__item__icon">
                     <use xlink:href="../index.svg#zd-svg-icon-14-chevron" />
                   </svg>
-                  <ul aria-hidden="true" class="c-menu c-menu--down c-arrow c-arrow--t" style="top:calc(100% + 4px);right:-50%">
-                    <li class="c-menu__item" role="menuitem">Brand A</li>
-                    <li class="c-menu__item is-checked" role="menuitem">Brand B</li>
-                    <li class="c-menu__item" role="menuitem">Brand C</li>
-                  </ul>
+                  <div class="menu-container u-1/1">
+                    <ul aria-hidden="true" class="c-menu c-menu--down c-arrow c-arrow--t" style="right:-50%">
+                      <li class="c-menu__item" role="menuitem">Brand A</li>
+                      <li class="c-menu__item is-checked" role="menuitem">Brand B</li>
+                      <li class="c-menu__item" role="menuitem">Brand C</li>
+                    </ul>
+                  </div>
                 </button>
                 <button class="c-chrome__body__header__item">
                   <svg class="c-chrome__body__header__item__icon">
                     <use xlink:href="../index.svg#zd-svg-icon-14-menu-tray" />
                   </svg>
                   <span class="c-chrome__body__header__item__text is-clipped">Products</span>
-                  <ul aria-hidden="true" class="c-menu c-menu--down c-arrow c-arrow--tr" style="top:calc(100% + 4px);right:-4px">
-                    <li class="c-menu__item c-menu__item--media u-fg-apple-green" role="menuitem">
-                      <svg class="c-menu__item--media__figure">
-                        <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-support" />
-                      </svg>
-                      <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Support</div>
-                    </li>
-                    <li class="c-menu__item c-menu__item--media u-fg-mandy" role="menuitem">
-                      <svg class="c-menu__item--media__figure">
-                        <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-guide" />
-                      </svg>
-                      <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Guide</div>
-                    </li>
-                    <li class="c-menu__item c-menu__item--media u-fg-sea-buckthorn" role="menuitem">
-                      <svg class="c-menu__item--media__figure">
-                        <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-chat" />
-                      </svg>
-                      <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Chat</div>
-                    </li>
-                    <li class="c-menu__item c-menu__item--media u-fg-golden-dream" role="menuitem">
-                      <svg class="c-menu__item--media__figure">
-                        <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-talk" />
-                      </svg>
-                      <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Talk</div>
-                    </li>
-                  </ul>
+                  <div class="menu-container u-1/1">
+                    <ul aria-hidden="true" class="c-menu c-menu--down c-arrow c-arrow--tr" style="right:-4px">
+                      <li class="c-menu__item c-menu__item--media u-fg-apple-green" role="menuitem">
+                        <svg class="c-menu__item--media__figure">
+                          <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-support" />
+                        </svg>
+                        <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Support</div>
+                      </li>
+                      <li class="c-menu__item c-menu__item--media u-fg-mandy" role="menuitem">
+                        <svg class="c-menu__item--media__figure">
+                          <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-guide" />
+                        </svg>
+                        <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Guide</div>
+                      </li>
+                      <li class="c-menu__item c-menu__item--media u-fg-sea-buckthorn" role="menuitem">
+                        <svg class="c-menu__item--media__figure">
+                          <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-chat" />
+                        </svg>
+                        <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Chat</div>
+                      </li>
+                      <li class="c-menu__item c-menu__item--media u-fg-golden-dream" role="menuitem">
+                        <svg class="c-menu__item--media__figure">
+                          <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-talk" />
+                        </svg>
+                        <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Talk</div>
+                      </li>
+                    </ul>
+                  </div>
                 </button>
                 <button class="c-chrome__body__header__item c-chrome__body__header__item--round">
                   <img alt="Helpy Helperton" class="c-chrome__body__header__item__icon" src="http://placeskull.com/22/22/EB4962/36/0">
                   <span class="c-chrome__body__header__item__text is-clipped">User</span>
-                  <ul aria-hidden="true" class="c-menu c-menu--down c-arrow c-arrow--tr" style="top:calc(100% + 4px);right:-4px">
-                    <li class="c-menu__item c-menu__item--media" role="menuitem">
-                      <img class="c-menu__item--media__figure u-br-50%" src="http://placeskull.com/32/32/EB4962/36/0">
-                      <div class="c-menu__item--media__body">
-                        <div class="u-truncate" title="Helpy Helperton">Helpy Helperton</div>
-                        <span class="c-menu__item__meta">View profile</span>
-                      </div>
-                    </li>
-                    <li class="c-menu__separator" role="separator">
-                    <li class="c-menu__item" role="menuitem">Help</li>
-                    <li class="c-menu__item" role="menuitem">Settings</li>
-                    <li class="c-menu__item" role="menuitem">About</li>
-                    <li class="c-menu__separator" role="separator">
-                    <li class="c-menu__item" role="menuitem">Sign out</li>
-                  </ul>
+                  <div class="menu-container u-1/1">
+                    <ul aria-hidden="true" class="c-menu c-menu--down c-arrow c-arrow--tr" style="right:-4px">
+                      <li class="c-menu__item c-menu__item--media" role="menuitem">
+                        <img class="c-menu__item--media__figure u-br-50%" src="http://placeskull.com/32/32/EB4962/36/0">
+                        <div class="c-menu__item--media__body">
+                          <div class="u-truncate" title="Helpy Helperton">Helpy Helperton</div>
+                          <span class="c-menu__item__meta">View profile</span>
+                        </div>
+                      </li>
+                      <li class="c-menu__separator" role="separator">
+                      <li class="c-menu__item" role="menuitem">Help</li>
+                      <li class="c-menu__item" role="menuitem">Settings</li>
+                      <li class="c-menu__item" role="menuitem">About</li>
+                      <li class="c-menu__separator" role="separator">
+                      <li class="c-menu__item" role="menuitem">Sign out</li>
+                    </ul>
+                  </div>
                 </button>
               </header>
             </div>
@@ -749,51 +772,55 @@
                     <use xlink:href="../index.svg#zd-svg-icon-14-menu-tray" />
                   </svg>
                   <span class="c-chrome__body__header__item__text is-clipped">Products</span>
-                  <ul aria-hidden="true" class="c-menu c-menu--down c-arrow c-arrow--tr" style="top:calc(100% + 4px);right:-4px">
-                    <li class="c-menu__item c-menu__item--media u-fg-apple-green" role="menuitem">
-                      <svg class="c-menu__item--media__figure">
-                        <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-support" />
-                      </svg>
-                      <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Support</div>
-                    </li>
-                    <li class="c-menu__item c-menu__item--media u-fg-mandy" role="menuitem">
-                      <svg class="c-menu__item--media__figure">
-                        <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-guide" />
-                      </svg>
-                      <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Guide</div>
-                    </li>
-                    <li class="c-menu__item c-menu__item--media u-fg-sea-buckthorn" role="menuitem">
-                      <svg class="c-menu__item--media__figure">
-                        <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-chat" />
-                      </svg>
-                      <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Chat</div>
-                    </li>
-                    <li class="c-menu__item c-menu__item--media u-fg-golden-dream" role="menuitem">
-                      <svg class="c-menu__item--media__figure">
-                        <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-talk" />
-                      </svg>
-                      <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Talk</div>
-                    </li>
-                  </ul>
+                  <div class="menu-container u-1/1">
+                    <ul aria-hidden="true" class="c-menu c-menu--down c-arrow c-arrow--tr" style="right:-4px">
+                      <li class="c-menu__item c-menu__item--media u-fg-apple-green" role="menuitem">
+                        <svg class="c-menu__item--media__figure">
+                          <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-support" />
+                        </svg>
+                        <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Support</div>
+                      </li>
+                      <li class="c-menu__item c-menu__item--media u-fg-mandy" role="menuitem">
+                        <svg class="c-menu__item--media__figure">
+                          <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-guide" />
+                        </svg>
+                        <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Guide</div>
+                      </li>
+                      <li class="c-menu__item c-menu__item--media u-fg-sea-buckthorn" role="menuitem">
+                        <svg class="c-menu__item--media__figure">
+                          <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-chat" />
+                        </svg>
+                        <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Chat</div>
+                      </li>
+                      <li class="c-menu__item c-menu__item--media u-fg-golden-dream" role="menuitem">
+                        <svg class="c-menu__item--media__figure">
+                          <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-talk" />
+                        </svg>
+                        <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Talk</div>
+                      </li>
+                    </ul>
+                  </div>
                 </button>
                 <button class="c-chrome__body__header__item c-chrome__body__header__item--round">
                   <img alt="Helpy Helperton" class="c-chrome__body__header__item__icon" src="http://placeskull.com/22/22/30AABC/20/0">
                   <span class="c-chrome__body__header__item__text is-clipped">User</span>
-                  <ul aria-hidden="true" class="c-menu c-menu--down c-arrow c-arrow--tr" style="top:calc(100% + 4px);right:-4px">
-                    <li class="c-menu__item c-menu__item--media" role="menuitem">
-                      <img class="c-menu__item--media__figure u-br-50%" src="http://placeskull.com/32/32/30AABC/20/0">
-                      <div class="c-menu__item--media__body">
-                        <div class="u-truncate" title="Helpy Helperton">Helpy Helperton</div>
-                        <span class="c-menu__item__meta">View profile</span>
-                      </div>
-                    </li>
-                    <li class="c-menu__separator" role="separator">
-                    <li class="c-menu__item" role="menuitem">Help</li>
-                    <li class="c-menu__item" role="menuitem">Settings</li>
-                    <li class="c-menu__item" role="menuitem">About</li>
-                    <li class="c-menu__separator" role="separator">
-                    <li class="c-menu__item" role="menuitem">Sign out</li>
-                  </ul>
+                  <div class="menu-container u-1/1">
+                    <ul aria-hidden="true" class="c-menu c-menu--down c-arrow c-arrow--tr" style="right:-4px">
+                      <li class="c-menu__item c-menu__item--media" role="menuitem">
+                        <img class="c-menu__item--media__figure u-br-50%" src="http://placeskull.com/32/32/30AABC/20/0">
+                        <div class="c-menu__item--media__body">
+                          <div class="u-truncate" title="Helpy Helperton">Helpy Helperton</div>
+                          <span class="c-menu__item__meta">View profile</span>
+                        </div>
+                      </li>
+                      <li class="c-menu__separator" role="separator">
+                      <li class="c-menu__item" role="menuitem">Help</li>
+                      <li class="c-menu__item" role="menuitem">Settings</li>
+                      <li class="c-menu__item" role="menuitem">About</li>
+                      <li class="c-menu__separator" role="separator">
+                      <li class="c-menu__item" role="menuitem">Sign out</li>
+                    </ul>
+                  </div>
                 </button>
               </header>
             </div>
@@ -813,51 +840,55 @@
                     <use xlink:href="../index.svg#zd-svg-icon-14-menu-tray" />
                   </svg>
                   <span class="c-chrome__body__header__item__text is-clipped">Products</span>
-                  <ul aria-hidden="true" class="c-menu c-menu--down c-arrow c-arrow--tr" style="top:calc(100% + 4px);right:-4px">
-                    <li class="c-menu__item c-menu__item--media u-fg-apple-green" role="menuitem">
-                      <svg class="c-menu__item--media__figure">
-                        <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-support" />
-                      </svg>
-                      <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Support</div>
-                    </li>
-                    <li class="c-menu__item c-menu__item--media u-fg-mandy" role="menuitem">
-                      <svg class="c-menu__item--media__figure">
-                        <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-guide" />
-                      </svg>
-                      <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Guide</div>
-                    </li>
-                    <li class="c-menu__item c-menu__item--media u-fg-sea-buckthorn" role="menuitem">
-                      <svg class="c-menu__item--media__figure">
-                        <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-chat" />
-                      </svg>
-                      <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Chat</div>
-                    </li>
-                    <li class="c-menu__item c-menu__item--media u-fg-golden-dream" role="menuitem">
-                      <svg class="c-menu__item--media__figure">
-                        <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-talk" />
-                      </svg>
-                      <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Talk</div>
-                    </li>
-                  </ul>
+                  <div class="menu-container u-1/1">
+                    <ul aria-hidden="true" class="c-menu c-menu--down c-arrow c-arrow--tr" style="right:-4px">
+                      <li class="c-menu__item c-menu__item--media u-fg-apple-green" role="menuitem">
+                        <svg class="c-menu__item--media__figure">
+                          <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-support" />
+                        </svg>
+                        <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Support</div>
+                      </li>
+                      <li class="c-menu__item c-menu__item--media u-fg-mandy" role="menuitem">
+                        <svg class="c-menu__item--media__figure">
+                          <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-guide" />
+                        </svg>
+                        <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Guide</div>
+                      </li>
+                      <li class="c-menu__item c-menu__item--media u-fg-sea-buckthorn" role="menuitem">
+                        <svg class="c-menu__item--media__figure">
+                          <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-chat" />
+                        </svg>
+                        <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Chat</div>
+                      </li>
+                      <li class="c-menu__item c-menu__item--media u-fg-golden-dream" role="menuitem">
+                        <svg class="c-menu__item--media__figure">
+                          <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-talk" />
+                        </svg>
+                        <div class="c-menu__item--media__body u-mt-sm u-fg-grey-700">Talk</div>
+                      </li>
+                    </ul>
+                  </div>
                 </button>
                 <button class="c-chrome__body__header__item c-chrome__body__header__item--round">
                   <img alt="Helpy Helperton" class="c-chrome__body__header__item__icon" src="http://placeskull.com/22/22/EFC93D/33/0">
                   <span class="c-chrome__body__header__item__text is-clipped">User</span>
-                  <ul aria-hidden="true" class="c-menu c-menu--down c-arrow c-arrow--tr" style="top:calc(100% + 4px);right:-4px">
-                    <li class="c-menu__item c-menu__item--media" role="menuitem">
-                      <img class="c-menu__item--media__figure u-br-50%" src="http://placeskull.com/32/32/EFC93D/33/0">
-                      <div class="c-menu__item--media__body">
-                        <div class="u-truncate" title="Helpy Helperton">Helpy Helperton</div>
-                        <span class="c-menu__item__meta">View profile</span>
-                      </div>
-                    </li>
-                    <li class="c-menu__separator" role="separator">
-                    <li class="c-menu__item" role="menuitem">Help</li>
-                    <li class="c-menu__item" role="menuitem">Settings</li>
-                    <li class="c-menu__item" role="menuitem">About</li>
-                    <li class="c-menu__separator" role="separator">
-                    <li class="c-menu__item" role="menuitem">Sign out</li>
-                  </ul>
+                  <div class="menu-container u-1/1">
+                    <ul aria-hidden="true" class="c-menu c-menu--down c-arrow c-arrow--tr" style="right:-4px">
+                      <li class="c-menu__item c-menu__item--media" role="menuitem">
+                        <img class="c-menu__item--media__figure u-br-50%" src="http://placeskull.com/32/32/EFC93D/33/0">
+                        <div class="c-menu__item--media__body">
+                          <div class="u-truncate" title="Helpy Helperton">Helpy Helperton</div>
+                          <span class="c-menu__item__meta">View profile</span>
+                        </div>
+                      </li>
+                      <li class="c-menu__separator" role="separator">
+                      <li class="c-menu__item" role="menuitem">Help</li>
+                      <li class="c-menu__item" role="menuitem">Settings</li>
+                      <li class="c-menu__item" role="menuitem">About</li>
+                      <li class="c-menu__separator" role="separator">
+                      <li class="c-menu__item" role="menuitem">Sign out</li>
+                    </ul>
+                  </div>
                 </button>
               </header>
             </div>
@@ -886,21 +917,23 @@
                 <button class="c-chrome__body__header__item c-chrome__body__header__item--round">
                   <img alt="Helpy Helperton" class="c-chrome__body__header__item__icon" src="http://placeskull.com/22/22/37B8AF/18/0">
                   <span class="c-chrome__body__header__item__text is-clipped">User</span>
-                  <ul aria-hidden="true" class="c-menu c-menu--down c-arrow c-arrow--tr" style="top:calc(100% + 4px);right:-4px">
-                    <li class="c-menu__item c-menu__item--media" role="menuitem">
-                      <img class="c-menu__item--media__figure u-br-50%" src="http://placeskull.com/32/32/37B8AF/18/0">
-                      <div class="c-menu__item--media__body">
-                        <div class="u-truncate" title="Helpy Helperton">Helpy Helperton</div>
-                        <span class="c-menu__item__meta">View profile</span>
-                      </div>
-                    </li>
-                    <li class="c-menu__separator" role="separator">
-                    <li class="c-menu__item" role="menuitem">Help</li>
-                    <li class="c-menu__item" role="menuitem">Settings</li>
-                    <li class="c-menu__item" role="menuitem">About</li>
-                    <li class="c-menu__separator" role="separator">
-                    <li class="c-menu__item" role="menuitem">Sign out</li>
-                  </ul>
+                  <div class="menu-container u-1/1">
+                    <ul aria-hidden="true" class="c-menu c-menu--down c-arrow c-arrow--tr" style="right:-4px">
+                      <li class="c-menu__item c-menu__item--media" role="menuitem">
+                        <img class="c-menu__item--media__figure u-br-50%" src="http://placeskull.com/32/32/37B8AF/18/0">
+                        <div class="c-menu__item--media__body">
+                          <div class="u-truncate" title="Helpy Helperton">Helpy Helperton</div>
+                          <span class="c-menu__item__meta">View profile</span>
+                        </div>
+                      </li>
+                      <li class="c-menu__separator" role="separator">
+                      <li class="c-menu__item" role="menuitem">Help</li>
+                      <li class="c-menu__item" role="menuitem">Settings</li>
+                      <li class="c-menu__item" role="menuitem">About</li>
+                      <li class="c-menu__separator" role="separator">
+                      <li class="c-menu__item" role="menuitem">Sign out</li>
+                    </ul>
+                  </div>
                 </button>
               </header>
             </div>

--- a/demo/chrome/index.js
+++ b/demo/chrome/index.js
@@ -14,7 +14,7 @@ $(document).ready(function() {
     '.c-chrome__body__header__item',
     '.c-chrome__nav__fab',
     '.c-chrome__nav__item',
-    '.c-chrome__subnav__item',
+    '.c-chrome__subnav__item'
   ].forEach(Garden.handleFocus);
 
   Garden.customClasses.push('.c-chrome');
@@ -24,7 +24,12 @@ $(document).ready(function() {
     var value = $(this).val();
     var $nav = $('.c-chrome__nav:not(.c-playground .c-chrome__nav)');
 
-    if (value.toUpperCase() === $(this).attr('value').toUpperCase()) {
+    if (
+      value.toUpperCase() ===
+      $(this)
+        .attr('value')
+        .toUpperCase()
+    ) {
       $nav.removeClass('c-chrome__nav--dark c-chrome__nav--light').css('backgroundColor', '');
     } else {
       updateNavColor($nav, value);
@@ -36,7 +41,9 @@ $(document).ready(function() {
   });
 
   $('.js-standalone').click(function() {
-    $('.c-chrome__body__header:not(.c-playground .c-chrome__body__header)').toggleClass('c-chrome__body__header--standalone');
+    $('.c-chrome__body__header:not(.c-playground .c-chrome__body__header)').toggleClass(
+      'c-chrome__body__header--standalone'
+    );
   });
 
   $(document).on('click', '.c-chrome__nav__item:not(.c-chrome__nav__item--logo)', function() {
@@ -55,7 +62,9 @@ $(document).ready(function() {
 
     if ($this.hasClass('c-chrome__subnav__item--header')) {
       $this.toggleClass('is-expanded');
-      $this.next('.c-chrome__subnav__panel').toggleClass('is-hidden', !$this.hasClass('is-expanded'));
+      $this
+        .next('.c-chrome__subnav__panel')
+        .toggleClass('is-hidden', !$this.hasClass('is-expanded'));
     } else {
       var $parent = $this.closest('.c-chrome__subnav');
 
@@ -71,6 +80,10 @@ $(document).ready(function() {
   $(document).on('click', '.c-chrome__body__header__item', function() {
     var $this = $(this);
     var $menu = $this.find('.c-menu');
+    var $icon = $this.find('svg, img');
+    var $container = $menu.parent('.menu-container');
+    var $offset = $icon.is('img') ? -3 : 5;
+    var y = $icon.outerHeight() + $offset;
 
     if ($menu.length) {
       if ($menu.hasClass('is-open')) {
@@ -80,6 +93,8 @@ $(document).ready(function() {
         $menu.addClass('is-open').attr('aria-hidden', false);
         $this.addClass('is-active');
       }
+
+      $container.css('transform', 'translate3d(0, ' + y + 'px, 0)');
 
       return false;
     }

--- a/demo/chrome/page.html
+++ b/demo/chrome/page.html
@@ -21,6 +21,11 @@
   <link href="../utilities/index.css" rel="stylesheet">
   <style>
   .c-chrome { min-height: 300px; }
+
+  .menu-container {
+    transform: translateZ(0);
+    position: absolute;
+  }
   </style>
 </head>
 <body class="c-chrome">
@@ -94,51 +99,55 @@
           <use xlink:href="../index.svg#zd-svg-icon-14-menu-tray" />
         </svg>
         <span class="c-chrome__body__header__item__text is-clipped">Products</span>
-        <ul aria-hidden="true" class="c-menu c-menu--down c-arrow c-arrow--tr" style="top:calc(100% + 4px);right:-4px">
-          <li class="c-menu__item c-menu__item--media u-fg-apple-green" role="menuitem">
-            <svg class="c-menu__item--media__figure">
-              <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-support" />
-            </svg>
-            <div class="c-menu__item--media__body u-mt-sm u-fg-dark-gray">Support</div>
-          </li>
-          <li class="c-menu__item c-menu__item--media u-fg-mandy" role="menuitem">
-            <svg class="c-menu__item--media__figure">
-              <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-guide" />
-            </svg>
-            <div class="c-menu__item--media__body u-mt-sm u-fg-dark-gray">Guide</div>
-          </li>
-          <li class="c-menu__item c-menu__item--media u-fg-sea-buckthorn" role="menuitem">
-            <svg class="c-menu__item--media__figure">
-              <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-chat" />
-            </svg>
-            <div class="c-menu__item--media__body u-mt-sm u-fg-dark-gray">Chat</div>
-          </li>
-          <li class="c-menu__item c-menu__item--media u-fg-golden-dream" role="menuitem">
-            <svg class="c-menu__item--media__figure">
-              <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-talk" />
-            </svg>
-            <div class="c-menu__item--media__body u-mt-sm u-fg-dark-gray">Talk</div>
-          </li>
-        </ul>
+        <div class="menu-container u-1/1">
+          <ul aria-hidden="true" class="c-menu c-menu--down c-arrow c-arrow--tr" style="right:-4px">
+            <li class="c-menu__item c-menu__item--media u-fg-apple-green" role="menuitem">
+              <svg class="c-menu__item--media__figure">
+                <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-support" />
+              </svg>
+              <div class="c-menu__item--media__body u-mt-sm u-fg-dark-gray">Support</div>
+            </li>
+            <li class="c-menu__item c-menu__item--media u-fg-mandy" role="menuitem">
+              <svg class="c-menu__item--media__figure">
+                <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-guide" />
+              </svg>
+              <div class="c-menu__item--media__body u-mt-sm u-fg-dark-gray">Guide</div>
+            </li>
+            <li class="c-menu__item c-menu__item--media u-fg-sea-buckthorn" role="menuitem">
+              <svg class="c-menu__item--media__figure">
+                <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-chat" />
+              </svg>
+              <div class="c-menu__item--media__body u-mt-sm u-fg-dark-gray">Chat</div>
+            </li>
+            <li class="c-menu__item c-menu__item--media u-fg-golden-dream" role="menuitem">
+              <svg class="c-menu__item--media__figure">
+                <use xlink:href="../index.svg#zd-svg-icon-26-relationshape-talk" />
+              </svg>
+              <div class="c-menu__item--media__body u-mt-sm u-fg-dark-gray">Talk</div>
+            </li>
+          </ul>
+        </div>
       </button>
       <button class="c-chrome__body__header__item c-chrome__body__header__item--round">
         <img alt="Helpy Helperton" class="c-chrome__body__header__item__icon" src="http://placeskull.com/22/22/03363D/41/0">
         <span class="c-chrome__body__header__item__text is-clipped">User</span>
-        <ul aria-hidden="true" class="c-menu c-menu--down c-arrow c-arrow--tr" style="top:calc(100% + 4px);right:-4px">
-          <li class="c-menu__item c-menu__item--media" role="menuitem">
-            <img class="c-menu__item--media__figure u-br-50%" src="http://placeskull.com/32/32/03363D/41/0">
-            <div class="c-menu__item--media__body">
-              <div class="u-truncate" title="Helpy Helperton">Helpy Helperton</div>
-              <span class="c-menu__item__meta">View profile</span>
-            </div>
-          </li>
-          <li class="c-menu__separator" role="separator">
-          <li class="c-menu__item" role="menuitem">Help</li>
-          <li class="c-menu__item" role="menuitem">Settings</li>
-          <li class="c-menu__item" role="menuitem">About</li>
-          <li class="c-menu__separator" role="separator">
-          <li class="c-menu__item" role="menuitem">Sign out</li>
-        </ul>
+        <div class="menu-container u-1/1">
+          <ul aria-hidden="true" class="c-menu c-menu--down c-arrow c-arrow--tr" style="right:-4px">
+            <li class="c-menu__item c-menu__item--media" role="menuitem">
+              <img class="c-menu__item--media__figure u-br-50%" src="http://placeskull.com/32/32/03363D/41/0">
+              <div class="c-menu__item--media__body">
+                <div class="u-truncate" title="Helpy Helperton">Helpy Helperton</div>
+                <span class="c-menu__item__meta">View profile</span>
+              </div>
+            </li>
+            <li class="c-menu__separator" role="separator">
+            <li class="c-menu__item" role="menuitem">Help</li>
+            <li class="c-menu__item" role="menuitem">Settings</li>
+            <li class="c-menu__item" role="menuitem">About</li>
+            <li class="c-menu__separator" role="separator">
+            <li class="c-menu__item" role="menuitem">Sign out</li>
+          </ul>
+        </div>
       </button>
     </header>
     <div class="c-chrome__body__content">

--- a/demo/forms/checkbox/index.html
+++ b/demo/forms/checkbox/index.html
@@ -17,6 +17,11 @@
   <link href="../../utilities/index.css" rel="stylesheet">
   <style>
   .l-wrapper { min-width: 1024px; }
+
+  .menu-container {
+    transform: translateZ(0);
+    position: absolute;
+  }
   </style>
 </head>
 <body>
@@ -43,41 +48,43 @@
             <use xlink:href="../../index.svg#zd-svg-icon-14-chevron">
           </svg>
         </a>
-        <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
-          <li class="c-menu__item" role="menuitem">
-            <div class="c-chk">
-              <input class="c-chk__input js-rtl" id="nav.ctl.rtl" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.rtl">RTL</label>
-            </div>
-          </li>
-          <li class="c-menu__item" role="menuitem">
-            <fieldset class="c-chk">
-              <input class="c-chk__input js-custom" id="nav.ctl.custom" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.custom">Custom</label>
-            </fieldset>
-          </li>
-          <li class="c-menu__item" role="menuitem">
-            <div class="u-mb">Validation</div>
-            <div class="u-ml">
+        <div class="menu-container u-1/1">
+          <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
+            <li class="c-menu__item" role="menuitem">
               <div class="c-chk">
-                <input class="c-chk__input js-validation" id="nav.ctl.validation.none" name="nav.ctl.validation" checked type="radio" value="">
-                <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.none">None</label>
+                <input class="c-chk__input js-rtl" id="nav.ctl.rtl" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.rtl">RTL</label>
               </div>
-              <div class="c-chk">
-                <input class="c-chk__input js-validation" id="nav.ctl.validation.success" name="nav.ctl.validation" type="radio" value="success">
-                <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.success">Success</label>
+            </li>
+            <li class="c-menu__item" role="menuitem">
+              <fieldset class="c-chk">
+                <input class="c-chk__input js-custom" id="nav.ctl.custom" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.custom">Custom</label>
+              </fieldset>
+            </li>
+            <li class="c-menu__item" role="menuitem">
+              <div class="u-mb">Validation</div>
+              <div class="u-ml">
+                <div class="c-chk">
+                  <input class="c-chk__input js-validation" id="nav.ctl.validation.none" name="nav.ctl.validation" checked type="radio" value="">
+                  <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.none">None</label>
+                </div>
+                <div class="c-chk">
+                  <input class="c-chk__input js-validation" id="nav.ctl.validation.success" name="nav.ctl.validation" type="radio" value="success">
+                  <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.success">Success</label>
+                </div>
+                <div class="c-chk">
+                  <input class="c-chk__input js-validation" id="nav.ctl.validation.warning" name="nav.ctl.validation" type="radio" value="warning">
+                  <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.warning">Warning</label>
+                </div>
+                <div class="c-chk">
+                  <input class="c-chk__input js-validation" id="nav.ctl.validation.error" name="nav.ctl.validation" type="radio" value="error">
+                  <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.error">Error</label>
+                </div>
               </div>
-              <div class="c-chk">
-                <input class="c-chk__input js-validation" id="nav.ctl.validation.warning" name="nav.ctl.validation" type="radio" value="warning">
-                <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.warning">Warning</label>
-              </div>
-              <div class="c-chk">
-                <input class="c-chk__input js-validation" id="nav.ctl.validation.error" name="nav.ctl.validation" type="radio" value="error">
-                <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.error">Error</label>
-              </div>
-            </div>
-          </li>
-        </ul>
+            </li>
+          </ul>
+        </div>
       </li>
     </ul>
   </header>

--- a/demo/forms/dropdown/index.html
+++ b/demo/forms/dropdown/index.html
@@ -19,15 +19,22 @@
   <style>
   .c-main .c-menu {
     width: 370px;
-    bottom: 47px;
-  }
-
-  .c-main .c-txt + .c-menu {
-    top: calc(100% + 5px);
-    bottom: auto;
   }
 
   .l-wrapper--370 { max-width: 370px; }
+
+  .menu-container--up {
+    position: absolute;
+    top: calc(1em + 4px);
+  }
+  .menu-container {
+    transform: translateZ(0);
+    position: absolute;
+    margin-top: 5px;
+  }
+  .menu-container .c-menu--up {
+    bottom: 0;
+  }
   </style>
 </head>
 <body>
@@ -54,47 +61,49 @@
             <use xlink:href="../../index.svg#zd-svg-icon-14-chevron">
           </svg>
         </a>
-        <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
-          <li class="c-menu__item" role="menuitem">
-            <fieldset class="c-chk">
-              <input class="c-chk__input js-rtl" id="nav.ctl.rtl" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.rtl">RTL</label>
-            </fieldset>
-          </li>
-          <li class="c-menu__item" role="menuitem">
-            <fieldset class="c-chk">
-              <input class="c-chk__input js-custom" id="nav.ctl.custom" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.custom">Custom</label>
-            </fieldset>
-          </li>
-          <li class="c-menu__item" role="menuitem">
-            <fieldset class="c-chk">
-              <input class="c-chk__input js-size" id="nav.ctl.size" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.size">Size</label>
-            </fieldset>
-          </li>
-          <li class="c-menu__item" role="menuitem">
-            <div class="u-mb">Validation</div>
-            <div class="u-ml">
+        <div class="menu-container u-1/1">
+          <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
+            <li class="c-menu__item" role="menuitem">
               <fieldset class="c-chk">
-                <input class="c-chk__input js-validation" id="nav.ctl.validation.none" name="nav.ctl.validation" checked type="radio" value="">
-                <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.none">None</label>
+                <input class="c-chk__input js-rtl" id="nav.ctl.rtl" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.rtl">RTL</label>
               </fieldset>
+            </li>
+            <li class="c-menu__item" role="menuitem">
               <fieldset class="c-chk">
-                <input class="c-chk__input js-validation" id="nav.ctl.validation.success" name="nav.ctl.validation" type="radio" value="success">
-                <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.success">Success</label>
+                <input class="c-chk__input js-custom" id="nav.ctl.custom" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.custom">Custom</label>
               </fieldset>
+            </li>
+            <li class="c-menu__item" role="menuitem">
               <fieldset class="c-chk">
-                <input class="c-chk__input js-validation" id="nav.ctl.validation.warning" name="nav.ctl.validation" type="radio" value="warning">
-                <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.warning">Warning</label>
+                <input class="c-chk__input js-size" id="nav.ctl.size" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.size">Size</label>
               </fieldset>
-              <fieldset class="c-chk">
-                <input class="c-chk__input js-validation" id="nav.ctl.validation.error" name="nav.ctl.validation" type="radio" value="error">
-                <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.error">Error</label>
-              </fieldset>
-            </div>
-          </li>
-        </ul>
+            </li>
+            <li class="c-menu__item" role="menuitem">
+              <div class="u-mb">Validation</div>
+              <div class="u-ml">
+                <fieldset class="c-chk">
+                  <input class="c-chk__input js-validation" id="nav.ctl.validation.none" name="nav.ctl.validation" checked type="radio" value="">
+                  <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.none">None</label>
+                </fieldset>
+                <fieldset class="c-chk">
+                  <input class="c-chk__input js-validation" id="nav.ctl.validation.success" name="nav.ctl.validation" type="radio" value="success">
+                  <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.success">Success</label>
+                </fieldset>
+                <fieldset class="c-chk">
+                  <input class="c-chk__input js-validation" id="nav.ctl.validation.warning" name="nav.ctl.validation" type="radio" value="warning">
+                  <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.warning">Warning</label>
+                </fieldset>
+                <fieldset class="c-chk">
+                  <input class="c-chk__input js-validation" id="nav.ctl.validation.error" name="nav.ctl.validation" type="radio" value="error">
+                  <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.error">Error</label>
+                </fieldset>
+              </div>
+            </li>
+          </ul>
+        </div>
       </li>
     </ul>
   </header>
@@ -120,18 +129,24 @@
             <label class="c-txt__label" for="select-0">A &lt;button&gt; Dropdown</label>
             <button class="c-txt__input c-txt__input--select" id="select-0"><span dir="ltr">.c-txt__input--select<span></button>
           </div>
-          <ul aria-hidden="true" class="c-menu c-menu--down">
-            <li class="c-menu__item">item</li>
-            <li class="c-menu__item is-checked"><span dir="ltr">.c-txt__input--select</span></li>
-            <li class="c-menu__item">item</li>
-          </ul>
+          <div class="menu-container u-1/1">
+            <ul aria-hidden="true" class="c-menu c-menu--down">
+              <li class="c-menu__item">item</li>
+              <li class="c-menu__item is-checked"><span dir="ltr">.c-txt__input--select</span></li>
+              <li class="c-menu__item">item</li>
+            </ul>
+          </div>
         </fieldset>
         <fieldset class="u-mb-lg u-position-relative">
-          <ul aria-hidden="true" class="c-menu c-menu--up">
-            <li class="c-menu__item">one</li>
-            <li class="c-menu__item is-checked">two</li>
-            <li class="c-menu__item">three</li>
-          </ul>
+          <div class="menu-container--up">
+            <div class="menu-container u-1/1">
+              <ul aria-hidden="true" class="c-menu c-menu--up">
+                <li class="c-menu__item">one</li>
+                <li class="c-menu__item is-checked">two</li>
+                <li class="c-menu__item">three</li>
+              </ul>
+            </div>
+          </div>
           <div class="c-txt">
             <label class="c-txt__label" for="select-1">A ContentEditable &lt;div&gt; Dropdown</label>
             <div class="c-txt__input c-txt__input--select" contenteditable="true" id="select-1" tabindex="0">two</div>
@@ -158,12 +173,14 @@
               </div>
             </div>
           </div>
-          <ul aria-hidden="true" class="c-menu c-menu--down">
-            <li class="c-menu__item">Tag Zero</li>
-            <li class="c-menu__item is-checked">Tag One</li>
-            <li class="c-menu__item is-checked">Tag Two</li>
-            <li class="c-menu__item is-checked">Tag Three</li>
-          </ul>
+          <div class="menu-container u-1/1">
+            <ul aria-hidden="true" class="c-menu c-menu--down">
+              <li class="c-menu__item">Tag Zero</li>
+              <li class="c-menu__item is-checked">Tag One</li>
+              <li class="c-menu__item is-checked">Tag Two</li>
+              <li class="c-menu__item is-checked">Tag Three</li>
+            </ul>
+          </div>
         </fieldset>
         <fieldset class="u-mb-lg">
           <div class="c-txt">

--- a/demo/forms/dropdown/index.js
+++ b/demo/forms/dropdown/index.js
@@ -1,27 +1,32 @@
 $(document).ready(function() {
-  $('.c-txt__input--select').click(function() {
-    var $this = $(this);
-    var $menu = $(this).parent().siblings('.c-menu');
+  $('.c-txt__input--select')
+    .click(function() {
+      var $this = $(this);
+      var $parent = $this.closest('.u-position-relative');
+      var $menu = $parent.find('.c-menu');
 
-    $this.toggleClass('is-open');
-    $menu.toggleClass('is-open', $this.hasClass('is-open'));
+      $this.toggleClass('is-open');
+      $menu.toggleClass('is-open', $this.hasClass('is-open'));
 
-    if ($menu.hasClass('is-open')) {
-      $menu.parent('.u-position-relative').css('zIndex', 1);
-      $menu.attr('aria-hidden', false);
-    } else {
-      $menu.attr('aria-hidden', true);
-      $menu.parent('.u-position-relative').css('zIndex', '');
-    }
+      if ($menu.hasClass('is-open')) {
+        $parent.css('zIndex', 1);
+        $menu.attr('aria-hidden', false);
+      } else {
+        $menu.attr('aria-hidden', true);
+        $parent.css('zIndex', '');
+      }
 
-    return false;
-  }).blur(function() {
-    var $menu = $(this).parent().siblings('.c-menu');
+      return false;
+    })
+    .blur(function() {
+      var $this = $(this);
+      var $parent = $this.closest('.u-position-relative');
+      var $menu = $parent.find('.c-menu');
 
-    $(this).removeClass('is-open');
-    $menu.removeClass('is-open').attr('aria-hidden', true);
-    $menu.parent('.u-position-relative').css('zIndex', '');
-  });
+      $this.removeClass('is-open');
+      $menu.removeClass('is-open').attr('aria-hidden', true);
+      $parent.css('zIndex', '');
+    });
 
   $('.c-txt__input--select[contenteditable]').focus(function() {
     var $this = $(this);

--- a/demo/forms/range/index.html
+++ b/demo/forms/range/index.html
@@ -17,6 +17,11 @@
   <link href="../../utilities/index.css" rel="stylesheet">
   <style>
   .l-wrapper--400 { max-width: 400px; }
+
+  .menu-container {
+    transform: translateZ(0);
+    position: absolute;
+  }
   </style>
 </head>
 <body>
@@ -43,47 +48,49 @@
             <use xlink:href="../../index.svg#zd-svg-icon-14-chevron">
           </svg>
         </a>
-        <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
-          <li class="c-menu__item" role="menuitem">
-            <div class="c-chk">
-              <input class="c-chk__input js-rtl" id="nav.ctl.rtl" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.rtl">RTL</label>
-            </div>
-          </li>
-          <li class="c-menu__item" role="menuitem">
-            <fieldset class="c-chk">
-              <input class="c-chk__input js-custom" id="nav.ctl.custom" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.custom">Custom</label>
-            </fieldset>
-          </li>
-          <li class="c-menu__item" role="menuitem">
-            <div class="c-chk">
-              <input class="c-chk__input js-size" id="nav.ctl.size" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.size">Size</label>
-            </div>
-          </li>
-          <li class="c-menu__item" role="menuitem">
-            <div class="u-mb">Validation</div>
-            <div class="u-ml">
+        <div class="menu-container u-1/1">
+          <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
+            <li class="c-menu__item" role="menuitem">
               <div class="c-chk">
-                <input class="c-chk__input js-validation" id="nav.ctl.validation.none" name="nav.ctl.validation" checked type="radio" value="">
-                <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.none">None</label>
+                <input class="c-chk__input js-rtl" id="nav.ctl.rtl" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.rtl">RTL</label>
               </div>
+            </li>
+            <li class="c-menu__item" role="menuitem">
+              <fieldset class="c-chk">
+                <input class="c-chk__input js-custom" id="nav.ctl.custom" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.custom">Custom</label>
+              </fieldset>
+            </li>
+            <li class="c-menu__item" role="menuitem">
               <div class="c-chk">
-                <input class="c-chk__input js-validation" id="nav.ctl.validation.success" name="nav.ctl.validation" type="radio" value="success">
-                <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.success">Success</label>
+                <input class="c-chk__input js-size" id="nav.ctl.size" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.size">Size</label>
               </div>
-              <div class="c-chk">
-                <input class="c-chk__input js-validation" id="nav.ctl.validation.warning" name="nav.ctl.validation" type="radio" value="warning">
-                <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.warning">Warning</label>
+            </li>
+            <li class="c-menu__item" role="menuitem">
+              <div class="u-mb">Validation</div>
+              <div class="u-ml">
+                <div class="c-chk">
+                  <input class="c-chk__input js-validation" id="nav.ctl.validation.none" name="nav.ctl.validation" checked type="radio" value="">
+                  <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.none">None</label>
+                </div>
+                <div class="c-chk">
+                  <input class="c-chk__input js-validation" id="nav.ctl.validation.success" name="nav.ctl.validation" type="radio" value="success">
+                  <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.success">Success</label>
+                </div>
+                <div class="c-chk">
+                  <input class="c-chk__input js-validation" id="nav.ctl.validation.warning" name="nav.ctl.validation" type="radio" value="warning">
+                  <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.warning">Warning</label>
+                </div>
+                <div class="c-chk">
+                  <input class="c-chk__input js-validation" id="nav.ctl.validation.error" name="nav.ctl.validation" type="radio" value="error">
+                  <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.error">Error</label>
+                </div>
               </div>
-              <div class="c-chk">
-                <input class="c-chk__input js-validation" id="nav.ctl.validation.error" name="nav.ctl.validation" type="radio" value="error">
-                <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.error">Error</label>
-              </div>
-            </div>
-          </li>
-        </ul>
+            </li>
+          </ul>
+        </div>
       </li>
     </ul>
   </header>

--- a/demo/forms/text/index.html
+++ b/demo/forms/text/index.html
@@ -19,6 +19,11 @@
   <link href="../../utilities/index.css" rel="stylesheet">
   <style>
   .l-wrapper--370 { max-width: 370px; }
+
+  .menu-container {
+    transform: translateZ(0);
+    position: absolute;
+  }
   </style>
 </head>
 <body>
@@ -45,53 +50,55 @@
             <use xlink:href="../../index.svg#zd-svg-icon-14-chevron">
           </svg>
         </a>
-        <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
-          <li class="c-menu__item" role="menuitem">
-            <div class="c-chk">
-              <input class="c-chk__input js-rtl" id="nav.ctl.rtl" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.rtl">RTL</label>
-            </div>
-          </li>
-          <li class="c-menu__item" role="menuitem">
-            <fieldset class="c-chk">
-              <input class="c-chk__input js-custom" id="nav.ctl.custom" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.custom">Custom</label>
-            </fieldset>
-          </li>
-          <li class="c-menu__item" role="menuitem">
-            <div class="c-chk">
-              <input class="c-chk__input js-size" id="nav.ctl.size" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.size">Size</label>
-            </div>
-          </li>
-          <li class="c-menu__item" role="menuitem">
-            <div class="c-chk">
-              <input class="c-chk__input js-bare" id="nav.ctl.bare" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.bare">Bare</label>
-            </div>
-          </li>
-          <li class="c-menu__item" role="menuitem">
-            <div class="u-mb">Validation</div>
-            <div class="u-ml">
+        <div class="menu-container u-1/1">
+          <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
+            <li class="c-menu__item" role="menuitem">
               <div class="c-chk">
-                <input class="c-chk__input js-validation" id="nav.ctl.validation.none" name="nav.ctl.validation" checked type="radio" value="">
-                <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.none">None</label>
+                <input class="c-chk__input js-rtl" id="nav.ctl.rtl" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.rtl">RTL</label>
               </div>
+            </li>
+            <li class="c-menu__item" role="menuitem">
+              <fieldset class="c-chk">
+                <input class="c-chk__input js-custom" id="nav.ctl.custom" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.custom">Custom</label>
+              </fieldset>
+            </li>
+            <li class="c-menu__item" role="menuitem">
               <div class="c-chk">
-                <input class="c-chk__input js-validation" id="nav.ctl.validation.success" name="nav.ctl.validation" type="radio" value="success">
-                <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.success">Success</label>
+                <input class="c-chk__input js-size" id="nav.ctl.size" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.size">Size</label>
               </div>
+            </li>
+            <li class="c-menu__item" role="menuitem">
               <div class="c-chk">
-                <input class="c-chk__input js-validation" id="nav.ctl.validation.warning" name="nav.ctl.validation" type="radio" value="warning">
-                <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.warning">Warning</label>
+                <input class="c-chk__input js-bare" id="nav.ctl.bare" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.bare">Bare</label>
               </div>
-              <div class="c-chk">
-                <input class="c-chk__input js-validation" id="nav.ctl.validation.error" name="nav.ctl.validation" type="radio" value="error">
-                <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.error">Error</label>
+            </li>
+            <li class="c-menu__item" role="menuitem">
+              <div class="u-mb">Validation</div>
+              <div class="u-ml">
+                <div class="c-chk">
+                  <input class="c-chk__input js-validation" id="nav.ctl.validation.none" name="nav.ctl.validation" checked type="radio" value="">
+                  <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.none">None</label>
+                </div>
+                <div class="c-chk">
+                  <input class="c-chk__input js-validation" id="nav.ctl.validation.success" name="nav.ctl.validation" type="radio" value="success">
+                  <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.success">Success</label>
+                </div>
+                <div class="c-chk">
+                  <input class="c-chk__input js-validation" id="nav.ctl.validation.warning" name="nav.ctl.validation" type="radio" value="warning">
+                  <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.warning">Warning</label>
+                </div>
+                <div class="c-chk">
+                  <input class="c-chk__input js-validation" id="nav.ctl.validation.error" name="nav.ctl.validation" type="radio" value="error">
+                  <label class="c-chk__label c-chk__label--radio" for="nav.ctl.validation.error">Error</label>
+                </div>
               </div>
-            </div>
-          </li>
-        </ul>
+            </li>
+          </ul>
+        </div>
       </li>
     </ul>
   </header>

--- a/demo/index.html
+++ b/demo/index.html
@@ -19,6 +19,17 @@
   <link href="grid/index.css" rel="stylesheet">
   <link href="//zendeskgarden.github.io/index.css" rel="stylesheet">
   <link href="utilities/index.css" rel="stylesheet">
+  <style>
+  .menu-container {
+    transform: translateZ(0);
+    position: absolute;
+  }
+  .is-responsive .c-ctl--header .c-ctl__item a:not(.c-menu__item) {
+    float: none !important;
+    height: calc(100% - 5px);
+    margin-left: calc(100% - 60px);
+  }
+  </style>
 </head>
 <body class="is-responsive u-bg-relationshapes">
   <nav class="c-nav">
@@ -59,17 +70,19 @@
             <use xlink:href="index.svg#zd-svg-icon-16-menu-stroke">
           </svg>
         </a>
-        <ul aria-hidden="true" class="c-menu c-menu--down c-menu--sm" role="menu">
-          <a href="//zendeskgarden.github.io/assets/" class="c-menu__item" role="menuitem">
-            Assets
-          </a>
-          <a href="/css-components" class="c-menu__item" role="menuitem">
-            CSS Components
-          </a>
-          <a href="//zendeskgarden.github.io/react-components/" class="c-menu__item" role="menuitem">
-            React Components
-          </a>
-        </ul>
+        <div class="menu-container u-1/1">
+          <ul aria-hidden="true" class="c-menu c-menu--down c-menu--sm" role="menu">
+            <a href="//zendeskgarden.github.io/assets/" class="c-menu__item" role="menuitem">
+              Assets
+            </a>
+            <a href="/css-components" class="c-menu__item" role="menuitem">
+              CSS Components
+            </a>
+            <a href="//zendeskgarden.github.io/react-components/" class="c-menu__item" role="menuitem">
+              React Components
+            </a>
+          </ul>
+        </div>
       </li>
     </ul>
   </header>

--- a/demo/menus/index.html
+++ b/demo/menus/index.html
@@ -62,26 +62,28 @@
             <use xlink:href="../index.svg#zd-svg-icon-14-chevron">
           </svg>
         </a>
-        <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
-          <li class="c-menu__item" role="menuitem">
-            <fieldset class="c-chk">
-              <input class="c-chk__input js-rtl" id="nav.ctl.rtl" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.rtl">RTL</label>
-            </fieldset>
-          </li>
-          <li class="c-menu__item" role="menuitem">
-            <fieldset class="c-chk">
-              <input class="c-chk__input js-custom" id="nav.ctl.custom" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.custom">Custom</label>
-            </fieldset>
-          </li>
-          <li class="c-menu__item" role="menuitem">
-            <fieldset class="c-chk">
-              <input class="c-chk__input js-size" id="nav.ctl.size" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.size">Size</label>
-            </fieldset>
-          </li>
-        </ul>
+        <div class="menu-container u-1/1">
+          <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
+            <li class="c-menu__item" role="menuitem">
+              <fieldset class="c-chk">
+                <input class="c-chk__input js-rtl" id="nav.ctl.rtl" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.rtl">RTL</label>
+              </fieldset>
+            </li>
+            <li class="c-menu__item" role="menuitem">
+              <fieldset class="c-chk">
+                <input class="c-chk__input js-custom" id="nav.ctl.custom" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.custom">Custom</label>
+              </fieldset>
+            </li>
+            <li class="c-menu__item" role="menuitem">
+              <fieldset class="c-chk">
+                <input class="c-chk__input js-size" id="nav.ctl.size" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.size">Size</label>
+              </fieldset>
+            </li>
+          </ul>
+        </div>
       </li>
     </ul>
   </header>
@@ -141,13 +143,11 @@
                   <code class="c-code">.c-menu.c-menu--down</code>
                 </button>
                 <div class="menu-container">
-                  <div class="menu-view">
-                    <ul aria-hidden="true" class="c-arrow c-arrow--t c-menu c-menu--down">
-                      <li class="c-menu__item">One</li>
-                      <li class="c-menu__item">Two</li>
-                      <li class="c-menu__item">Three</li>
-                    </ul>
-                  </div>
+                  <ul aria-hidden="true" class="c-arrow c-arrow--t c-menu c-menu--down">
+                    <li class="c-menu__item">One</li>
+                    <li class="c-menu__item">Two</li>
+                    <li class="c-menu__item">Three</li>
+                  </ul>
                 </div>
               </div>
             </div
@@ -160,13 +160,11 @@
                   <code class="c-code">.c-menu.c-menu--right</code>
                 </button>
                 <div class="menu-container">
-                  <div class="menu-view">
-                    <ul aria-hidden="true" class="c-arrow c-arrow--l c-menu c-menu--right">
-                      <li class="c-menu__item">One</li>
-                      <li class="c-menu__item">Two</li>
-                      <li class="c-menu__item">Three</li>
-                    </ul>
-                  </div>
+                  <ul aria-hidden="true" class="c-arrow c-arrow--l c-menu c-menu--right">
+                    <li class="c-menu__item">One</li>
+                    <li class="c-menu__item">Two</li>
+                    <li class="c-menu__item">Three</li>
+                  </ul>
                 </div>
               </div>
             </div
@@ -177,13 +175,11 @@
                   <code class="c-code">.c-menu.c-menu--left</code>
                 </button>
                 <div class="menu-container">
-                  <div class="menu-view">
-                    <ul aria-hidden="true" class="c-arrow c-arrow--r c-menu c-menu--left">
-                      <li class="c-menu__item">One</li>
-                      <li class="c-menu__item">Two</li>
-                      <li class="c-menu__item">Three</li>
-                    </ul>
-                  </div>
+                  <ul aria-hidden="true" class="c-arrow c-arrow--r c-menu c-menu--left">
+                    <li class="c-menu__item">One</li>
+                    <li class="c-menu__item">Two</li>
+                    <li class="c-menu__item">Three</li>
+                  </ul>
                 </div>
               </div>
             </div>
@@ -196,13 +192,11 @@
                   <code class="c-code">.c-menu.c-menu--up</code>
                 </button>
                 <div class="menu-container">
-                  <div class="menu-view">
-                    <ul aria-hidden="true" class="c-arrow c-arrow--b c-menu c-menu--up">
-                      <li class="c-menu__item">One</li>
-                      <li class="c-menu__item">Two</li>
-                      <li class="c-menu__item">Three</li>
-                    </ul>
-                  </div>
+                  <ul aria-hidden="true" class="c-arrow c-arrow--b c-menu c-menu--up">
+                    <li class="c-menu__item">One</li>
+                    <li class="c-menu__item">Two</li>
+                    <li class="c-menu__item">Three</li>
+                  </ul>
                 </div>
               </div>
             </div

--- a/demo/menus/index.html
+++ b/demo/menus/index.html
@@ -18,33 +18,24 @@
   <link href="custom.css" rel="stylesheet">
   <link href="../utilities/index.css" rel="stylesheet">
   <style>
-  .c-arrow--b,
-  .c-arrow--t {
-    left: calc(50% - 90px);
-  }
-
   .c-arrow--b {
-    bottom: calc(100% + 2px);
+    margin-bottom: 2px;
   }
 
   .c-arrow--t {
-    top: calc(100% + 2px);
-  }
-
-  .c-arrow--l,
-  .c-arrow--r {
-    top: -52px;
-  }
-
-  .c-arrow--l {
-    left: calc(100% + 2px);
-  }
-
-  .c-arrow--r {
-    right: calc(100% + 2px);
+    margin-top: 2px;
   }
 
   .u-mb-xxl { margin-bottom: 140px !important; }
+
+  .menu-container .c-menu {
+    position: relative;
+  }
+
+  .menu-container {
+    transform: translateZ(0);
+    position: absolute;
+  }
   </style>
 </head>
 <body>
@@ -149,11 +140,15 @@
                 <button class="c-btn c-btn--full js-menu">
                   <code class="c-code">.c-menu.c-menu--down</code>
                 </button>
-                <ul aria-hidden="true" class="c-arrow c-arrow--t c-menu c-menu--down">
-                  <li class="c-menu__item">One</li>
-                  <li class="c-menu__item">Two</li>
-                  <li class="c-menu__item">Three</li>
-                </ul>
+                <div class="menu-container">
+                  <div class="menu-view">
+                    <ul aria-hidden="true" class="c-arrow c-arrow--t c-menu c-menu--down">
+                      <li class="c-menu__item">One</li>
+                      <li class="c-menu__item">Two</li>
+                      <li class="c-menu__item">Three</li>
+                    </ul>
+                  </div>
+                </div>
               </div>
             </div
             ><div class="l-grid__item u-1/3"></div>
@@ -164,11 +159,15 @@
                 <button class="c-btn c-btn--full js-menu">
                   <code class="c-code">.c-menu.c-menu--right</code>
                 </button>
-                <ul aria-hidden="true" class="c-arrow c-arrow--l c-menu c-menu--right">
-                  <li class="c-menu__item">One</li>
-                  <li class="c-menu__item">Two</li>
-                  <li class="c-menu__item">Three</li>
-                </ul>
+                <div class="menu-container">
+                  <div class="menu-view">
+                    <ul aria-hidden="true" class="c-arrow c-arrow--l c-menu c-menu--right">
+                      <li class="c-menu__item">One</li>
+                      <li class="c-menu__item">Two</li>
+                      <li class="c-menu__item">Three</li>
+                    </ul>
+                  </div>
+                </div>
               </div>
             </div
             ><div class="l-grid__item u-1/3"></div
@@ -177,11 +176,15 @@
                 <button class="c-btn c-btn--full js-menu">
                   <code class="c-code">.c-menu.c-menu--left</code>
                 </button>
-                <ul aria-hidden="true" class="c-arrow c-arrow--r c-menu c-menu--left">
-                  <li class="c-menu__item">One</li>
-                  <li class="c-menu__item">Two</li>
-                  <li class="c-menu__item">Three</li>
-                </ul>
+                <div class="menu-container">
+                  <div class="menu-view">
+                    <ul aria-hidden="true" class="c-arrow c-arrow--r c-menu c-menu--left">
+                      <li class="c-menu__item">One</li>
+                      <li class="c-menu__item">Two</li>
+                      <li class="c-menu__item">Three</li>
+                    </ul>
+                  </div>
+                </div>
               </div>
             </div>
           </div>
@@ -192,11 +195,15 @@
                 <button class="c-btn c-btn--full js-menu">
                   <code class="c-code">.c-menu.c-menu--up</code>
                 </button>
-                <ul aria-hidden="true" class="c-arrow c-arrow--b c-menu c-menu--up">
-                  <li class="c-menu__item">One</li>
-                  <li class="c-menu__item">Two</li>
-                  <li class="c-menu__item">Three</li>
-                </ul>
+                <div class="menu-container">
+                  <div class="menu-view">
+                    <ul aria-hidden="true" class="c-arrow c-arrow--b c-menu c-menu--up">
+                      <li class="c-menu__item">One</li>
+                      <li class="c-menu__item">Two</li>
+                      <li class="c-menu__item">Three</li>
+                    </ul>
+                  </div>
+                </div>
               </div>
             </div
             ><div class="l-grid__item u-1/3"></div>

--- a/demo/menus/index.js
+++ b/demo/menus/index.js
@@ -33,20 +33,51 @@ $(document).ready(function() {
 
     if ($menu.hasClass('c-menu--right')) {
       var x = $width + 2;
-      $popper.css('transform', 'translate3d(' + x + 'px, -89px, 0)');
+
+      if (!$popper.closest('.c-table__row__cell--overflow').length) {
+        $popper.css('transform', 'translate3d(' + x + 'px, -89px, 0)');
+      }
     }
     if ($menu.hasClass('c-menu--left')) {
       var x = $menuWidth + 2;
-      $popper.css('transform', 'translate3d(' + -x + 'px, -89px, 0)');
+
+      if (!$popper.closest('.c-table__row__cell--overflow').length) {
+        $popper.css('transform', 'translate3d(' + -x + 'px, -89px, 0)');
+      }
     }
     if ($menu.hasClass('c-menu--up')) {
       var x = $width / 2 - $menuWidth / 2;
       var y = $menu.outerHeight() + $this.outerHeight() + 2;
-      $popper.css('transform', 'translate3d(' + x + 'px, ' + -y + 'px, 0)');
+
+      if ($this.hasClass('js-menu--split')) {
+        x = 0;
+        y = $menu.outerHeight() + $this.outerHeight() + 4;
+      }
+
+      if (!$popper.closest('.c-table__row__cell--overflow').length) {
+        $popper.css('transform', 'translate3d(' + x + 'px, ' + -y + 'px, 0)');
+      }
     }
     if ($menu.hasClass('c-menu--down')) {
-      var x = $width / 2 - $menuWidth / 2;
-      $popper.css('transform', 'translate3d(' + x + 'px, 0, 0)');
+      var x = Math.max($width / 2 - $menuWidth / 2, 0); // Avoid negative numbers
+
+      if (!$popper.closest('.c-table__row__cell--overflow').length) {
+        $popper.css('transform', 'translate3d(' + x + 'px, 0, 0)');
+      } else {
+        // Same as css calc(2em + 1px)
+        var y = $this.outerHeight() + 1;
+
+        // Special treatment here for overflow button in tables
+        // since the icon is a pseudo element we need to hint to
+        // the menu what the "real" y position is and clean up
+        // on animationend so as not to mess with table styles
+        if (!$menu.hasClass('is-open')) {
+          $popper.css('transform', 'translateY(' + y + 'px)');
+          $popper.one('animationend', function() {
+            $popper.css('transform', '');
+          });
+        }
+      }
     }
 
     if ($menu.hasClass('is-open')) {

--- a/demo/menus/index.js
+++ b/demo/menus/index.js
@@ -9,17 +9,45 @@ $(document).ready(function() {
 
   $(document).on('click', '.c-menu__item', function(event) {
     if (event.target === event.currentTarget) {
-      $(this).find('.c-chk__input').click();
+      $(this)
+        .find('.c-chk__input')
+        .click();
     }
   });
 
-  $(document).on('click', '.c-menu__item:not(.is-disabled):not(.c-menu__item--header):not(.c-ctl .c-menu__item)', function() {
-    $(this).toggleClass('is-checked');
-  });
+  $(document).on(
+    'click',
+    '.c-menu__item:not(.is-disabled):not(.c-menu__item--header):not(.c-ctl .c-menu__item)',
+    function() {
+      $(this).toggleClass('is-checked');
+    }
+  );
 
   $(document).on('click', '.js-menu', function() {
     var $this = $(this);
+    var $pos = $this.offset();
+    var $width = $this.outerWidth();
     var $menu = $this.parent().find('.c-menu');
+    var $menuWidth = $menu.outerWidth();
+    var $popper = $this.parent().find('.menu-container');
+
+    if ($menu.hasClass('c-menu--right')) {
+      var x = $width + 2;
+      $popper.css('transform', 'translate3d(' + x + 'px, -89px, 0)');
+    }
+    if ($menu.hasClass('c-menu--left')) {
+      var x = $menuWidth + 2;
+      $popper.css('transform', 'translate3d(' + -x + 'px, -89px, 0)');
+    }
+    if ($menu.hasClass('c-menu--up')) {
+      var x = $width / 2 - $menuWidth / 2;
+      var y = $menu.outerHeight() + $this.outerHeight() + 2;
+      $popper.css('transform', 'translate3d(' + x + 'px, ' + -y + 'px, 0)');
+    }
+    if ($menu.hasClass('c-menu--down')) {
+      var x = $width / 2 - $menuWidth / 2;
+      $popper.css('transform', 'translate3d(' + x + 'px, 0, 0)');
+    }
 
     if ($menu.hasClass('is-open')) {
       $(document).trigger('click');
@@ -34,10 +62,15 @@ $(document).ready(function() {
   });
 
   $(document).click(function() {
-    $('.c-menu').removeClass('is-open').each(function() {
-      this.offsetHeight; // trigger reflow
-    }).attr('aria-hidden', true);
+    $('.c-menu')
+      .removeClass('is-open')
+      .each(function() {
+        this.offsetHeight; // trigger reflow
+      })
+      .attr('aria-hidden', true);
     $('.js-menu').removeClass('is-active');
-    $('.js-menu').children('.c-btn__icon').removeClass('is-rotated');
+    $('.js-menu')
+      .children('.c-btn__icon')
+      .removeClass('is-rotated');
   });
 });

--- a/demo/pagination/index.html
+++ b/demo/pagination/index.html
@@ -16,6 +16,12 @@
   <link href="index.css" rel="stylesheet">
   <link href="custom.css" rel="stylesheet">
   <link href="../utilities/index.css" rel="stylesheet">
+  <style>
+  .menu-container {
+    transform: translateZ(0);
+    position: absolute;
+  }
+  </style>
 </head>
 <body>
   <header class="c-header">
@@ -41,20 +47,22 @@
             <use xlink:href="../index.svg#zd-svg-icon-14-chevron" />
           </svg>
         </a>
-        <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
-          <li class="c-menu__item" role="menuitem">
-            <fieldset class="c-chk">
-              <input class="c-chk__input js-rtl" id="nav.ctl.rtl" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.rtl">RTL</label>
-            </fieldset>
-          </li>
-          <li class="c-menu__item" role="menuitem">
-            <fieldset class="c-chk">
-              <input class="c-chk__input js-custom" id="nav.ctl.custom" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.custom">Custom</label>
-            </fieldset>
-          </li>
-        </ul>
+        <div class="menu-container u-1/1">
+          <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
+            <li class="c-menu__item" role="menuitem">
+              <fieldset class="c-chk">
+                <input class="c-chk__input js-rtl" id="nav.ctl.rtl" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.rtl">RTL</label>
+              </fieldset>
+            </li>
+            <li class="c-menu__item" role="menuitem">
+              <fieldset class="c-chk">
+                <input class="c-chk__input js-custom" id="nav.ctl.custom" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.custom">Custom</label>
+              </fieldset>
+            </li>
+          </ul>
+        </div>
       </li>
     </ul>
   </header>

--- a/demo/tables/index.html
+++ b/demo/tables/index.html
@@ -24,6 +24,14 @@
     height: 1em;
     vertical-align: middle;
   }
+
+  .menu-container {
+    transform: translateZ(0);
+    position: absolute;
+  }
+  .c-table .menu-container {
+    top: 0;
+  }
   </style>
 </head>
 <body>
@@ -50,43 +58,45 @@
             <use xlink:href="../index.svg#zd-svg-icon-14-chevron" />
           </svg>
         </a>
-        <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
-          <li class="c-menu__item" role="menuitem">
-            <fieldset class="c-chk">
-              <input class="c-chk__input js-rtl" id="nav.ctl.rtl" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.rtl">RTL</label>
-            </fieldset>
-          </li>
-          <li class="c-menu__item" role="menuitem">
-            <fieldset class="c-chk">
-              <input class="c-chk__input js-custom" id="nav.ctl.custom" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.custom">Custom</label>
-            </fieldset>
-          </li>
-          <li class="c-menu__item" role="menuitem">
-            <div class="u-mb">Display Density</div>
-            <div class="u-ml">
-              <fieldset class="c-chk c-chk--radio">
-                <input class="c-chk__input js-display" id="nav.ctl.display.small" name="nav.ctl.display" type="radio" value="sm">
-                <label class="c-chk__label" for="nav.ctl.display.small">Cozy</label>
+        <div class="menu-container u-1/1">
+          <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
+            <li class="c-menu__item" role="menuitem">
+              <fieldset class="c-chk">
+                <input class="c-chk__input js-rtl" id="nav.ctl.rtl" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.rtl">RTL</label>
               </fieldset>
-              <fieldset class="c-chk c-chk--radio">
-                <input class="c-chk__input js-display" id="nav.ctl.display.default" name="nav.ctl.display" checked type="radio" value="">
-                <label class="c-chk__label" for="nav.ctl.display.default">Comfortable</label>
+            </li>
+            <li class="c-menu__item" role="menuitem">
+              <fieldset class="c-chk">
+                <input class="c-chk__input js-custom" id="nav.ctl.custom" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.custom">Custom</label>
               </fieldset>
-              <fieldset class="c-chk c-chk--radio">
-                <input class="c-chk__input js-display" id="nav.ctl.display.large" name="nav.ctl.display" type="radio" value="lg">
-                <label class="c-chk__label" for="nav.ctl.display.large">Airy</label>
+            </li>
+            <li class="c-menu__item" role="menuitem">
+              <div class="u-mb">Display Density</div>
+              <div class="u-ml">
+                <fieldset class="c-chk c-chk--radio">
+                  <input class="c-chk__input js-display" id="nav.ctl.display.small" name="nav.ctl.display" type="radio" value="sm">
+                  <label class="c-chk__label" for="nav.ctl.display.small">Cozy</label>
+                </fieldset>
+                <fieldset class="c-chk c-chk--radio">
+                  <input class="c-chk__input js-display" id="nav.ctl.display.default" name="nav.ctl.display" checked type="radio" value="">
+                  <label class="c-chk__label" for="nav.ctl.display.default">Comfortable</label>
+                </fieldset>
+                <fieldset class="c-chk c-chk--radio">
+                  <input class="c-chk__input js-display" id="nav.ctl.display.large" name="nav.ctl.display" type="radio" value="lg">
+                  <label class="c-chk__label" for="nav.ctl.display.large">Airy</label>
+                </fieldset>
+              </div>
+            </li>
+            <li class="c-menu__item" role="menuitem">
+              <fieldset class="c-chk">
+                <input class="c-chk__input js-stripes" id="nav.ctl.stripes" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.stripes">Zebra Stripes</label>
               </fieldset>
-            </div>
-          </li>
-          <li class="c-menu__item" role="menuitem">
-            <fieldset class="c-chk">
-              <input class="c-chk__input js-stripes" id="nav.ctl.stripes" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.stripes">Zebra Stripes</label>
-            </fieldset>
-          </li>
-        </ul>
+            </li>
+          </ul>
+        </div>
   </header>
   <main class="c-main c-main--page">
     <a href="https://github.com/zendeskgarden/css-components/tree/master/packages/tables"><img class="u-float-right u-ml-sm u-mt-sm" src="../github.svg"></a>
@@ -214,11 +224,13 @@
               probably haven't heard of them.</td>
             <td class="c-table__row__cell c-table__row__cell--overflow">
               <div class="c-table__row__cell__overflow js-menu" tabindex="0">
-                <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
-                  <li class="c-menu__item" role="menuitem">One</li>
-                  <li class="c-menu__item" role="menuitem">Two</li>
-                  <li class="c-menu__item" role="menuitem">Three</li>
-                </ul>
+                <div class="menu-container">
+                  <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
+                    <li class="c-menu__item" role="menuitem">One</li>
+                    <li class="c-menu__item" role="menuitem">Two</li>
+                    <li class="c-menu__item" role="menuitem">Three</li>
+                  </ul>
+                </div>
               </div>
             </td>
           </tr>
@@ -229,11 +241,13 @@
               vegan paleo occupy you probably haven't heard of them.</td>
             <td class="c-table__row__cell c-table__row__cell--overflow">
               <div class="c-table__row__cell__overflow js-menu" tabindex="0">
-                <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
-                  <li class="c-menu__item" role="menuitem">One</li>
-                  <li class="c-menu__item" role="menuitem">Two</li>
-                  <li class="c-menu__item" role="menuitem">Three</li>
-                </ul>
+                <div class="menu-container">
+                  <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
+                    <li class="c-menu__item" role="menuitem">One</li>
+                    <li class="c-menu__item" role="menuitem">Two</li>
+                    <li class="c-menu__item" role="menuitem">Three</li>
+                  </ul>
+                </div>
               </div>
             </td>
           </tr>
@@ -334,11 +348,13 @@
               <th class="c-table__row__cell">TH, C4</th>
               <th class="c-table__row__cell c-table__row__cell--overflow">
                 <div class="c-table__row__cell__overflow js-menu" tabindex="0">
-                  <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
-                    <li class="c-menu__item" role="menuitem">One</li>
-                    <li class="c-menu__item" role="menuitem">Two</li>
-                    <li class="c-menu__item" role="menuitem">Three</li>
-                  </ul>
+                  <div class="menu-container">
+                    <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
+                      <li class="c-menu__item" role="menuitem">One</li>
+                      <li class="c-menu__item" role="menuitem">Two</li>
+                      <li class="c-menu__item" role="menuitem">Three</li>
+                    </ul>
+                  </div>
                 </div>
               </th>
             </tr>
@@ -352,11 +368,13 @@
               <td class="c-table__row__cell">R0, C4</td>
               <td class="c-table__row__cell c-table__row__cell--overflow">
                 <div class="c-table__row__cell__overflow js-menu" tabindex="0">
-                  <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
-                    <li class="c-menu__item" role="menuitem">One</li>
-                    <li class="c-menu__item" role="menuitem">Two</li>
-                    <li class="c-menu__item" role="menuitem">Three</li>
-                  </ul>
+                  <div class="menu-container">
+                    <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
+                      <li class="c-menu__item" role="menuitem">One</li>
+                      <li class="c-menu__item" role="menuitem">Two</li>
+                      <li class="c-menu__item" role="menuitem">Three</li>
+                    </ul>
+                  </div>
                 </div>
               </td>
             </tr>
@@ -368,11 +386,13 @@
               <td class="c-table__row__cell">R1, C4</td>
               <td class="c-table__row__cell c-table__row__cell--overflow">
                 <div class="c-table__row__cell__overflow js-menu" tabindex="0">
-                  <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
-                    <li class="c-menu__item" role="menuitem">One</li>
-                    <li class="c-menu__item" role="menuitem">Two</li>
-                    <li class="c-menu__item" role="menuitem">Three</li>
-                  </ul>
+                  <div class="menu-container">
+                    <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
+                      <li class="c-menu__item" role="menuitem">One</li>
+                      <li class="c-menu__item" role="menuitem">Two</li>
+                      <li class="c-menu__item" role="menuitem">Three</li>
+                    </ul>
+                  </div>
                 </div>
               </td>
             </tr>
@@ -384,11 +404,13 @@
               <td class="c-table__row__cell">R2, C4</td>
               <td class="c-table__row__cell c-table__row__cell--overflow">
                 <div class="c-table__row__cell__overflow js-menu" tabindex="0">
-                  <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
-                    <li class="c-menu__item" role="menuitem">One</li>
-                    <li class="c-menu__item" role="menuitem">Two</li>
-                    <li class="c-menu__item" role="menuitem">Three</li>
-                  </ul>
+                  <div class="menu-container">
+                    <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
+                      <li class="c-menu__item" role="menuitem">One</li>
+                      <li class="c-menu__item" role="menuitem">Two</li>
+                      <li class="c-menu__item" role="menuitem">Three</li>
+                    </ul>
+                  </div>
                 </div>
               </td>
             </tr>
@@ -510,11 +532,13 @@
       <th class="c-table__row__cell c-table__row__cell--truncate">Header 3</th>
       <th class="c-table__row__cell c-table__row__cell--overflow">
         <button aria-haspopup="true" class="c-table__row__cell__overflow js-menu" type="button">
-          <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
-            <li class="c-menu__item" role="menuitem">One</li>
-            <li class="c-menu__item" role="menuitem">Two</li>
-            <li class="c-menu__item" role="menuitem">Three</li>
-          </ul>
+          <div class="menu-container">
+            <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
+              <li class="c-menu__item" role="menuitem">One</li>
+              <li class="c-menu__item" role="menuitem">Two</li>
+              <li class="c-menu__item" role="menuitem">Three</li>
+            </ul>
+          </div>
         </button>
       </th>
     </tr>
@@ -535,11 +559,13 @@
       <td class="c-table__row__cell">Row 1, Column 3</td>
       <td class="c-table__row__cell c-table__row__cell--overflow">
         <button aria-haspopup="true" class="c-table__row__cell__overflow js-menu" type="button">
-          <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
-            <li class="c-menu__item" role="menuitem">One</li>
-            <li class="c-menu__item" role="menuitem">Two</li>
-            <li class="c-menu__item" role="menuitem">Three</li>
-          </ul>
+          <div class="menu-container">
+            <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
+              <li class="c-menu__item" role="menuitem">One</li>
+              <li class="c-menu__item" role="menuitem">Two</li>
+              <li class="c-menu__item" role="menuitem">Three</li>
+            </ul>
+          </div>
         </button>
       </td>
     </tr>
@@ -555,11 +581,13 @@
       <td class="c-table__row__cell">Row 2, Column 3</td>
       <td class="c-table__row__cell c-table__row__cell--overflow">
         <button aria-haspopup="true" class="c-table__row__cell__overflow js-menu" type="button">
-          <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
-            <li class="c-menu__item" role="menuitem">One</li>
-            <li class="c-menu__item" role="menuitem">Two</li>
-            <li class="c-menu__item" role="menuitem">Three</li>
-          </ul>
+          <div class="menu-container">
+            <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
+              <li class="c-menu__item" role="menuitem">One</li>
+              <li class="c-menu__item" role="menuitem">Two</li>
+              <li class="c-menu__item" role="menuitem">Three</li>
+            </ul>
+          </div>
         </button>
       </td>
     </tr>
@@ -578,11 +606,13 @@
       <td class="c-table__row__cell">Row 3, Column 3</td>
       <td class="c-table__row__cell c-table__row__cell--overflow">
         <button aria-haspopup="true" class="c-table__row__cell__overflow js-menu" type="button">
-          <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
-            <li class="c-menu__item" role="menuitem">One</li>
-            <li class="c-menu__item" role="menuitem">Two</li>
-            <li class="c-menu__item" role="menuitem">Three</li>
-          </ul>
+          <div class="menu-container">
+            <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
+              <li class="c-menu__item" role="menuitem">One</li>
+              <li class="c-menu__item" role="menuitem">Two</li>
+              <li class="c-menu__item" role="menuitem">Three</li>
+            </ul>
+          </div>
         </button>
       </td>
     </tr>
@@ -598,11 +628,13 @@
       <td class="c-table__row__cell">Row 4, Column 3</td>
       <td class="c-table__row__cell c-table__row__cell--overflow">
         <button aria-haspopup="true" class="c-table__row__cell__overflow js-menu" type="button">
-          <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
-            <li class="c-menu__item" role="menuitem">One</li>
-            <li class="c-menu__item" role="menuitem">Two</li>
-            <li class="c-menu__item" role="menuitem">Three</li>
-          </ul>
+          <div class="menu-container">
+            <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
+              <li class="c-menu__item" role="menuitem">One</li>
+              <li class="c-menu__item" role="menuitem">Two</li>
+              <li class="c-menu__item" role="menuitem">Three</li>
+            </ul>
+          </div>
         </button>
       </td>
     </tr>
@@ -618,11 +650,13 @@
       <td class="c-table__row__cell">Row 5, Column 3</td>
       <td class="c-table__row__cell c-table__row__cell--overflow">
         <button aria-haspopup="true" class="c-table__row__cell__overflow js-menu" type="button">
-          <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
-            <li class="c-menu__item" role="menuitem">One</li>
-            <li class="c-menu__item" role="menuitem">Two</li>
-            <li class="c-menu__item" role="menuitem">Three</li>
-          </ul>
+          <div class="menu-container">
+            <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
+              <li class="c-menu__item" role="menuitem">One</li>
+              <li class="c-menu__item" role="menuitem">Two</li>
+              <li class="c-menu__item" role="menuitem">Three</li>
+            </ul>
+          </div>
         </button>
       </td>
     </tr>

--- a/demo/tabs/index.html
+++ b/demo/tabs/index.html
@@ -16,6 +16,12 @@
   <link href="index.css" rel="stylesheet">
   <link href="custom.css" rel="stylesheet">
   <link href="../utilities/index.css" rel="stylesheet">
+  <style>
+  .menu-container {
+    transform: translateZ(0);
+    position: absolute;
+  }
+  </style>
 </head>
 <body>
   <header class="c-header">
@@ -41,20 +47,22 @@
             <use xlink:href="../index.svg#zd-svg-icon-14-chevron">
           </svg>
         </a>
-        <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
-          <li class="c-menu__item" role="menuitem">
-            <fieldset class="c-chk">
-              <input class="c-chk__input js-rtl" id="nav.ctl.rtl" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.rtl">RTL</label>
-            </fieldset>
-          </li>
-          <li class="c-menu__item" role="menuitem">
-            <fieldset class="c-chk">
-              <input class="c-chk__input js-custom" id="nav.ctl.custom" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.custom">Custom</label>
-            </fieldset>
-          </li>
-        </ul>
+        <div class="menu-container u-1/1">
+          <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
+            <li class="c-menu__item" role="menuitem">
+              <fieldset class="c-chk">
+                <input class="c-chk__input js-rtl" id="nav.ctl.rtl" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.rtl">RTL</label>
+              </fieldset>
+            </li>
+            <li class="c-menu__item" role="menuitem">
+              <fieldset class="c-chk">
+                <input class="c-chk__input js-custom" id="nav.ctl.custom" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.custom">Custom</label>
+              </fieldset>
+            </li>
+          </ul>
+        </div>
       </li>
     </ul>
   </header>

--- a/demo/tags/index.html
+++ b/demo/tags/index.html
@@ -20,6 +20,11 @@
   <link href="../utilities/index.css" rel="stylesheet">
   <style>
   .c-txt__input .c-tag { min-width: 75px; }
+
+  .menu-container {
+    transform: translateZ(0);
+    position: absolute;
+  }
   </style>
 </head>
 <body>
@@ -46,20 +51,22 @@
             <use xlink:href="../index.svg#zd-svg-icon-14-chevron">
           </svg>
         </a>
-        <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
-          <li class="c-menu__item" role="menuitem">
-            <fieldset class="c-chk">
-              <input class="c-chk__input js-rtl" id="nav.ctl.rtl" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.rtl">RTL</label>
-            </fieldset>
-          </li>
-          <li class="c-menu__item" role="menuitem">
-            <fieldset class="c-chk">
-              <input class="c-chk__input js-custom" id="nav.ctl.custom" type="checkbox">
-              <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.custom">Custom</label>
-            </fieldset>
-          </li>
-        </ul>
+        <div class="menu-container u-1/1">
+          <ul aria-hidden="true" class="c-menu c-menu--down" role="menu">
+            <li class="c-menu__item" role="menuitem">
+              <fieldset class="c-chk">
+                <input class="c-chk__input js-rtl" id="nav.ctl.rtl" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.rtl">RTL</label>
+              </fieldset>
+            </li>
+            <li class="c-menu__item" role="menuitem">
+              <fieldset class="c-chk">
+                <input class="c-chk__input js-custom" id="nav.ctl.custom" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.custom">Custom</label>
+              </fieldset>
+            </li>
+          </ul>
+        </div>
       </li>
     </ul>
   </header>

--- a/packages/menus/src/_keyframes.css
+++ b/packages/menus/src/_keyframes.css
@@ -5,11 +5,11 @@
 
 @keyframes zd-menu--up-open {
   0% {
-    margin-bottom: var(--zd-menu-open-margin);
+    bottom: var(--zd-menu-open-margin);
   }
 
   100% {
-    margin-bottom: 0;
+    bottom: 0;
   }
 }
 
@@ -21,11 +21,11 @@
 
 @keyframes zd-menu--right-open {
   0% {
-    margin-left: var(--zd-menu-open-margin);
+    left: var(--zd-menu-open-margin);
   }
 
   100% {
-    margin-left: 0;
+    left: 0;
   }
 }
 
@@ -37,11 +37,11 @@
 
 @keyframes zd-menu--down-open {
   0% {
-    margin-top: var(--zd-menu-open-margin);
+    top: var(--zd-menu-open-margin);
   }
 
   100% {
-    margin-top: 0;
+    top: 0;
   }
 }
 
@@ -53,11 +53,11 @@
 
 @keyframes zd-menu--left-open {
   0% {
-    margin-right: var(--zd-menu-open-margin);
+    right: var(--zd-menu-open-margin);
   }
 
   100% {
-    margin-right: 0;
+    right: 0;
   }
 }
 


### PR DESCRIPTION
## Description

This PR is the first step to allow support for top and left animations to work correctly with popper.js in our select & menu components.

## Detail

The real change is just using top, left, right & bottom instead of margins. 

Popper positions the element using a transform so top, left, right & bottom are relative to that gpu layer and not to the document.

![menus-anim](https://user-images.githubusercontent.com/143402/49982158-4e21d580-ffaf-11e8-8855-ac8f3332f720.gif)

### react-menus

Here's this running locally for react-menus

![react-menus-anim](https://user-images.githubusercontent.com/143402/49982362-52022780-ffb0-11e8-8180-52c65b3f9dea.gif)

### Less important stuff

I added a .prettierrc file that matches react-components.

The demo page needed some changes to support working with the new usage of position properties over using margins to emulate what popper would do.

## Checklist

* [ ] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
