### PR TITLE
feat(variables|utilities): add secondary colors

### DIFF
--- a/demo/utilities/color/index.html
+++ b/demo/utilities/color/index.html
@@ -56,6 +56,7 @@
       <code class="c-code">.u-{??}-current-color</code>,
       <code class="c-code">.u-{??}-transparent</code>, and
       <code class="c-code">.u-{??}-inherit</code>.</p>
+      <h2 class="c-main__subtitle u-fs-xl u-mb">Product Colors</h2>
       <!-- products -->
       <div class="l-grid l-grid-sm u-mb-lg">
         <div class="l-grid__item u-1/8 u-mb">
@@ -168,7 +169,7 @@
             <div class="c-swatch__color u-bg-sell-gold">
               <svg class="c-swatch__color__product">
                 <use xlink:href="../../index.svg#zd-svg-icon-26-relationshape-sell">
-                  <title>Inbox Orange</title>
+                  <title>Sell Gold</title>
                 </use>
               </svg>
             </div>
@@ -179,6 +180,7 @@
           </figure>
         </div>
       </div>
+      <h2 class="c-main__subtitle u-fs-xl u-mb">Primary Colors</h2>
       <div class="u-mb-lg">
         <!-- grey -->
         <div class="l-grid l-grid-sm">
@@ -636,6 +638,282 @@
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">yellow-100</bold>
                 <span class="c-swatch__info__hex">fff8ed</span>
+              </figcaption>
+            </figure>
+          </div>
+        </div>
+      </div>
+      <h2 class="c-main__subtitle u-fs-xl u-mb">Secondary Colors</h2>
+      <!-- fuschia -->
+      <div class="u-mb">
+        <div class="l-grid l-grid-sm">
+          <div class="l-grid__item u-1/4"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-fuschia-600"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">fuschia-600</bold>
+                <span class="c-swatch__info__hex">a81897</span>
+              </figcaption>
+            </figure>
+          </div
+          ><div class="l-grid__item u-1/8"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-fuschia-400"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">fuschia-400</bold>
+                <span class="c-swatch__info__hex">d653c2</span>
+              </figcaption>
+            </figure>
+          </div>
+        </div>
+      </div>
+      <!-- pink -->
+      <div class="u-mb">
+        <div class="l-grid l-grid-sm">
+          <div class="l-grid__item u-1/4"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-pink-600"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">pink-600</bold>
+                <span class="c-swatch__info__hex">d42054</span>
+              </figcaption>
+            </figure>
+          </div
+          ><div class="l-grid__item u-1/8"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-pink-400"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">pink-400</bold>
+                <span class="c-swatch__info__hex">ec4d63</span>
+              </figcaption>
+            </figure>
+          </div>
+        </div>
+      </div>
+      <!-- crimson -->
+      <div class="u-mb">
+        <div class="l-grid l-grid-sm">
+          <div class="l-grid__item u-1/4"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-crimson-600"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">crimson-600</bold>
+                <span class="c-swatch__info__hex">c72a1c</span>
+              </figcaption>
+            </figure>
+          </div
+          ><div class="l-grid__item u-1/8"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-crimson-400"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">crimson-400</bold>
+                <span class="c-swatch__info__hex">e34f32</span>
+              </figcaption>
+            </figure>
+          </div>
+        </div>
+      </div>
+      <!-- orange -->
+      <div class="u-mb">
+        <div class="l-grid l-grid-sm">
+          <div class="l-grid__item u-1/4"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-orange-600"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">orange-600</bold>
+                <span class="c-swatch__info__hex">bf5000</span>
+              </figcaption>
+            </figure>
+          </div
+          ><div class="l-grid__item u-1/8"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-orange-400"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">orange-400</bold>
+                <span class="c-swatch__info__hex">de701d</span>
+              </figcaption>
+            </figure>
+          </div>
+        </div>
+      </div>
+      <!-- lemon -->
+      <div class="u-mb">
+        <div class="l-grid l-grid-sm">
+          <div class="l-grid__item u-1/4"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-lemon-600"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">lemon-600</bold>
+                <span class="c-swatch__info__hex">ffbb10</span>
+              </figcaption>
+            </figure>
+          </div
+          ><div class="l-grid__item u-1/8"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-lemon-400"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">lemon-400</bold>
+                <span class="c-swatch__info__hex">ffd424</span>
+              </figcaption>
+            </figure>
+          </div>
+        </div>
+      </div>
+      <!-- lime -->
+      <div class="u-mb">
+        <div class="l-grid l-grid-sm">
+          <div class="l-grid__item u-1/4"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-lime-600"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">lime-600</bold>
+                <span class="c-swatch__info__hex">2e8200</span>
+              </figcaption>
+            </figure>
+          </div
+          ><div class="l-grid__item u-1/8"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-lime-400"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">lime-400</bold>
+                <span class="c-swatch__info__hex">43b324</span>
+              </figcaption>
+            </figure>
+          </div>
+        </div>
+      </div>
+      <!-- mint -->
+      <div class="u-mb">
+        <div class="l-grid l-grid-sm">
+          <div class="l-grid__item u-1/4"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-mint-600"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">mint-600</bold>
+                <span class="c-swatch__info__hex">058541</span>
+              </figcaption>
+            </figure>
+          </div
+          ><div class="l-grid__item u-1/8"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-mint-400"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">mint-400</bold>
+                <span class="c-swatch__info__hex">00a656</span>
+              </figcaption>
+            </figure>
+          </div>
+        </div>
+      </div>
+      <!-- teal -->
+      <div class="u-mb">
+        <div class="l-grid l-grid-sm">
+          <div class="l-grid__item u-1/4"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-teal-600"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">teal-600</bold>
+                <span class="c-swatch__info__hex">028079</span>
+              </figcaption>
+            </figure>
+          </div
+          ><div class="l-grid__item u-1/8"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-teal-400"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">teal-400</bold>
+                <span class="c-swatch__info__hex">02a191</span>
+              </figcaption>
+            </figure>
+          </div>
+        </div>
+      </div>
+      <!-- azure -->
+      <div class="u-mb">
+        <div class="l-grid l-grid-sm">
+          <div class="l-grid__item u-1/4"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-azure-600"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">azure-600</bold>
+                <span class="c-swatch__info__hex">1371d6</span>
+              </figcaption>
+            </figure>
+          </div
+          ><div class="l-grid__item u-1/8"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-azure-400"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">azure-400</bold>
+                <span class="c-swatch__info__hex">3091ec</span>
+              </figcaption>
+            </figure>
+          </div>
+        </div>
+      </div>
+      <!-- royal -->
+      <div class="u-mb">
+        <div class="l-grid l-grid-sm">
+          <div class="l-grid__item u-1/4"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-royal-600"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">royal-600</bold>
+                <span class="c-swatch__info__hex">3353e2</span>
+              </figcaption>
+            </figure>
+          </div
+          ><div class="l-grid__item u-1/8"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-royal-400"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">royal-400</bold>
+                <span class="c-swatch__info__hex">5d7d5f</span>
+              </figcaption>
+            </figure>
+          </div>
+        </div>
+      </div>
+      <!-- purple -->
+      <div class="u-mb">
+        <div class="l-grid l-grid-sm">
+          <div class="l-grid__item u-1/4"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-purple-600"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">purple-600</bold>
+                <span class="c-swatch__info__hex">6a27b8</span>
+              </figcaption>
+            </figure>
+          </div
+          ><div class="l-grid__item u-1/8"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-purple-400"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">purple-400</bold>
+                <span class="c-swatch__info__hex">b552e2</span>
               </figcaption>
             </figure>
           </div>

--- a/packages/utilities/src/color.css
+++ b/packages/utilities/src/color.css
@@ -107,6 +107,52 @@
 
 .u-bg-yellow-800 { background-color: var(--zd-color-yellow-800) !important; }
 
+/* Background Colors (secondary) */
+
+.u-bg-azure-400 { background-color: var(--zd-color-secondary-azure-400) !important; }
+
+.u-bg-azure-600 { background-color: var(--zd-color-secondary-azure-600) !important; }
+
+.u-bg-crimson-400 { background-color: var(--zd-color-secondary-crimson-400) !important; }
+
+.u-bg-crimson-600 { background-color: var(--zd-color-secondary-crimson-600) !important; }
+
+.u-bg-fuschia-400 { background-color: var(--zd-color-secondary-fuschia-400) !important; }
+
+.u-bg-fuschia-600 { background-color: var(--zd-color-secondary-fuschia-600) !important; }
+
+.u-bg-lemon-400 { background-color: var(--zd-color-secondary-lemon-400) !important; }
+
+.u-bg-lemon-600 { background-color: var(--zd-color-secondary-lemon-600) !important; }
+
+.u-bg-lime-400 { background-color: var(--zd-color-secondary-lime-400) !important; }
+
+.u-bg-lime-600 { background-color: var(--zd-color-secondary-lime-600) !important; }
+
+.u-bg-mint-400 { background-color: var(--zd-color-secondary-mint-400) !important; }
+
+.u-bg-mint-600 { background-color: var(--zd-color-secondary-mint-600) !important; }
+
+.u-bg-orange-400 { background-color: var(--zd-color-secondary-orange-400) !important; }
+
+.u-bg-orange-600 { background-color: var(--zd-color-secondary-orange-600) !important; }
+
+.u-bg-pink-400 { background-color: var(--zd-color-secondary-pink-400) !important; }
+
+.u-bg-pink-600 { background-color: var(--zd-color-secondary-pink-600) !important; }
+
+.u-bg-purple-400 { background-color: var(--zd-color-secondary-purple-400) !important; }
+
+.u-bg-purple-600 { background-color: var(--zd-color-secondary-purple-600) !important; }
+
+.u-bg-royal-400 { background-color: var(--zd-color-secondary-royal-400) !important; }
+
+.u-bg-royal-600 { background-color: var(--zd-color-secondary-royal-600) !important; }
+
+.u-bg-teal-400 { background-color: var(--zd-color-secondary-teal-400) !important; }
+
+.u-bg-teal-600 { background-color: var(--zd-color-secondary-teal-600) !important; }
+
 /* Background Colors (standard) */
 
 .u-bg-black { background-color: var(--zd-color-black) !important; }
@@ -235,6 +281,52 @@
 
 .u-fg-yellow-800 { color: var(--zd-color-yellow-800) !important; }
 
+/* Foreground Colors (secondary) */
+
+.u-fg-azure-400 { color: var(--zd-color-secondary-azure-400) !important; }
+
+.u-fg-azure-600 { color: var(--zd-color-secondary-azure-600) !important; }
+
+.u-fg-crimson-400 { color: var(--zd-color-secondary-crimson-400) !important; }
+
+.u-fg-crimson-600 { color: var(--zd-color-secondary-crimson-600) !important; }
+
+.u-fg-fuschia-400 { color: var(--zd-color-secondary-fuschia-400) !important; }
+
+.u-fg-fuschia-600 { color: var(--zd-color-secondary-fuschia-600) !important; }
+
+.u-fg-lemon-400 { color: var(--zd-color-secondary-lemon-400) !important; }
+
+.u-fg-lemon-600 { color: var(--zd-color-secondary-lemon-600) !important; }
+
+.u-fg-lime-400 { color: var(--zd-color-secondary-lime-400) !important; }
+
+.u-fg-lime-600 { color: var(--zd-color-secondary-lime-600) !important; }
+
+.u-fg-mint-400 { color: var(--zd-color-secondary-mint-400) !important; }
+
+.u-fg-mint-600 { color: var(--zd-color-secondary-mint-600) !important; }
+
+.u-fg-orange-400 { color: var(--zd-color-secondary-orange-400) !important; }
+
+.u-fg-orange-600 { color: var(--zd-color-secondary-orange-600) !important; }
+
+.u-fg-pink-400 { color: var(--zd-color-secondary-pink-400) !important; }
+
+.u-fg-pink-600 { color: var(--zd-color-secondary-pink-600) !important; }
+
+.u-fg-purple-400 { color: var(--zd-color-secondary-purple-400) !important; }
+
+.u-fg-purple-600 { color: var(--zd-color-secondary-purple-600) !important; }
+
+.u-fg-royal-400 { color: var(--zd-color-secondary-royal-400) !important; }
+
+.u-fg-royal-600 { color: var(--zd-color-secondary-royal-600) !important; }
+
+.u-fg-teal-400 { color: var(--zd-color-secondary-teal-400) !important; }
+
+.u-fg-teal-600 { color: var(--zd-color-secondary-teal-600) !important; }
+
 /* Foreground Colors (standard) */
 
 .u-fg-black { color: var(--zd-color-black) !important; }
@@ -360,6 +452,52 @@
 .u-bc-yellow-700 { border-color: var(--zd-color-yellow-700) !important; }
 
 .u-bc-yellow-800 { border-color: var(--zd-color-yellow-800) !important; }
+
+/* Border Colors (secondary) */
+
+.u-bc-azure-400 { border-color: var(--zd-color-secondary-azure-400) !important; }
+
+.u-bc-azure-600 { border-color: var(--zd-color-secondary-azure-600) !important; }
+
+.u-bc-crimson-400 { border-color: var(--zd-color-secondary-crimson-400) !important; }
+
+.u-bc-crimson-600 { border-color: var(--zd-color-secondary-crimson-600) !important; }
+
+.u-bc-fuschia-400 { border-color: var(--zd-color-secondary-fuschia-400) !important; }
+
+.u-bc-fuschia-600 { border-color: var(--zd-color-secondary-fuschia-600) !important; }
+
+.u-bc-lemon-400 { border-color: var(--zd-color-secondary-lemon-400) !important; }
+
+.u-bc-lemon-600 { border-color: var(--zd-color-secondary-lemon-600) !important; }
+
+.u-bc-lime-400 { border-color: var(--zd-color-secondary-lime-400) !important; }
+
+.u-bc-lime-600 { border-color: var(--zd-color-secondary-lime-600) !important; }
+
+.u-bc-mint-400 { border-color: var(--zd-color-secondary-mint-400) !important; }
+
+.u-bc-mint-600 { border-color: var(--zd-color-secondary-mint-600) !important; }
+
+.u-bc-orange-400 { border-color: var(--zd-color-secondary-orange-400) !important; }
+
+.u-bc-orange-600 { border-color: var(--zd-color-secondary-orange-600) !important; }
+
+.u-bc-pink-400 { border-color: var(--zd-color-secondary-pink-400) !important; }
+
+.u-bc-pink-600 { border-color: var(--zd-color-secondary-pink-600) !important; }
+
+.u-bc-purple-400 { border-color: var(--zd-color-secondary-purple-400) !important; }
+
+.u-bc-purple-600 { border-color: var(--zd-color-secondary-purple-600) !important; }
+
+.u-bc-royal-400 { border-color: var(--zd-color-secondary-royal-400) !important; }
+
+.u-bc-royal-600 { border-color: var(--zd-color-secondary-royal-600) !important; }
+
+.u-bc-teal-400 { border-color: var(--zd-color-secondary-teal-400) !important; }
+
+.u-bc-teal-600 { border-color: var(--zd-color-secondary-teal-600) !important; }
 
 /* Border Colors (standard) */
 

--- a/packages/variables/src/_color.js
+++ b/packages/variables/src/_color.js
@@ -58,6 +58,32 @@ let retVal = {
   'white': { r: 255, g: 255, b: 255 }
 };
 
+/* Secondary colors */
+retVal = Object.assign(retVal, {
+  'secondary-azure-400': { r: 48, g: 145, b: 236 },
+  'secondary-azure-600': { r: 19, g: 113, b: 214 },
+  'secondary-crimson-400': { r: 227, g: 79, b: 50 },
+  'secondary-crimson-600': { r: 199, g: 42, b: 28 },
+  'secondary-fuschia-400': { r: 214, g: 83, b: 194 },
+  'secondary-fuschia-600': { r: 168, g: 24, b: 151 },
+  'secondary-lemon-400': { r: 255, g: 212, b: 36 },
+  'secondary-lemon-600': { r: 255, g: 187, b: 16 },
+  'secondary-lime-400': { r: 67, g: 179, b: 36 },
+  'secondary-lime-600': { r: 46, g: 130, b: 0 },
+  'secondary-mint-400': { r: 0, g: 166, b: 86 },
+  'secondary-mint-600': { r: 5, g: 133, b: 65 },
+  'secondary-orange-400': { r: 222, g: 112, b: 29 },
+  'secondary-orange-600': { r: 191, g: 80, b: 0 },
+  'secondary-pink-400': { r: 236, g: 77, b: 99 },
+  'secondary-pink-600': { r: 212, g: 32, b: 84 },
+  'secondary-purple-400': { r: 181, g: 82, b: 226 },
+  'secondary-purple-600': { r: 106, g: 39, b: 184 },
+  'secondary-royal-400': { r: 93, g: 125, b: 245 },
+  'secondary-royal-600': { r: 51, g: 83, b: 226 },
+  'secondary-teal-400': { r: 2, g: 161, b: 145 },
+  'secondary-teal-600': { r: 2, g: 128, b: 121 }
+});
+
 /* Product colors */
 retVal = Object.assign(retVal, {
   'chat-orange': { r: 247, g: 154, b: 62 },


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

New 400/600 colors:
* fuschia
* pink
* crimson
* orange
* lemon
* lime
* mint
* teal
* azure
* royal
* purple

## Detail

Demo pre-published for review: https://garden.zendesk.com/css-components/utilities/color/

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
