### PR TITLE
feat(callouts): add info styling

### DIFF
--- a/demo/callouts/index.html
+++ b/demo/callouts/index.html
@@ -103,12 +103,12 @@
             </div>
           </div>
         </div>
-        <h2 class="u-fs-lg u-mb-sm">Alert Modifications</h2>
+        <h2 class="u-fs-lg u-mb-sm">Alerts and Notifications</h2>
         <div class="l-grid u-mb-lg">
           <div class="l-grid__item u-1/2 u-mb">
             <div class="c-callout c-callout--success">
               <button class="c-callout__close"></button>
-              <strong class="c-callout__title"><span dir="ltr">Success Callout: Standard</span></strong>
+              <strong class="c-callout__title"><span dir="ltr">Success Callout: Well</span></strong>
               <p class="c-callout__paragraph">Lorem ipsum dolor sit amet,
               consectetur adipiscing elit. Morbi scelerisque sapien quis purus
               tincidunt ultrices. Morbi rutrum, tellus et viverra tincidunt,
@@ -128,7 +128,7 @@
           ><div class="l-grid__item u-1/2 u-mb">
             <div class="c-callout c-callout--warning">
               <button class="c-callout__close"></button>
-              <strong class="c-callout__title"><span dir="ltr">Warning Callout: Standard</span></strong>
+              <strong class="c-callout__title"><span dir="ltr">Warning Callout: Well</span></strong>
               <p class="c-callout__paragraph">Lorem ipsum dolor sit amet,
               consectetur adipiscing elit. Morbi scelerisque sapien quis purus
               tincidunt ultrices. Morbi rutrum, tellus et viverra tincidunt,
@@ -148,7 +148,7 @@
           ><div class="l-grid__item u-1/2 u-mb">
             <div class="c-callout c-callout--error">
               <button class="c-callout__close"></button>
-              <strong class="c-callout__title"><span dir="ltr">Error Callout: Standard</span></strong>
+              <strong class="c-callout__title"><span dir="ltr">Error Callout: Well</span></strong>
               <p class="c-callout__paragraph">Lorem ipsum dolor sit amet,
               consectetur adipiscing elit. Morbi scelerisque sapien quis purus
               tincidunt ultrices. Morbi rutrum, tellus et viverra tincidunt,
@@ -159,6 +159,26 @@
             <div class="c-callout c-callout--dialog c-callout--error">
               <button class="c-callout__close"></button>
               <strong class="c-callout__title"><span dir="ltr">Error Callout: Dialog</span></strong>
+              <p class="c-callout__paragraph">Lorem ipsum dolor sit amet,
+              consectetur adipiscing elit. Morbi scelerisque sapien quis purus
+              tincidunt ultrices. Morbi rutrum, tellus et viverra tincidunt,
+              diam ipsum laoreet risus, non tempus ligula arcu eget mi.</p>
+            </div>
+          </div
+          ><div class="l-grid__item u-1/2 u-mb">
+            <div class="c-callout c-callout--info c-callout--recessed">
+              <button class="c-callout__close"></button>
+              <strong class="c-callout__title"><span dir="ltr">Info Callout: Well</span></strong>
+              <p class="c-callout__paragraph">Lorem ipsum dolor sit amet,
+              consectetur adipiscing elit. Morbi scelerisque sapien quis purus
+              tincidunt ultrices. Morbi rutrum, tellus et viverra tincidunt,
+              diam ipsum laoreet risus, non tempus ligula arcu eget mi.</p>
+            </div>
+          </div
+          ><div class="l-grid__item u-1/2 u-mb">
+            <div class="c-callout c-callout--dialog c-callout--info">
+              <button class="c-callout__close"></button>
+              <strong class="c-callout__title"><span dir="ltr">Info Callout: Dialog</span></strong>
               <p class="c-callout__paragraph">Lorem ipsum dolor sit amet,
               consectetur adipiscing elit. Morbi scelerisque sapien quis purus
               tincidunt ultrices. Morbi rutrum, tellus et viverra tincidunt,
@@ -249,7 +269,7 @@
         <h1 class="c-main__subtitle u-fs-xl u-mb">Playground</h1>
         <div class="c-playground">
           <div class="c-playground__preview"></div>
-<textarea class="c-playground__code"><div class="c-callout c-callout--recessed">
+<textarea class="c-playground__code"><div class="c-callout c-callout--info c-callout--recessed">
   <button aria-label="close" class="c-callout__close"></button>
   <strong class="c-callout__title">Callout Title</strong>
   <p class="c-callout__paragraph">Taxidermy tousled listicle tilde. Tattooed

--- a/packages/callouts/src/_color.css
+++ b/packages/callouts/src/_color.css
@@ -20,6 +20,7 @@
   --zd-callout--error-border-color: var(--zd-color-red-300);
   --zd-callout--error-color: var(--zd-color-red-700);
   --zd-callout--error__title-color: var(--zd-color-red-800);
+  --zd-callout--info-background-image: svg-load('16/info-stroke.svg', color: var(--zd-color-grey-600));
   --zd-callout--recessed-background-color: var(--zd-color-grey-100);
   --zd-callout--success-background-color: var(--zd-color-green-100);
   --zd-callout--success-background-image: svg-load('16/check-circle-stroke.svg', color: var(--zd-color-green-600));
@@ -35,6 +36,10 @@
 
 .c-callout--recessed {
   background-color: var(--zd-callout--recessed-background-color);
+}
+
+.c-callout--info {
+  background-image: var(--zd-callout--info-background-image);
 }
 
 .c-callout--error {
@@ -58,6 +63,7 @@
   color: var(--zd-callout--warning-color);
 }
 
+.c-callout--info,
 .c-callout--error,
 .c-callout--success,
 .c-callout--warning {
@@ -102,6 +108,7 @@
   color: var(--zd-callout--dialog--warning__title-color);
 }
 
+.c-callout--info.is-rtl,
 .c-callout--error.is-rtl,
 .c-callout--success.is-rtl,
 .c-callout--warning.is-rtl {


### PR DESCRIPTION
## Description

Adds a `.c-callout--info` class that can be used for information wells and notification styling.

## Detail

Demo pre-published for review: https://garden.zendesk.com/css-components/callouts/

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [ ] :nail_care: ~provides `custom.css` example for modifying the
  primary accent color~
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
