### PR TITLE
chore: fix demo hex value for `royal-400`

### DIFF
--- a/demo/utilities/color/index.html
+++ b/demo/utilities/color/index.html
@@ -1044,7 +1044,7 @@
               <div class="c-swatch__color u-bg-royal-400"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">royal-400</bold>
-                <span class="c-swatch__info__hex">5d7d5f</span>
+                <span class="c-swatch__info__hex">5d7df5</span>
               </figcaption>
             </figure>
           </div


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Update to display the correct variable value: `#5d7df5`.

## Detail

Demo has been pre-published for review: https://garden.zendesk.com/css-components/utilities/color/

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [ ] :white_check_mark: ~all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)~
* [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [ ] :nail_care: ~provides `custom.css` example for modifying the
  primary accent color~
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
