### PR TITLE
fix(menus): express item line-height via explicit pixels

### DIFF
--- a/packages/menus/src/_item.css
+++ b/packages/menus/src/_item.css
@@ -4,7 +4,7 @@
 
 :root {
   --zd-menu__item-color: var(--zd-color-grey-800);
-  --zd-menu__item-line-height: calc(20 / 14);
+  --zd-menu__item-line-height: 20px;
   --zd-menu__item-padding-horizontal: 32px;
   --zd-menu__item-padding-vertical: 10px;
   --zd-menu__item-padding: var(--zd-menu__item-padding-vertical) var(--zd-menu__item-padding-horizontal);
@@ -41,7 +41,7 @@
   --zd-menu--sm__item--media--icon-height: calc(var(--zd-menu--sm__item--media__figure-size) + calc(var(--zd-menu--sm__item-padding-vertical) * 2));
   --zd-menu__item__meta-color: var(--zd-color-grey-600);
   --zd-menu__item__meta-font-size: var(--zd-font-size-sm);
-  --zd-menu__item__meta-line-height: calc(16 / 12);
+  --zd-menu__item__meta-line-height: 16px;
 }
 
 /* 1. Allows an item to contain a positioned sub-menu.


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "fix(buttons):
     increase specificity for disabled state". the title informs the
     semantic version bump if this PR is merged. -->

- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Several `react-components` wrap menu items in a container for enhanced overflow support. Unitless line heights produce unexpected wrapper scrollbars in Chrome browsers. Providing definite pixel heights fixes Chrome's ability to calculate the correct height for the container <div>.

## Detail

addresses https://github.com/zendeskgarden/react-components/issues/279

## Checklist

* [ ] :ok_hand: ~style updates are Garden Designer approved (add the
  designer as a reviewer)~
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
