### PR TITLE
fix(forms): bare-styled select chevron sizing

### DIFF
--- a/demo/forms/dropdown/index.html
+++ b/demo/forms/dropdown/index.html
@@ -74,6 +74,12 @@
             </li>
             <li class="c-menu__item" role="menuitem">
               <div class="c-chk">
+                <input class="c-chk__input js-bare" id="nav.ctl.bare" type="checkbox">
+                <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.bare">Bare</label>
+              </div>
+            </li>
+            <li class="c-menu__item" role="menuitem">
+              <div class="c-chk">
                 <input class="c-chk__input js-inset" id="nav.ctl.inset" type="checkbox">
                 <label class="c-chk__label c-chk__label--toggle" for="nav.ctl.inset">Inset Focus</label>
               </div>

--- a/packages/forms/src/_text/_bare.css
+++ b/packages/forms/src/_text/_bare.css
@@ -1,3 +1,10 @@
+:root {
+  --zd-txt__input--select--bare-height: calc(var(--zd-txt__input-line-height) * 1em);
+}
+
+/* 1. Calendar picker reset (standalone ruleset prevents non-Chrome parsing
+ *    errors). */
+
 .c-txt__input.c-txt__input--bare {
   border: none;
   border-radius: 0;
@@ -12,4 +19,12 @@
 
 .c-txt__input:--txt-disabled.c-txt__input--bare {
   background-color: transparent;
+}
+
+.c-txt__input--select.c-txt__input--bare:not(select)::before {
+  height: var(--zd-txt__input--select--bare-height);
+}
+
+.c-txt__input--select.c-txt__input--bare::-webkit-calendar-picker-indicator {
+  height: var(--zd-txt__input--select--bare-height); /* [1] */
 }

--- a/packages/forms/src/_text/_size.css
+++ b/packages/forms/src/_text/_size.css
@@ -51,6 +51,11 @@ select.c-txt__input--sm.c-txt__input--select {
   height: var(--zd-txt--sm__input-height);
 }
 
+.c-txt__input--sm.c-txt__input--select::-webkit-calendar-picker-indicator {
+  width: var(--zd-txt--sm__input--select__chevron-width);
+  height: var(--zd-txt--sm__input-height);
+}
+
 .is-rtl.c-txt__input--sm.c-txt__input--select {
   padding-right: var(--zd-txt--sm__input-padding-horizontal);
   padding-left: var(--zd-txt--sm__input--select-padding-right);


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Provide styling to manage the size of a dropdown chevron when the field is styled using the `.c-txt__input--bare` modifier.

## Detail

Demo is pre-published for review: https://garden.zendesk.com/css-components/forms/dropdown/. Use menu settings to alter component styling.

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
