### PR TITLE
fix(breadcrumbs): inherit current link color on hover/focus

### DIFF
--- a/packages/breadcrumbs/src/_state.css
+++ b/packages/breadcrumbs/src/_state.css
@@ -8,6 +8,10 @@
   color: var(--zd-breadcrumb__item--current-color);
 }
 
-.c-breadcrumb__item.is-current > :any-link {
+/* stylelint-disable selector-max-specificity */
+.c-breadcrumb__item.is-current > :any-link,
+.c-breadcrumb__item.is-current > :any-link:hover,
+.c-breadcrumb__item.is-current > :any-link:focus {
   color: inherit;
 }
+/* stylelint-enable selector-max-specificity */


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
