### PR TITLE
feat(variables|utilities): add muted secondary colors

### DIFF
--- a/demo/utilities/color/index.html
+++ b/demo/utilities/color/index.html
@@ -871,7 +871,7 @@
               <div class="c-swatch__color u-bg-lime-M600"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">lime-M600</bold>
-                <span class="c-swatch__info__hex">378522</span>
+                <span class="c-swatch__info__hex">368221</span>
               </figcaption>
             </figure>
           </div

--- a/demo/utilities/color/index.html
+++ b/demo/utilities/color/index.html
@@ -644,11 +644,15 @@
         </div>
       </div>
       <h2 class="c-main__subtitle u-fs-xl u-mb">Secondary Colors</h2>
+      <p class="u-mb">Secondary colors are meant to be used in icons, tags,
+        status badges, and illustrations. Each color has a light and a dark
+        weight, and each weight has a default (bright) and muted version. Muted
+        colors are denoted by an "M" prefix on the weight (i.e.
+        <code class="c-code">M400</code>).</p>
       <!-- fuschia -->
       <div class="u-mb">
         <div class="l-grid l-grid-sm">
-          <div class="l-grid__item u-1/4"></div
-          ><div class="l-grid__item u-1/8 u-mb">
+          <div class="l-grid__item u-1/8 u-mb">
             <figure class="c-swatch">
               <div class="c-swatch__color u-bg-fuschia-600"></div>
               <figcaption class="c-swatch__info">
@@ -657,7 +661,15 @@
               </figcaption>
             </figure>
           </div
-          ><div class="l-grid__item u-1/8"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-fuschia-M600"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">fuschia-M600</bold>
+                <span class="c-swatch__info__hex">a8458c</span>
+              </figcaption>
+            </figure>
+          </div
           ><div class="l-grid__item u-1/8 u-mb">
             <figure class="c-swatch">
               <div class="c-swatch__color u-bg-fuschia-400"></div>
@@ -666,14 +678,22 @@
                 <span class="c-swatch__info__hex">d653c2</span>
               </figcaption>
             </figure>
+          </div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-fuschia-M400"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">fuschia-M400</bold>
+                <span class="c-swatch__info__hex">cf62a8</span>
+              </figcaption>
+            </figure>
           </div>
         </div>
       </div>
       <!-- pink -->
       <div class="u-mb">
         <div class="l-grid l-grid-sm">
-          <div class="l-grid__item u-1/4"></div
-          ><div class="l-grid__item u-1/8 u-mb">
+          <div class="l-grid__item u-1/8 u-mb">
             <figure class="c-swatch">
               <div class="c-swatch__color u-bg-pink-600"></div>
               <figcaption class="c-swatch__info">
@@ -682,7 +702,15 @@
               </figcaption>
             </figure>
           </div
-          ><div class="l-grid__item u-1/8"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-pink-M600"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">pink-M600</bold>
+                <span class="c-swatch__info__hex">b23a5d</span>
+              </figcaption>
+            </figure>
+          </div
           ><div class="l-grid__item u-1/8 u-mb">
             <figure class="c-swatch">
               <div class="c-swatch__color u-bg-pink-400"></div>
@@ -691,14 +719,22 @@
                 <span class="c-swatch__info__hex">ec4d63</span>
               </figcaption>
             </figure>
+          </div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-pink-M400"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">pink-M400</bold>
+                <span class="c-swatch__info__hex">d57287</span>
+              </figcaption>
+            </figure>
           </div>
         </div>
       </div>
       <!-- crimson -->
       <div class="u-mb">
         <div class="l-grid l-grid-sm">
-          <div class="l-grid__item u-1/4"></div
-          ><div class="l-grid__item u-1/8 u-mb">
+          <div class="l-grid__item u-1/8 u-mb">
             <figure class="c-swatch">
               <div class="c-swatch__color u-bg-crimson-600"></div>
               <figcaption class="c-swatch__info">
@@ -707,7 +743,15 @@
               </figcaption>
             </figure>
           </div
-          ><div class="l-grid__item u-1/8"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-crimson-M600"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">crimson-M600</bold>
+                <span class="c-swatch__info__hex">b24a3c</span>
+              </figcaption>
+            </figure>
+          </div
           ><div class="l-grid__item u-1/8 u-mb">
             <figure class="c-swatch">
               <div class="c-swatch__color u-bg-crimson-400"></div>
@@ -716,14 +760,22 @@
                 <span class="c-swatch__info__hex">e34f32</span>
               </figcaption>
             </figure>
+          </div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-crimson-M400"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">crimson-M400</bold>
+                <span class="c-swatch__info__hex">cc6c5b</span>
+              </figcaption>
+            </figure>
           </div>
         </div>
       </div>
       <!-- orange -->
       <div class="u-mb">
         <div class="l-grid l-grid-sm">
-          <div class="l-grid__item u-1/4"></div
-          ><div class="l-grid__item u-1/8 u-mb">
+          <div class="l-grid__item u-1/8 u-mb">
             <figure class="c-swatch">
               <div class="c-swatch__color u-bg-orange-600"></div>
               <figcaption class="c-swatch__info">
@@ -732,7 +784,15 @@
               </figcaption>
             </figure>
           </div
-          ><div class="l-grid__item u-1/8"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-orange-M600"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">orange-M600</bold>
+                <span class="c-swatch__info__hex">b35827</span>
+              </figcaption>
+            </figure>
+          </div
           ><div class="l-grid__item u-1/8 u-mb">
             <figure class="c-swatch">
               <div class="c-swatch__color u-bg-orange-400"></div>
@@ -741,14 +801,22 @@
                 <span class="c-swatch__info__hex">de701d</span>
               </figcaption>
             </figure>
+          </div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-orange-M400"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">orange-M400</bold>
+                <span class="c-swatch__info__hex">d4772c</span>
+              </figcaption>
+            </figure>
           </div>
         </div>
       </div>
       <!-- lemon -->
       <div class="u-mb">
         <div class="l-grid l-grid-sm">
-          <div class="l-grid__item u-1/4"></div
-          ><div class="l-grid__item u-1/8 u-mb">
+          <div class="l-grid__item u-1/8 u-mb">
             <figure class="c-swatch">
               <div class="c-swatch__color u-bg-lemon-600"></div>
               <figcaption class="c-swatch__info">
@@ -757,7 +825,15 @@
               </figcaption>
             </figure>
           </div
-          ><div class="l-grid__item u-1/8"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-lemon-M600"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">lemon-M600</bold>
+                <span class="c-swatch__info__hex">c38f00</span>
+              </figcaption>
+            </figure>
+          </div
           ><div class="l-grid__item u-1/8 u-mb">
             <figure class="c-swatch">
               <div class="c-swatch__color u-bg-lemon-400"></div>
@@ -766,14 +842,22 @@
                 <span class="c-swatch__info__hex">ffd424</span>
               </figcaption>
             </figure>
+          </div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-lemon-M400"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">lemon-M400</bold>
+                <span class="c-swatch__info__hex">e7a500</span>
+              </figcaption>
+            </figure>
           </div>
         </div>
       </div>
       <!-- lime -->
       <div class="u-mb">
         <div class="l-grid l-grid-sm">
-          <div class="l-grid__item u-1/4"></div
-          ><div class="l-grid__item u-1/8 u-mb">
+          <div class="l-grid__item u-1/8 u-mb">
             <figure class="c-swatch">
               <div class="c-swatch__color u-bg-lime-600"></div>
               <figcaption class="c-swatch__info">
@@ -782,7 +866,15 @@
               </figcaption>
             </figure>
           </div
-          ><div class="l-grid__item u-1/8"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-lime-M600"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">lime-M600</bold>
+                <span class="c-swatch__info__hex">378522</span>
+              </figcaption>
+            </figure>
+          </div
           ><div class="l-grid__item u-1/8 u-mb">
             <figure class="c-swatch">
               <div class="c-swatch__color u-bg-lime-400"></div>
@@ -791,14 +883,22 @@
                 <span class="c-swatch__info__hex">43b324</span>
               </figcaption>
             </figure>
+          </div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-lime-M400"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">lime-M400</bold>
+                <span class="c-swatch__info__hex">519e2d</span>
+              </figcaption>
+            </figure>
           </div>
         </div>
       </div>
       <!-- mint -->
       <div class="u-mb">
         <div class="l-grid l-grid-sm">
-          <div class="l-grid__item u-1/4"></div
-          ><div class="l-grid__item u-1/8 u-mb">
+          <div class="l-grid__item u-1/8 u-mb">
             <figure class="c-swatch">
               <div class="c-swatch__color u-bg-mint-600"></div>
               <figcaption class="c-swatch__info">
@@ -807,7 +907,15 @@
               </figcaption>
             </figure>
           </div
-          ><div class="l-grid__item u-1/8"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-mint-M600"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">mint-M600</bold>
+                <span class="c-swatch__info__hex">2e8057</span>
+              </figcaption>
+            </figure>
+          </div
           ><div class="l-grid__item u-1/8 u-mb">
             <figure class="c-swatch">
               <div class="c-swatch__color u-bg-mint-400"></div>
@@ -816,14 +924,22 @@
                 <span class="c-swatch__info__hex">00a656</span>
               </figcaption>
             </figure>
+          </div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-mint-M400"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">mint-M400</bold>
+                <span class="c-swatch__info__hex">299c66</span>
+              </figcaption>
+            </figure>
           </div>
         </div>
       </div>
       <!-- teal -->
       <div class="u-mb">
         <div class="l-grid l-grid-sm">
-          <div class="l-grid__item u-1/4"></div
-          ><div class="l-grid__item u-1/8 u-mb">
+          <div class="l-grid__item u-1/8 u-mb">
             <figure class="c-swatch">
               <div class="c-swatch__color u-bg-teal-600"></div>
               <figcaption class="c-swatch__info">
@@ -832,7 +948,15 @@
               </figcaption>
             </figure>
           </div
-          ><div class="l-grid__item u-1/8"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-teal-M600"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">teal-M600</bold>
+                <span class="c-swatch__info__hex">3c7873</span>
+              </figcaption>
+            </figure>
+          </div
           ><div class="l-grid__item u-1/8 u-mb">
             <figure class="c-swatch">
               <div class="c-swatch__color u-bg-teal-400"></div>
@@ -841,14 +965,22 @@
                 <span class="c-swatch__info__hex">02a191</span>
               </figcaption>
             </figure>
+          </div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-teal-M400"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">teal-M400</bold>
+                <span class="c-swatch__info__hex">2d9e8f</span>
+              </figcaption>
+            </figure>
           </div>
         </div>
       </div>
       <!-- azure -->
       <div class="u-mb">
         <div class="l-grid l-grid-sm">
-          <div class="l-grid__item u-1/4"></div
-          ><div class="l-grid__item u-1/8 u-mb">
+          <div class="l-grid__item u-1/8 u-mb">
             <figure class="c-swatch">
               <div class="c-swatch__color u-bg-azure-600"></div>
               <figcaption class="c-swatch__info">
@@ -857,7 +989,15 @@
               </figcaption>
             </figure>
           </div
-          ><div class="l-grid__item u-1/8"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-azure-M600"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">azure-M600</bold>
+                <span class="c-swatch__info__hex">3a70b2</span>
+              </figcaption>
+            </figure>
+          </div
           ><div class="l-grid__item u-1/8 u-mb">
             <figure class="c-swatch">
               <div class="c-swatch__color u-bg-azure-400"></div>
@@ -866,14 +1006,22 @@
                 <span class="c-swatch__info__hex">3091ec</span>
               </figcaption>
             </figure>
+          </div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-azure-M400"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">azure-M400</bold>
+                <span class="c-swatch__info__hex">5f8dcf</span>
+              </figcaption>
+            </figure>
           </div>
         </div>
       </div>
       <!-- royal -->
       <div class="u-mb">
         <div class="l-grid l-grid-sm">
-          <div class="l-grid__item u-1/4"></div
-          ><div class="l-grid__item u-1/8 u-mb">
+          <div class="l-grid__item u-1/8 u-mb">
             <figure class="c-swatch">
               <div class="c-swatch__color u-bg-royal-600"></div>
               <figcaption class="c-swatch__info">
@@ -882,7 +1030,15 @@
               </figcaption>
             </figure>
           </div
-          ><div class="l-grid__item u-1/8"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-royal-M600"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">royal-M600</bold>
+                <span class="c-swatch__info__hex">4b61c3</span>
+              </figcaption>
+            </figure>
+          </div
           ><div class="l-grid__item u-1/8 u-mb">
             <figure class="c-swatch">
               <div class="c-swatch__color u-bg-royal-400"></div>
@@ -891,14 +1047,22 @@
                 <span class="c-swatch__info__hex">5d7d5f</span>
               </figcaption>
             </figure>
+          </div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-royal-M400"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">royal-M400</bold>
+                <span class="c-swatch__info__hex">7986d8</span>
+              </figcaption>
+            </figure>
           </div>
         </div>
       </div>
       <!-- purple -->
       <div class="u-mb">
         <div class="l-grid l-grid-sm">
-          <div class="l-grid__item u-1/4"></div
-          ><div class="l-grid__item u-1/8 u-mb">
+          <div class="l-grid__item u-1/8 u-mb">
             <figure class="c-swatch">
               <div class="c-swatch__color u-bg-purple-600"></div>
               <figcaption class="c-swatch__info">
@@ -907,13 +1071,30 @@
               </figcaption>
             </figure>
           </div
-          ><div class="l-grid__item u-1/8"></div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-purple-M600"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">purple-M600</bold>
+                <span class="c-swatch__info__hex">9358b0</span>
+              </figcaption>
+            </figure>
+          </div
           ><div class="l-grid__item u-1/8 u-mb">
             <figure class="c-swatch">
               <div class="c-swatch__color u-bg-purple-400"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">purple-400</bold>
                 <span class="c-swatch__info__hex">b552e2</span>
+              </figcaption>
+            </figure>
+          </div
+          ><div class="l-grid__item u-1/8 u-mb">
+            <figure class="c-swatch">
+              <div class="c-swatch__color u-bg-purple-M400"></div>
+              <figcaption class="c-swatch__info">
+                <bold class="c-swatch__info__name">purple-M400</bold>
+                <span class="c-swatch__info__hex">b072cc</span>
               </figcaption>
             </figure>
           </div>

--- a/demo/utilities/color/index.html
+++ b/demo/utilities/color/index.html
@@ -871,7 +871,7 @@
               <div class="c-swatch__color u-bg-lime-M600"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">lime-M600</bold>
-                <span class="c-swatch__info__hex">368221</span>
+                <span class="c-swatch__info__hex">47782c</span>
               </figcaption>
             </figure>
           </div

--- a/packages/utilities/src/color.css
+++ b/packages/utilities/src/color.css
@@ -153,6 +153,52 @@
 
 .u-bg-teal-600 { background-color: var(--zd-color-secondary-teal-600) !important; }
 
+/* Background Colors (muted secondary) */
+
+.u-bg-azure-M400 { background-color: var(--zd-color-secondary-azure-M400) !important; }
+
+.u-bg-azure-M600 { background-color: var(--zd-color-secondary-azure-M600) !important; }
+
+.u-bg-crimson-M400 { background-color: var(--zd-color-secondary-crimson-M400) !important; }
+
+.u-bg-crimson-M600 { background-color: var(--zd-color-secondary-crimson-M600) !important; }
+
+.u-bg-fuschia-M400 { background-color: var(--zd-color-secondary-fuschia-M400) !important; }
+
+.u-bg-fuschia-M600 { background-color: var(--zd-color-secondary-fuschia-M600) !important; }
+
+.u-bg-lemon-M400 { background-color: var(--zd-color-secondary-lemon-M400) !important; }
+
+.u-bg-lemon-M600 { background-color: var(--zd-color-secondary-lemon-M600) !important; }
+
+.u-bg-lime-M400 { background-color: var(--zd-color-secondary-lime-M400) !important; }
+
+.u-bg-lime-M600 { background-color: var(--zd-color-secondary-lime-M600) !important; }
+
+.u-bg-mint-M400 { background-color: var(--zd-color-secondary-mint-M400) !important; }
+
+.u-bg-mint-M600 { background-color: var(--zd-color-secondary-mint-M600) !important; }
+
+.u-bg-orange-M400 { background-color: var(--zd-color-secondary-orange-M400) !important; }
+
+.u-bg-orange-M600 { background-color: var(--zd-color-secondary-orange-M600) !important; }
+
+.u-bg-pink-M400 { background-color: var(--zd-color-secondary-pink-M400) !important; }
+
+.u-bg-pink-M600 { background-color: var(--zd-color-secondary-pink-M600) !important; }
+
+.u-bg-purple-M400 { background-color: var(--zd-color-secondary-purple-M400) !important; }
+
+.u-bg-purple-M600 { background-color: var(--zd-color-secondary-purple-M600) !important; }
+
+.u-bg-royal-M400 { background-color: var(--zd-color-secondary-royal-M400) !important; }
+
+.u-bg-royal-M600 { background-color: var(--zd-color-secondary-royal-M600) !important; }
+
+.u-bg-teal-M400 { background-color: var(--zd-color-secondary-teal-M400) !important; }
+
+.u-bg-teal-M600 { background-color: var(--zd-color-secondary-teal-M600) !important; }
+
 /* Background Colors (standard) */
 
 .u-bg-black { background-color: var(--zd-color-black) !important; }
@@ -327,6 +373,52 @@
 
 .u-fg-teal-600 { color: var(--zd-color-secondary-teal-600) !important; }
 
+/* Foreground Colors (muted secondary) */
+
+.u-fg-azure-M400 { color: var(--zd-color-secondary-azure-M400) !important; }
+
+.u-fg-azure-M600 { color: var(--zd-color-secondary-azure-M600) !important; }
+
+.u-fg-crimson-M400 { color: var(--zd-color-secondary-crimson-M400) !important; }
+
+.u-fg-crimson-M600 { color: var(--zd-color-secondary-crimson-M600) !important; }
+
+.u-fg-fuschia-M400 { color: var(--zd-color-secondary-fuschia-M400) !important; }
+
+.u-fg-fuschia-M600 { color: var(--zd-color-secondary-fuschia-M600) !important; }
+
+.u-fg-lemon-M400 { color: var(--zd-color-secondary-lemon-M400) !important; }
+
+.u-fg-lemon-M600 { color: var(--zd-color-secondary-lemon-M600) !important; }
+
+.u-fg-lime-M400 { color: var(--zd-color-secondary-lime-M400) !important; }
+
+.u-fg-lime-M600 { color: var(--zd-color-secondary-lime-M600) !important; }
+
+.u-fg-mint-M400 { color: var(--zd-color-secondary-mint-M400) !important; }
+
+.u-fg-mint-M600 { color: var(--zd-color-secondary-mint-M600) !important; }
+
+.u-fg-orange-M400 { color: var(--zd-color-secondary-orange-M400) !important; }
+
+.u-fg-orange-M600 { color: var(--zd-color-secondary-orange-M600) !important; }
+
+.u-fg-pink-M400 { color: var(--zd-color-secondary-pink-M400) !important; }
+
+.u-fg-pink-M600 { color: var(--zd-color-secondary-pink-M600) !important; }
+
+.u-fg-purple-M400 { color: var(--zd-color-secondary-purple-M400) !important; }
+
+.u-fg-purple-M600 { color: var(--zd-color-secondary-purple-M600) !important; }
+
+.u-fg-royal-M400 { color: var(--zd-color-secondary-royal-M400) !important; }
+
+.u-fg-royal-M600 { color: var(--zd-color-secondary-royal-M600) !important; }
+
+.u-fg-teal-M400 { color: var(--zd-color-secondary-teal-M400) !important; }
+
+.u-fg-teal-M600 { color: var(--zd-color-secondary-teal-M600) !important; }
+
 /* Foreground Colors (standard) */
 
 .u-fg-black { color: var(--zd-color-black) !important; }
@@ -498,6 +590,52 @@
 .u-bc-teal-400 { border-color: var(--zd-color-secondary-teal-400) !important; }
 
 .u-bc-teal-600 { border-color: var(--zd-color-secondary-teal-600) !important; }
+
+/* Border Colors (muted secondary) */
+
+.u-bc-azure-M400 { border-color: var(--zd-color-secondary-azure-M400) !important; }
+
+.u-bc-azure-M600 { border-color: var(--zd-color-secondary-azure-M600) !important; }
+
+.u-bc-crimson-M400 { border-color: var(--zd-color-secondary-crimson-M400) !important; }
+
+.u-bc-crimson-M600 { border-color: var(--zd-color-secondary-crimson-M600) !important; }
+
+.u-bc-fuschia-M400 { border-color: var(--zd-color-secondary-fuschia-M400) !important; }
+
+.u-bc-fuschia-M600 { border-color: var(--zd-color-secondary-fuschia-M600) !important; }
+
+.u-bc-lemon-M400 { border-color: var(--zd-color-secondary-lemon-M400) !important; }
+
+.u-bc-lemon-M600 { border-color: var(--zd-color-secondary-lemon-M600) !important; }
+
+.u-bc-lime-M400 { border-color: var(--zd-color-secondary-lime-M400) !important; }
+
+.u-bc-lime-M600 { border-color: var(--zd-color-secondary-lime-M600) !important; }
+
+.u-bc-mint-M400 { border-color: var(--zd-color-secondary-mint-M400) !important; }
+
+.u-bc-mint-M600 { border-color: var(--zd-color-secondary-mint-M600) !important; }
+
+.u-bc-orange-M400 { border-color: var(--zd-color-secondary-orange-M400) !important; }
+
+.u-bc-orange-M600 { border-color: var(--zd-color-secondary-orange-M600) !important; }
+
+.u-bc-pink-M400 { border-color: var(--zd-color-secondary-pink-M400) !important; }
+
+.u-bc-pink-M600 { border-color: var(--zd-color-secondary-pink-M600) !important; }
+
+.u-bc-purple-M400 { border-color: var(--zd-color-secondary-purple-M400) !important; }
+
+.u-bc-purple-M600 { border-color: var(--zd-color-secondary-purple-M600) !important; }
+
+.u-bc-royal-M400 { border-color: var(--zd-color-secondary-royal-M400) !important; }
+
+.u-bc-royal-M600 { border-color: var(--zd-color-secondary-royal-M600) !important; }
+
+.u-bc-teal-M400 { border-color: var(--zd-color-secondary-teal-M400) !important; }
+
+.u-bc-teal-M600 { border-color: var(--zd-color-secondary-teal-M600) !important; }
 
 /* Border Colors (standard) */
 

--- a/packages/variables/scripts/build.js
+++ b/packages/variables/scripts/build.js
@@ -63,7 +63,7 @@ function toProperties(variables) {
  * @returns {String} The value converted to camelCase.
  */
 function toCamelCase(value) {
-  return value.replace(/-([a-z0-9])/gu, (_, c) => {
+  return value.replace(/-([\w\d])/gu, (_, c) => {
     return c.toUpperCase();
   });
 }

--- a/packages/variables/src/_color.js
+++ b/packages/variables/src/_color.js
@@ -95,7 +95,7 @@ retVal = Object.assign(retVal, {
   'secondary-lemon-M400': { r: 231, g: 165, b: 0 },
   'secondary-lemon-M600': { r: 195, g: 143, b: 0 },
   'secondary-lime-M400': { r: 81, g: 158, b: 45 },
-  'secondary-lime-M600': { r: 54, g: 130, b: 33 },
+  'secondary-lime-M600': { r: 71, g: 120, b: 44 },
   'secondary-mint-M400': { r: 41, g: 156, b: 102 },
   'secondary-mint-M600': { r: 46, g: 128, b: 87 },
   'secondary-orange-M400': { r: 212, g: 119, b: 44 },

--- a/packages/variables/src/_color.js
+++ b/packages/variables/src/_color.js
@@ -84,6 +84,32 @@ retVal = Object.assign(retVal, {
   'secondary-teal-600': { r: 2, g: 128, b: 121 }
 });
 
+/* Muted secondary colors */
+retVal = Object.assign(retVal, {
+  'secondary-azure-M400': { r: 95, g: 141, b: 207 },
+  'secondary-azure-M600': { r: 58, g: 112, b: 178 },
+  'secondary-crimson-M400': { r: 204, g: 108, b: 91 },
+  'secondary-crimson-M600': { r: 178, g: 74, b: 60 },
+  'secondary-fuschia-M400': { r: 207, g: 98, b: 168 },
+  'secondary-fuschia-M600': { r: 168, g: 69, b: 140 },
+  'secondary-lemon-M400': { r: 231, g: 165, b: 0 },
+  'secondary-lemon-M600': { r: 195, g: 143, b: 0 },
+  'secondary-lime-M400': { r: 81, g: 158, b: 45 },
+  'secondary-lime-M600': { r: 55, g: 133, b: 34 },
+  'secondary-mint-M400': { r: 41, g: 156, b: 102 },
+  'secondary-mint-M600': { r: 46, g: 128, b: 87 },
+  'secondary-orange-M400': { r: 212, g: 119, b: 44 },
+  'secondary-orange-M600': { r: 179, g: 88, b: 39 },
+  'secondary-pink-M400': { r: 213, g: 114, b: 135 },
+  'secondary-pink-M600': { r: 178, g: 58, b: 93 },
+  'secondary-purple-M400': { r: 176, g: 114, b: 204 },
+  'secondary-purple-M600': { r: 147, g: 88, b: 176 },
+  'secondary-royal-M400': { r: 121, g: 134, b: 216 },
+  'secondary-royal-M600': { r: 75, g: 97, b: 195 },
+  'secondary-teal-M400': { r: 45, g: 158, b: 143 },
+  'secondary-teal-M600': { r: 60, g: 120, b: 115 }
+});
+
 /* Product colors */
 retVal = Object.assign(retVal, {
   'chat-orange': { r: 247, g: 154, b: 62 },

--- a/packages/variables/src/_color.js
+++ b/packages/variables/src/_color.js
@@ -95,7 +95,7 @@ retVal = Object.assign(retVal, {
   'secondary-lemon-M400': { r: 231, g: 165, b: 0 },
   'secondary-lemon-M600': { r: 195, g: 143, b: 0 },
   'secondary-lime-M400': { r: 81, g: 158, b: 45 },
-  'secondary-lime-M600': { r: 55, g: 133, b: 34 },
+  'secondary-lime-M600': { r: 54, g: 130, b: 33 },
   'secondary-mint-M400': { r: 41, g: 156, b: 102 },
   'secondary-mint-M600': { r: 46, g: 128, b: 87 },
   'secondary-orange-M400': { r: 212, g: 119, b: 44 },


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Adds `M400/600` colors to the secondary palette.

## Detail

Demo pre-published for review: https://garden.zendesk.com/css-components/utilities/color/

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [ ] :white_check_mark: ~all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)~
* [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [ ] :nail_care: ~provides `custom.css` example for modifying the
  primary accent color~
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
