### PR TITLE
fix(forms): padding/margin for small `.c-txt__input--media` element

### DIFF
--- a/demo/forms/text/index.js
+++ b/demo/forms/text/index.js
@@ -45,4 +45,8 @@ $(document).ready(function() {
   }).on('blur', '.c-txt__input--media input', function() {
     $(this).parent().removeClass('is-focused');
   });
+
+  $(document).on('click', '.c-txt__input--media', function() {
+    $(this).children('input').focus();
+  });
 });

--- a/packages/forms/src/_text/_media.css
+++ b/packages/forms/src/_text/_media.css
@@ -8,6 +8,7 @@
 .c-txt__input--media {
   display: flex;
   align-items: baseline;
+  cursor: text;
 }
 
 .c-txt__input--media__body {

--- a/packages/forms/src/_text/_size.css
+++ b/packages/forms/src/_text/_size.css
@@ -56,13 +56,13 @@ select.is-rtl.c-txt__input--sm.c-txt__input--select {
   background-position: var(--zd-txt-rtl--sm__input--select__chevron-background-position);
 }
 
-.c-txt__input--sm .c-txt__input--media__figure:first-of-type,
-.is-rtl.c-txt__input--sm .c-txt__input--media__figure:last-of-type {
+.c-txt__input--sm .c-txt__input--media__figure:first-child,
+.is-rtl.c-txt__input--sm .c-txt__input--media__figure:last-child {
   margin: auto var(--zd-txt--sm__media-end-margin) auto 0;
 }
 
-.c-txt__input--sm .c-txt__input--media__figure:last-of-type,
-.is-rtl.c-txt__input--sm .c-txt__input--media__figure:first-of-type {
+.c-txt__input--sm .c-txt__input--media__figure:last-child,
+.is-rtl.c-txt__input--sm .c-txt__input--media__figure:first-child {
   margin: auto 0 auto var(--zd-txt--sm__media-end-margin);
 }
 /* stylelint-enable no-descending-specificity, selector-max-specificity */

--- a/packages/forms/src/_text/_size.css
+++ b/packages/forms/src/_text/_size.css
@@ -9,7 +9,6 @@
   --zd-txt--sm__input--select__chevron-background-size: 12px;
   --zd-txt--sm__input--select__chevron-width: calc(var(--zd-txt--sm__input--select-padding-unit) * 1px);
   --zd-txt-rtl--sm__input--select__chevron-background-position: left var(--zd-txt--sm__input--select__chevron-background-position-x) center;
-  --zd-txt--sm__media-start-margin: var(--zd-txt--sm__input-padding-horizontal);
   --zd-txt--sm__media-end-margin: calc(var(--zd-txt--sm__input-padding-horizontal) * (3 / 4));
 }
 
@@ -29,11 +28,6 @@
 
 .c-txt__input--sm::-ms-browse {
   font-size: 11px;
-}
-
-.c-txt__input--sm.c-txt__input--media {
-  padding-right: 0;
-  padding-left: 0;
 }
 
 .c-txt__input--sm.c-txt__input--select {
@@ -64,11 +58,11 @@ select.is-rtl.c-txt__input--sm.c-txt__input--select {
 
 .c-txt__input--sm .c-txt__input--media__figure:first-of-type,
 .is-rtl.c-txt__input--sm .c-txt__input--media__figure:last-of-type {
-  margin: auto var(--zd-txt--sm__media-end-margin) auto var(--zd-txt--sm__media-start-margin);
+  margin: auto var(--zd-txt--sm__media-end-margin) auto 0;
 }
 
 .c-txt__input--sm .c-txt__input--media__figure:last-of-type,
 .is-rtl.c-txt__input--sm .c-txt__input--media__figure:first-of-type {
-  margin: auto var(--zd-txt--sm__media-start-margin) auto var(--zd-txt--sm__media-end-margin);
+  margin: auto 0 auto var(--zd-txt--sm__media-end-margin);
 }
 /* stylelint-enable no-descending-specificity, selector-max-specificity */


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Also apply `cursor: text` to `.c-txt__input--media` elements.

## Detail

Partially addresses https://github.com/zendeskgarden/react-components/issues/265

## Checklist

* [ ] :ok_hand: ~style updates are Garden Designer approved (add the
  designer as a reviewer)~
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
