### PR TITLE
feat(chrome): add new `.c-chrome__body__footer` bottom action bar.

### DIFF
--- a/demo/chrome/index.html
+++ b/demo/chrome/index.html
@@ -11,6 +11,7 @@
   <title>Chrome / CSS Components / Zendesk Garden</title>
   <link href="../bedrock/index.css" rel="stylesheet">
   <link href="../arrows/index.css" rel="stylesheet">
+  <link href="../buttons/index.css" rel="stylesheet">
   <link href="../menus/index.css" rel="stylesheet">
   <link href="../forms/index.css" rel="stylesheet">
   <link href="../breadcrumbs/index.css" rel="stylesheet">
@@ -169,6 +170,16 @@
                       </li>
                     </ul>
                   </li>
+                  <li>
+                    <code>&lt;footer class="</code><code class="c-code">c-chrome__body__footer</code><code>"&gt;</code>
+                    <span>(optional)</span>
+                  </li>
+                  <ul class="u-list-style-disc">
+                    <li>
+                      <code>&lt;div class="</code><code class="c-code">c-chrome__body__footer__item</code><code>"&gt;</code>
+                    </li>
+                    <li>etc.</li>
+                  </ul>
                 </ul>
               </li>
             </ul>
@@ -940,6 +951,30 @@
         </div>
       </div>
 
+      <div class="u-mb-xl">
+        <h2 class="c-main__subtitle u-fs-lg u-mb">Footer</h2>
+        <p class="u-mb">The <code class="c-code">.c-chrome__body__footer</code>
+          element contains footer items – typically "Save" and "Cancel" action
+          buttons – within individual <code class="c-code">.c-chrome__body__footer__item</code>
+          children used to provide consistent item spacing.</p>
+
+        <div class="u-mb">
+          <div class="c-chrome c-chrome--demo u-mb">
+            <div class="c-chrome__body c-chrome__body--footer">
+              <header class="c-chrome__body__header c-chrome__body__header--standalone">
+                <div class="c-chrome__body__header__item">Header</div>
+                <div class="c-chrome__body__header__item c-chrome__body__header__item--max-x"></div>
+              </header>
+              <div class="c-chrome__body__content"></div>
+              <footer class="c-chrome__body__footer">
+                <div class="c-chrome__body__footer__item"><button class="c-btn c-btn--basic">Cancel</button></div>
+                <div class="c-chrome__body__footer__item"><button class="c-btn c-btn--primary">Save</button></div>
+              </footer>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <div class="u-mb-lg">
         <h2 class="c-main__subtitle u-fs-lg u-mb">Modification</h2>
         <p class="u-mb">In addition to the navigation and header modifiers
@@ -956,6 +991,7 @@
           <li class="u-mb-sm"><code class="c-code">.c-chrome__subnav__item--header.is-expanded</code> – toggle to indicate accordion expansion.</li>
           <li class="u-mb-sm"><code class="c-code">.c-chrome__subnav__item__text--wrap</code> – combine with max-width on the <code class="c-code">.c-chrome__subnav</code> container to wrap long text.</li>
           <li class="u-mb-sm"><code class="c-code">.c-chrome__subnav__panel.is-hidden</code> – remove in conjunction with the associated <code class="c-code">.c-chrome__subnav__item--header</code> expansion to reveal the accordion panel. Note that in order to achieve the intended animation, a <code class="c-code">max-height</code> should be manually applied to the panel for the full height of the expanded container.</li>
+          <li class="u-mb-sm"><code class="c-code">.c-chrome__body--footer</code> – set the body content height to allow space for a <code class="c-code">.c-chrome__body__footer</code> child element; otherwise, the footer will be pushed out of view.</li>
           <li class="u-mb-sm"><code class="c-code">.c-chrome__body__header__item--logo</code> – style the product logo shown as the first item in the header (only displayed in standalone).</li>
           <li class="u-mb-sm"><code class="c-code">.c-chrome__body__header__item--max-x</code> – horizontally maximize a flex item in the header to take as much space as possible (i.e. breadcrumb container or an empty element separating starting items from ending items).</li>
           <li class="u-mb-sm"><code class="c-code">.c-chrome__body__header__item--max-y</code> – vertically maximize the height for a header item (i.e. contains a search input).</li>
@@ -1136,6 +1172,7 @@
   </main>
   <script src="//zendeskgarden.github.io/index.js"></script>
   <script src="tinycolor.js"></script>
+  <script src="../buttons/index.js"></script>
   <script src="../menus/index.js"></script>
   <script src="../forms/checkbox/index.js"></script>
   <script src="../forms/text/index.js"></script>

--- a/demo/chrome/page.html
+++ b/demo/chrome/page.html
@@ -299,7 +299,7 @@
     </div>
     <footer class="c-chrome__body__footer">
       <div class="c-chrome__body__footer__item">
-        <button class="c-btn">Cancel</button>
+        <button class="c-btn c-btn--basic">Cancel</button>
       </div>
       <div class="c-chrome__body__footer__item">
         <button class="c-btn c-btn--primary">Save</button>

--- a/demo/chrome/page.html
+++ b/demo/chrome/page.html
@@ -16,6 +16,7 @@
   <link rel="shortcut icon" href="//zendeskgarden.github.io/favicons/zendesk/favicon.ico">
   <link href="../bedrock/index.css" rel="stylesheet">
   <link href="../arrows/index.css" rel="stylesheet">
+  <link href="../buttons/index.css" rel="stylesheet">
   <link href="../menus/index.css" rel="stylesheet">
   <link href="index.css" rel="stylesheet">
   <link href="../utilities/index.css" rel="stylesheet">
@@ -93,7 +94,7 @@
       <span class="c-chrome__subnav__item__text">Sandbox</span>
     </a>
   </nav>
-  <div class="c-chrome__body">
+  <div class="c-chrome__body c-chrome__body--footer">
     <header class="c-chrome__body__header">
       <button class="c-chrome__body__header__item">
         <svg class="c-chrome__body__header__item__icon">
@@ -296,9 +297,18 @@
         augue lacus. Id aliquet risus feugiat in ante metus dictum at.</p>
       </main>
     </div>
+    <footer class="c-chrome__body__footer">
+      <div class="c-chrome__body__footer__item">
+        <button class="c-btn">Cancel</button>
+      </div>
+      <div class="c-chrome__body__footer__item">
+        <button class="c-btn c-btn--primary">Save</button>
+      </div>
+    </footer>
   </div>
   <script src="//zendeskgarden.github.io/index.js"></script>
   <script src="tinycolor.js"></script>
+  <script src="../buttons/index.js"></script>
   <script src="../menus/index.js"></script>
   <script src="index.js"></script>
   <script>

--- a/packages/chrome/src/_base.css
+++ b/packages/chrome/src/_base.css
@@ -5,6 +5,7 @@
   --zd-chrome-font-family: var(--zd-font-family-system);
   --zd-chrome-min-height: 100vh;
   --zd-chrome__body-color: var(--zd-color-grey-100);
+  --zd-chrome__body--footer__content-height: calc(100% - calc(var(--zd-chrome__body__header-height) + var(--zd-chrome__body__footer-height)));
   --zd-chrome__body__content-color: var(--zd-color-grey-800);
   --zd-chrome__body__content-font-size: var(--zd-font-size-md);
   --zd-chrome__body__content-height: calc(100% - var(--zd-chrome__body__header-height));
@@ -40,6 +41,10 @@
   line-height: var(--zd-chrome__body__content-line-height);
   color: var(--zd-chrome__body__content-color);
   font-size: var(--zd-chrome__body__content-font-size);
+}
+
+.c-chrome__body--footer .c-chrome__body__content {
+  height: var(--zd-chrome__body--footer__content-height);
 }
 
 .c-chrome__body__content__main {

--- a/packages/chrome/src/_footer.css
+++ b/packages/chrome/src/_footer.css
@@ -1,0 +1,28 @@
+@import '@zendeskgarden/css-variables';
+@import '_variables';
+@import '_selectors';
+
+:root {
+  --zd-chrome__body__footer-background-color: var(--zd-chrome__body__header-background-color);
+  --zd-chrome__body__footer-border-top: var(--zd-chrome__body__header-border-bottom);
+  --zd-chrome__body__footer-height: 80px;
+  --zd-chrome__body__footer-padding-horizontal: 40px;
+  --zd-chrome__body__footer-padding: 0 calc(var(--zd-chrome__body__footer-padding-horizontal) - var(--zd-chrome__body__footer__item-margin-horizontal));
+  --zd-chrome__body__footer__item-margin-horizontal: 4px;
+  --zd-chrome__body__footer__item-margin: 0 var(--zd-chrome__body__footer__item-margin-horizontal);
+}
+
+.c-chrome__body__footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  box-sizing: border-box;
+  border-top: var(--zd-chrome__body__footer-border-top);
+  background-color: var(--zd-chrome__body__footer-background-color);
+  padding: var(--zd-chrome__body__footer-padding);
+  height: var(--zd-chrome__body__footer-height);
+}
+
+.c-chrome__body__footer__item {
+  margin: var(--zd-chrome__body__footer__item-margin);
+}

--- a/packages/chrome/src/index.css
+++ b/packages/chrome/src/index.css
@@ -9,5 +9,6 @@
 @import '_nav';
 @import '_subnav';
 @import '_header';
+@import '_footer';
 @import '_products';
 @import '_brand';


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Provides a new bottom bar for Save/Cancel type actions.

<img width="900" alt="screen shot 2019-01-30 at 9 03 33 am" src="https://user-images.githubusercontent.com/143773/51998691-f7446280-246d-11e9-9d4e-55a710fcfb7e.png">

## Detail

Demo is pre-published for review: https://garden.zendesk.com/css-components/chrome/

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
