### PR TITLE
feat(buttons|forms): add `--focus-inset` styling variant

### DIFF
--- a/demo/arrows/index.html
+++ b/demo/arrows/index.html
@@ -19,11 +19,6 @@
   .c-arrow.u-visibility-visible:before,
   .c-arrow.u-visibility-visible:after { display: inline-block !important; }
   .u-z-index-0 { z-index: 0 !important; }
-
-  .menu-container {
-    transform: translateZ(0);
-    position: absolute;
-  }
   </style>
 </head>
 <body>

--- a/demo/buttons/index.html
+++ b/demo/buttons/index.html
@@ -16,20 +16,6 @@
   <link href="index.css" rel="stylesheet">
   <link href="custom.css" rel="stylesheet">
   <link href="../utilities/index.css" rel="stylesheet">
-  <style>
-  .c-ctl__item .menu-container .c-menu {
-    position: absolute;
-  }
-
-  .menu-container .c-menu {
-    position: relative;
-  }
-
-  .menu-container {
-    transform: translateZ(0);
-    position: absolute;
-  }
-  </style>
 </head>
 <body>
   <header class="c-header">

--- a/demo/buttons/index.html
+++ b/demo/buttons/index.html
@@ -17,6 +17,10 @@
   <link href="custom.css" rel="stylesheet">
   <link href="../utilities/index.css" rel="stylesheet">
   <style>
+  .c-ctl__item .menu-container .c-menu {
+    position: absolute;
+  }
+
   .menu-container .c-menu {
     position: relative;
   }
@@ -64,6 +68,12 @@
                 <input class="c-chk__input js-custom" id="nav.ctl.custom" type="checkbox">
                 <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.custom">Custom</label>
               </fieldset>
+            </li>
+            <li class="c-menu__item" role="menuitem">
+              <div class="c-chk">
+                <input class="c-chk__input js-inset" id="nav.ctl.inset" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.inset">Inset Focus</label>
+              </div>
             </li>
           </ul>
         </div>

--- a/demo/buttons/index.js
+++ b/demo/buttons/index.js
@@ -4,6 +4,10 @@ $(document).ready(function() {
   Garden.rtlClasses.push('.l-btn-group');
   Garden.handleFocus('.c-btn');
 
+  $('.js-inset').change(function() {
+    $('.c-btn').toggleClass('c-btn--focus-inset');
+  });
+
   $(document).on('click', '.l-btn-group[role=tablist] .c-btn:not(:disabled):not(.is-disabled)', function() {
     $(this).addClass('is-selected').siblings('.c-btn').removeClass('is-selected');
   });

--- a/demo/chrome/index.html
+++ b/demo/chrome/index.html
@@ -22,11 +22,6 @@
   .c-chrome--demo { height: 300px !important; }
 
   .u-list-style-disc { padding-left: 20px; }
-
-  .menu-container {
-    transform: translateZ(0);
-    position: absolute;
-  }
   </style>
 </head>
 <body>

--- a/demo/chrome/page.html
+++ b/demo/chrome/page.html
@@ -21,11 +21,6 @@
   <link href="../utilities/index.css" rel="stylesheet">
   <style>
   .c-chrome { min-height: 300px; }
-
-  .menu-container {
-    transform: translateZ(0);
-    position: absolute;
-  }
   </style>
 </head>
 <body class="c-chrome">

--- a/demo/forms/checkbox/index.html
+++ b/demo/forms/checkbox/index.html
@@ -17,11 +17,6 @@
   <link href="../../utilities/index.css" rel="stylesheet">
   <style>
   .l-wrapper { min-width: 1024px; }
-
-  .menu-container {
-    transform: translateZ(0);
-    position: absolute;
-  }
   </style>
 </head>
 <body>

--- a/demo/forms/dropdown/index.html
+++ b/demo/forms/dropdown/index.html
@@ -82,6 +82,12 @@
               </fieldset>
             </li>
             <li class="c-menu__item" role="menuitem">
+              <div class="c-chk">
+                <input class="c-chk__input js-inset" id="nav.ctl.inset" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.inset">Inset Focus</label>
+              </div>
+            </li>
+            <li class="c-menu__item" role="menuitem">
               <div class="u-mb">Validation</div>
               <div class="u-ml">
                 <fieldset class="c-chk">

--- a/demo/forms/dropdown/index.html
+++ b/demo/forms/dropdown/index.html
@@ -21,20 +21,11 @@
     width: 370px;
   }
 
-  .l-wrapper--370 { max-width: 370px; }
-
-  .menu-container--up {
-    position: absolute;
-    top: calc(1em + 4px);
-  }
-  .menu-container {
-    transform: translateZ(0);
-    position: absolute;
+  .c-main .menu-container {
     margin-top: 5px;
   }
-  .menu-container .c-menu--up {
-    bottom: 0;
-  }
+
+  .l-wrapper--370 { max-width: 370px; }
   </style>
 </head>
 <body>
@@ -144,18 +135,16 @@
           </div>
         </fieldset>
         <fieldset class="u-mb-lg u-position-relative">
-          <div class="menu-container--up">
-            <div class="menu-container u-1/1">
-              <ul aria-hidden="true" class="c-menu c-menu--up">
-                <li class="c-menu__item">one</li>
-                <li class="c-menu__item is-checked">two</li>
-                <li class="c-menu__item">three</li>
-              </ul>
-            </div>
-          </div>
           <div class="c-txt">
             <label class="c-txt__label" for="select-1">A ContentEditable &lt;div&gt; Dropdown</label>
             <div class="c-txt__input c-txt__input--select" contenteditable="true" id="select-1" tabindex="0">two</div>
+          </div>
+          <div class="menu-container u-1/1">
+            <ul aria-hidden="true" class="c-menu c-menu--down">
+              <li class="c-menu__item">one</li>
+              <li class="c-menu__item is-checked">two</li>
+              <li class="c-menu__item">three</li>
+            </ul>
           </div>
         </fieldset>
         <fieldset class="u-mb-lg u-position-relative">

--- a/demo/forms/range/index.html
+++ b/demo/forms/range/index.html
@@ -17,11 +17,6 @@
   <link href="../../utilities/index.css" rel="stylesheet">
   <style>
   .l-wrapper--400 { max-width: 400px; }
-
-  .menu-container {
-    transform: translateZ(0);
-    position: absolute;
-  }
   </style>
 </head>
 <body>

--- a/demo/forms/text/index.html
+++ b/demo/forms/text/index.html
@@ -19,11 +19,6 @@
   <link href="../../utilities/index.css" rel="stylesheet">
   <style>
   .l-wrapper--370 { max-width: 370px; }
-
-  .menu-container {
-    transform: translateZ(0);
-    position: absolute;
-  }
   </style>
 </head>
 <body>

--- a/demo/forms/text/index.html
+++ b/demo/forms/text/index.html
@@ -77,6 +77,12 @@
               </div>
             </li>
             <li class="c-menu__item" role="menuitem">
+              <div class="c-chk">
+                <input class="c-chk__input js-inset" id="nav.ctl.inset" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.inset">Inset Focus</label>
+              </div>
+            </li>
+            <li class="c-menu__item" role="menuitem">
               <div class="u-mb">Validation</div>
               <div class="u-ml">
                 <div class="c-chk">

--- a/demo/forms/text/index.js
+++ b/demo/forms/text/index.js
@@ -17,6 +17,10 @@ $(document).ready(function() {
     $('.c-txt__input:not(.c-playground .c-txt__input):not(.c-txt__input--media__body)').toggleClass('c-txt__input--bare');
   });
 
+  $('.js-inset').change(function() {
+    $('.c-txt__input:not(.c-playground .c-txt__input):not(.c-txt__input--media__body)').toggleClass('c-txt__input--focus-inset');
+  });
+
   $('.js-validation').change(function() {
     var value = $(this).val();
 

--- a/demo/menus/index.html
+++ b/demo/menus/index.html
@@ -27,15 +27,6 @@
   }
 
   .u-mb-xxl { margin-bottom: 140px !important; }
-
-  .menu-container .c-menu {
-    position: relative;
-  }
-
-  .menu-container {
-    transform: translateZ(0);
-    position: absolute;
-  }
   </style>
 </head>
 <body>

--- a/demo/pagination/index.html
+++ b/demo/pagination/index.html
@@ -16,12 +16,6 @@
   <link href="index.css" rel="stylesheet">
   <link href="custom.css" rel="stylesheet">
   <link href="../utilities/index.css" rel="stylesheet">
-  <style>
-  .menu-container {
-    transform: translateZ(0);
-    position: absolute;
-  }
-  </style>
 </head>
 <body>
   <header class="c-header">

--- a/demo/tables/index.html
+++ b/demo/tables/index.html
@@ -25,10 +25,6 @@
     vertical-align: middle;
   }
 
-  .menu-container {
-    transform: translateZ(0);
-    position: absolute;
-  }
   .c-table .menu-container {
     top: 0;
   }

--- a/demo/tabs/index.html
+++ b/demo/tabs/index.html
@@ -16,12 +16,6 @@
   <link href="index.css" rel="stylesheet">
   <link href="custom.css" rel="stylesheet">
   <link href="../utilities/index.css" rel="stylesheet">
-  <style>
-  .menu-container {
-    transform: translateZ(0);
-    position: absolute;
-  }
-  </style>
 </head>
 <body>
   <header class="c-header">

--- a/demo/tags/index.html
+++ b/demo/tags/index.html
@@ -20,11 +20,6 @@
   <link href="../utilities/index.css" rel="stylesheet">
   <style>
   .c-txt__input .c-tag { min-width: 75px; }
-
-  .menu-container {
-    transform: translateZ(0);
-    position: absolute;
-  }
   </style>
 </head>
 <body>

--- a/packages/buttons/src/_state.css
+++ b/packages/buttons/src/_state.css
@@ -34,12 +34,21 @@
   box-shadow: var(--zd-btn-focused-box-shadow);
 }
 
+.c-btn.c-btn--danger:--btn-focused {
+  box-shadow: var(--zd-btn--danger-focused-box-shadow);
+}
+
 .c-btn--focus-inset:--btn-focused {
   box-shadow: inset var(--zd-btn-focused-box-shadow);
 }
 
-.c-btn.c-btn--danger:--btn-focused {
-  box-shadow: var(--zd-btn--danger-focused-box-shadow);
+.c-btn--focus-inset.c-btn--danger:--btn-focused {
+  box-shadow: inset var(--zd-btn--danger-focused-box-shadow);
+}
+
+.c-btn--focus-inset:--btn-hovered:--btn-focused,
+.c-btn--focus-inset:--btn-primary:--btn-focused {
+  box-shadow: var(--zd-btn-group--primary-focused-box-shadow);
 }
 
 .c-btn:--btn-active {

--- a/packages/buttons/src/_state.css
+++ b/packages/buttons/src/_state.css
@@ -34,6 +34,10 @@
   box-shadow: var(--zd-btn-focused-box-shadow);
 }
 
+.c-btn--focus-inset:--btn-focused {
+  box-shadow: inset var(--zd-btn-focused-box-shadow);
+}
+
 .c-btn.c-btn--danger:--btn-focused {
   box-shadow: var(--zd-btn--danger-focused-box-shadow);
 }

--- a/packages/buttons/src/custom.css
+++ b/packages/buttons/src/custom.css
@@ -76,6 +76,7 @@
   box-shadow: inset var(--zd-btn--custom-focused-box-shadow);
 }
 
+.c-btn--custom.c-btn--muted:--btn-focused,
 .c-btn--custom.c-btn--anchor:--btn-focused {
   box-shadow: none;
 }

--- a/packages/buttons/src/custom.css
+++ b/packages/buttons/src/custom.css
@@ -71,6 +71,11 @@
   color: var(--zd-btn--custom--anchor-disabled-color);
 }
 
+.c-btn--custom.c-btn--focus-inset:--btn-focused,
 .l-btn-group .c-btn--custom:--btn-focused {
   box-shadow: inset var(--zd-btn--custom-focused-box-shadow);
+}
+
+.c-btn--custom.c-btn--anchor:--btn-focused {
+  box-shadow: none;
 }

--- a/packages/forms/src/_text/_state.css
+++ b/packages/forms/src/_text/_state.css
@@ -8,6 +8,7 @@
   --zd-txt-disabled-color: var(--zd-forms-disabled-color);
   --zd-txt-focused-border-color: var(--zd-forms-accent-color);
   --zd-txt-focused-box-shadow: var(--zd-forms-focused-box-shadow);
+  --zd-txt-focused-box-shadow-inset: var(--zd-forms-focused-box-shadow-inset);
   --zd-txt-hovered-border-color: var(--zd-forms-hovered-border-color);
 }
 
@@ -22,6 +23,10 @@
 .c-txt__input:--txt-focused {
   border-color: var(--zd-txt-focused-border-color);
   box-shadow: var(--zd-txt-focused-box-shadow);
+}
+
+.c-txt__input--focus-inset:--txt-focused {
+  box-shadow: var(--zd-txt-focused-box-shadow-inset);
 }
 
 .c-txt__input:--txt-disabled {

--- a/packages/forms/src/_text/_state.css
+++ b/packages/forms/src/_text/_state.css
@@ -8,7 +8,7 @@
   --zd-txt-disabled-color: var(--zd-forms-disabled-color);
   --zd-txt-focused-border-color: var(--zd-forms-accent-color);
   --zd-txt-focused-box-shadow: var(--zd-forms-focused-box-shadow);
-  --zd-txt-focused-box-shadow-inset: var(--zd-forms-focused-box-shadow-inset);
+  --zd-txt-focused-box-shadow-inset: inset var(--zd-forms-focused-box-shadow);
   --zd-txt-hovered-border-color: var(--zd-forms-hovered-border-color);
 }
 

--- a/packages/forms/src/_text/_validation.css
+++ b/packages/forms/src/_text/_validation.css
@@ -5,14 +5,17 @@
   --zd-txt--error-focused-box-shadow:
     0 0 0 3px
     color-mod(var(--zd-txt--error-focused-border-color) alpha(35%));
+  --zd-txt--error-focused-box-shadow-inset: inset var(--zd-txt--error-focused-box-shadow);
   --zd-txt--success-focused-border-color: var(--zd-color-green-600);
   --zd-txt--success-focused-box-shadow:
     0 0 0 3px
     color-mod(var(--zd-txt--success-focused-border-color) alpha(35%));
+  --zd-txt--success-focused-box-shadow-inset: inset var(--zd-txt--success-focused-box-shadow);
   --zd-txt--warning-focused-border-color: var(--zd-color-yellow-600);
   --zd-txt--warning-focused-box-shadow:
     0 0 0 3px
     color-mod(var(--zd-txt--warning-focused-border-color) alpha(35%));
+  --zd-txt--warning-focused-box-shadow-inset: inset var(--zd-txt--warning-focused-box-shadow);
 }
 
 /* stylelint-disable selector-max-specificity */
@@ -24,6 +27,10 @@
   box-shadow: var(--zd-txt--error-focused-box-shadow);
 }
 
+.c-txt__input--focus-inset.c-txt__input--error:--txt-focused {
+  box-shadow: var(--zd-txt--error-focused-box-shadow-inset);
+}
+
 .c-txt__input.c-txt__input--success:not(.is-disabled):not([disabled]) {
   border-color: var(--zd-forms-success-color);
 }
@@ -32,11 +39,19 @@
   box-shadow: var(--zd-txt--success-focused-box-shadow);
 }
 
+.c-txt__input--focus-inset.c-txt__input--success:--txt-focused {
+  box-shadow: var(--zd-txt--success-focused-box-shadow-inset);
+}
+
 .c-txt__input.c-txt__input--warning:not(.is-disabled):not([disabled]) {
   border-color: var(--zd-forms-warning-color);
 }
 
 .c-txt__input--warning:--txt-focused {
   box-shadow: var(--zd-txt--warning-focused-box-shadow);
+}
+
+.c-txt__input--focus-inset.c-txt__input--warning:--txt-focused {
+  box-shadow: var(--zd-txt--warning-focused-box-shadow-inset);
 }
 /* stylelint-enable selector-max-specificity */

--- a/packages/forms/src/_variables.css
+++ b/packages/forms/src/_variables.css
@@ -9,7 +9,6 @@
   --zd-forms-focused-box-shadow:
     0 0 0 var(--zd-forms-focused-box-shadow-spread-radius)
     color-mod(var(--zd-forms-accent-color) alpha(35%));
-  --zd-forms-focused-box-shadow-inset: inset var(--zd-forms-focused-box-shadow);
   --zd-forms-hovered-border-color: var(--zd-color-blue-400);
   --zd-forms-error-color: var(--zd-color-red-400);
   --zd-forms-success-color: var(--zd-color-green-400);

--- a/packages/forms/src/_variables.css
+++ b/packages/forms/src/_variables.css
@@ -9,6 +9,7 @@
   --zd-forms-focused-box-shadow:
     0 0 0 var(--zd-forms-focused-box-shadow-spread-radius)
     color-mod(var(--zd-forms-accent-color) alpha(35%));
+  --zd-forms-focused-box-shadow-inset: inset var(--zd-forms-focused-box-shadow);
   --zd-forms-hovered-border-color: var(--zd-color-blue-400);
   --zd-forms-error-color: var(--zd-color-red-400);
   --zd-forms-success-color: var(--zd-color-green-400);

--- a/packages/forms/src/custom.css
+++ b/packages/forms/src/custom.css
@@ -16,6 +16,7 @@
   --zd-forms--custom-box-shadow:
     0 0 0 3px
     color-mod(var(--zd-forms--custom-accent-color) alpha(40%));
+  --zd-forms--custom-box-shadow-inset: inset var(--zd-forms--custom-box-shadow);
   --zd-range--custom-track-background-image: linear-gradient(var(--zd-forms--custom-accent-color), var(--zd-forms--custom-accent-color));
 }
 
@@ -98,6 +99,10 @@
 
 .c-txt__input--custom:not(.c-txt__input--error):not(.c-txt__input--success):not(.c-txt__input--warning):--txt-focused:not(.c-txt__input--bare) {
   box-shadow: var(--zd-forms--custom-box-shadow);
+}
+
+.c-txt__input--custom.c-txt__input--focus-inset:not(.c-txt__input--error):not(.c-txt__input--success):not(.c-txt__input--warning):--txt-focused:not(.c-txt__input--bare) {
+  box-shadow: var(--zd-forms--custom-box-shadow-inset);
 }
 
 /* stylelint-enable max-line-length, selector-max-specificity */


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Provide a way to inset box-shadow styling for focused buttons and text fields.

## Detail

Demo pages are pre-published for review. See "Inset Focus" toggle under the settings menu for the following pages:

https://garden.zendesk.com/css-components/buttons/
https://garden.zendesk.com/css-components/forms/dropdown/
https://garden.zendesk.com/css-components/forms/text/

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
