### PR TITLE
feat(tags): add secondary color styling modifiers

### DIFF
--- a/demo/tags/index.html
+++ b/demo/tags/index.html
@@ -10,6 +10,7 @@
   </script>
   <title>Tags / CSS Components / Zendesk Garden</title>
   <link href="../bedrock/index.css" rel="stylesheet">
+  <link href="../grid/index.css" rel="stylesheet">
   <link href="../menus/index.css" rel="stylesheet">
   <link href="../forms/checkbox/index.css" rel="stylesheet">
   <link href="../forms/range/index.css" rel="stylesheet">
@@ -136,24 +137,72 @@
         <h1 class="c-main__subtitle u-fs-xl u-mb">Colors</h1>
         <p class="u-mb">Modifiers may be added to override the tag color. The
         component contains colors for each Garden palette hue.</p>
-        <div class="l-grid u-mb">
-          <div class="l-grid__item u-1/6">
-            <div class="c-tag c-tag--grey"><span dir="ltr">.c-tag.c-tag--grey</span></div>
-          </div
-          ><div class="l-grid__item u-1/6">
-            <div class="c-tag c-tag--blue"><span dir="ltr">.c-tag.c-tag--blue</span></div>
-          </div
-          ><div class="l-grid__item u-1/6">
-            <div class="c-tag c-tag--kale"><span dir="ltr">.c-tag.c-tag--kale</span></div>
-          </div
-          ><div class="l-grid__item u-1/6">
-            <div class="c-tag c-tag--red"><span dir="ltr">.c-tag.c-tag--red</span></div>
-          </div
-          ><div class="l-grid__item u-1/6">
-            <div class="c-tag c-tag--green"><span dir="ltr">.c-tag.c-tag--green</span></div>
-          </div
-          ><div class="l-grid__item u-1/6">
-            <div class="c-tag c-tag--yellow"><span dir="ltr">.c-tag.c-tag--yellow</span></div>
+        <div class="row">
+          <div class="col-2">
+            <div class="u-mb">
+              <div class="c-tag c-tag--red"><span dir="ltr">.c-tag.c-tag--red</span></div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--crimson"><span dir="ltr">.c-tag.c-tag--crimson</span></div>
+            </div>
+            <div>
+              <div class="c-tag c-tag--pink"><span dir="ltr">.c-tag.c-tag--pink</span></div>
+            </div>
+          </div>
+          <div class="col-2">
+            <div class="u-mb">
+              <div class="c-tag c-tag--yellow"><span dir="ltr">.c-tag.c-tag--yellow</span></div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--lemon"><span dir="ltr">.c-tag.c-tag--lemon</span></div>
+            </div>
+            <div>
+              <div class="c-tag c-tag--orange"><span dir="ltr">.c-tag.c-tag--orange</span></div>
+            </div>
+          </div>
+          <div class="col-2">
+            <div class="u-mb">
+              <div class="c-tag c-tag--green"><span dir="ltr">.c-tag.c-tag--green</span></div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--mint"><span dir="ltr">.c-tag.c-tag--mint</span></div>
+            </div>
+            <div>
+              <div class="c-tag c-tag--lime"><span dir="ltr">.c-tag.c-tag--lime</span></div>
+            </div>
+          </div>
+          <div class="col-2">
+            <div class="u-mb">
+              <div class="c-tag c-tag--blue"><span dir="ltr">.c-tag.c-tag--blue</span></div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--azure"><span dir="ltr">.c-tag.c-tag--azure</span></div>
+            </div>
+            <div>
+              <div class="c-tag c-tag--royal"><span dir="ltr">.c-tag.c-tag--royal</span></div>
+            </div>
+          </div>
+          <div class="col-2">
+            <div class="u-mb">
+              <div class="c-tag c-tag--grey"><span dir="ltr">.c-tag.c-tag--grey</span></div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--purple"><span dir="ltr">.c-tag.c-tag--purple</span></div>
+            </div>
+            <div>
+              <div class="c-tag c-tag--fuschia"><span dir="ltr">.c-tag.c-tag--fuschia</span></div>
+            </div>
+          </div>
+          <div class="col-2">
+            <div class="u-mb">
+              <div class="c-tag"><span dir="ltr">.c-tag</span></div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--kale"><span dir="ltr">.c-tag.c-tag--kale</span></div>
+            </div>
+            <div>
+              <div class="c-tag c-tag--teal"><span dir="ltr">.c-tag.c-tag--teal</span></div>
+            </div>
           </div>
         </div>
       </section>
@@ -212,43 +261,127 @@
             </div>
           </div>
         </div>
-        <div class="l-grid u-mb">
-          <div class="l-grid__item u-1/3">
-            <div class="c-tag c-tag--grey" tabindex="0">
-              <span dir="ltr">.c-tag.c-tag--grey .c-tag__remove</span>
-              <button class="c-tag__remove" tabindex="-1"></button>
+        <p class="u-mb">The <i>remove</i> element displays correctly when
+        applied to color-modified tags.</p>
+        <div class="row">
+          <div class="col-2">
+            <div class="u-mb">
+              <div class="c-tag c-tag--red" tabindex="0">
+                <span dir="ltr">.c-tag--red .c-tag__remove</span>
+                <button class="c-tag__remove" tabindex="-1"></button>
+              </div>
             </div>
-          </div
-          ><div class="l-grid__item u-1/3">
-            <div class="c-tag c-tag--blue" tabindex="0">
-              <span dir="ltr">.c-tag.c-tag--blue .c-tag__remove</span>
-              <button class="c-tag__remove" tabindex="-1"></button>
+            <div class="u-mb">
+              <div class="c-tag c-tag--crimson" tabindex="0">
+                <span dir="ltr">.c-tag--crimson .c-tag__remove</span>
+                <button class="c-tag__remove" tabindex="-1"></button>
+              </div>
             </div>
-          </div
-          ><div class="l-grid__item u-1/3">
-            <div class="c-tag c-tag--green" tabindex="0">
-              <span dir="ltr">.c-tag.c-tag--green .c-tag__remove</span>
-              <button class="c-tag__remove" tabindex="-1"></button>
+            <div class="u-mb">
+              <div class="c-tag c-tag--pink" tabindex="0">
+                <span dir="ltr">.c-tag--pink .c-tag__remove</span>
+                <button class="c-tag__remove" tabindex="-1"></button>
+              </div>
             </div>
           </div>
-        </div>
-        <div class="l-grid u-mb">
-          <div class="l-grid__item u-1/3">
-            <div class="c-tag c-tag--kale" tabindex="0">
-              <span dir="ltr">.c-tag.c-tag--kale .c-tag__remove</span>
-              <button class="c-tag__remove" tabindex="-1"></button>
+          <div class="col-2">
+            <div class="u-mb">
+              <div class="c-tag c-tag--yellow" tabindex="0">
+                <span dir="ltr">.c-tag--yellow .c-tag__remove</span>
+                <button class="c-tag__remove" tabindex="-1"></button>
+              </div>
             </div>
-          </div
-          ><div class="l-grid__item u-1/3">
-            <div class="c-tag c-tag--red" tabindex="0">
-              <span dir="ltr">.c-tag.c-tag--red .c-tag__remove</span>
-              <button class="c-tag__remove" tabindex="-1"></button>
+            <div class="u-mb">
+              <div class="c-tag c-tag--lemon" tabindex="0">
+                <span dir="ltr">.c-tag--lemon .c-tag__remove</span>
+                <button class="c-tag__remove" tabindex="-1"></button>
+              </div>
             </div>
-          </div
-          ><div class="l-grid__item u-1/3">
-            <div class="c-tag c-tag--yellow" tabindex="0">
-              <span dir="ltr">.c-tag.c-tag--yellow .c-tag__remove</span>
-              <button class="c-tag__remove" tabindex="-1"></button>
+            <div class="u-mb">
+              <div class="c-tag c-tag--orange" tabindex="0">
+                <span dir="ltr">.c-tag--orange .c-tag__remove</span>
+                <button class="c-tag__remove" tabindex="-1"></button>
+              </div>
+            </div>
+          </div>
+          <div class="col-2">
+            <div class="u-mb">
+              <div class="c-tag c-tag--green" tabindex="0">
+                <span dir="ltr">.c-tag--green .c-tag__remove</span>
+                <button class="c-tag__remove" tabindex="-1"></button>
+              </div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--mint" tabindex="0">
+                <span dir="ltr">.c-tag--mint .c-tag__remove</span>
+                <button class="c-tag__remove" tabindex="-1"></button>
+              </div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--lime" tabindex="0">
+                <span dir="ltr">.c-tag--lime .c-tag__remove</span>
+                <button class="c-tag__remove" tabindex="-1"></button>
+              </div>
+            </div>
+          </div>
+          <div class="col-2">
+            <div class="u-mb">
+              <div class="c-tag c-tag--blue" tabindex="0">
+                <span dir="ltr">.c-tag--blue .c-tag__remove</span>
+                <button class="c-tag__remove" tabindex="-1"></button>
+              </div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--azure" tabindex="0">
+                <span dir="ltr">.c-tag--azure .c-tag__remove</span>
+                <button class="c-tag__remove" tabindex="-1"></button>
+              </div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--royal" tabindex="0">
+                <span dir="ltr">.c-tag--royal .c-tag__remove</span>
+                <button class="c-tag__remove" tabindex="-1"></button>
+              </div>
+            </div>
+          </div>
+          <div class="col-2">
+            <div class="u-mb">
+              <div class="c-tag c-tag--grey" tabindex="0">
+                <span dir="ltr">.c-tag--grey .c-tag__remove</span>
+                <button class="c-tag__remove" tabindex="-1"></button>
+              </div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--purple" tabindex="0">
+                <span dir="ltr">.c-tag--purple .c-tag__remove</span>
+                <button class="c-tag__remove" tabindex="-1"></button>
+              </div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--fuschia" tabindex="0">
+                <span dir="ltr">.c-tag--fuschia .c-tag__remove</span>
+                <button class="c-tag__remove" tabindex="-1"></button>
+              </div>
+            </div>
+          </div>
+          <div class="col-2">
+            <div class="u-mb">
+              <div class="c-tag" tabindex="0">
+                <span dir="ltr">.c-tag .c-tag__remove</span>
+                <button class="c-tag__remove" tabindex="-1"></button>
+              </div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--kale" tabindex="0">
+                <span dir="ltr">.c-tag--kale .c-tag__remove</span>
+                <button class="c-tag__remove" tabindex="-1"></button>
+              </div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--teal" tabindex="0">
+                <span dir="ltr">.c-tag--teal .c-tag__remove</span>
+                <button class="c-tag__remove" tabindex="-1"></button>
+              </div>
             </div>
           </div>
         </div>
@@ -321,76 +454,195 @@
         <p class="u-mb">Focus states are shown for the tags included in
         Garden. Remember to style an accompanying focus state along with custom
         background color overrides.</p>
-        <div class="l-grid u-mb">
-          <div class="l-grid__item u-1/4">
-            <div class="c-tag is-focused"><span dir="ltr">.c-tag.is-focused</span></div>
-          </div
-          ><div class="l-grid__item u-1/4">
-            <div class="c-tag c-tag--grey is-focused"><span dir="ltr">.c-tag.c-tag--grey.is-focused</span></div>
-          </div
-          ><div class="l-grid__item u-1/4">
-            <div class="c-tag c-tag--blue is-focused"><span dir="ltr">.c-tag.c-tag--blue.is-focused</span></div>
+        <div class="row">
+          <div class="col-2">
+            <div class="u-mb">
+              <div class="c-tag c-tag--red is-focused"><span dir="ltr">.c-tag--red.is-focused</span></div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--crimson is-focused"><span dir="ltr">.c-tag--crimson.is-focused</span></div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--pink is-focused"><span dir="ltr">.c-tag--pink.is-focused</span></div>
+            </div>
           </div>
-        </div>
-        <div class="l-grid u-mb">
-          <div class="l-grid__item u-1/4">
-            <div class="c-tag c-tag--kale is-focused"><span dir="ltr">.c-tag.c-tag--kale.is-focused</span></div>
-          </div
-          ><div class="l-grid__item u-1/4">
-            <div class="c-tag c-tag--red is-focused"><span dir="ltr">.c-tag.c-tag--red.is-focused</span></div>
-          </div
-          ><div class="l-grid__item u-1/4">
-            <div class="c-tag c-tag--green is-focused"><span dir="ltr">.c-tag.c-tag--green.is-focused</span></div>
-          </div
-          ><div class="l-grid__item u-1/4">
-            <div class="c-tag c-tag--yellow is-focused"><span dir="ltr">.c-tag.c-tag--yellow.is-focused</span></div>
+          <div class="col-2">
+            <div class="u-mb">
+              <div class="c-tag c-tag--yellow is-focused"><span dir="ltr">.c-tag--yellow.is-focused</span></div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--lemon is-focused"><span dir="ltr">.c-tag--lemon.is-focused</span></div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--orange is-focused"><span dir="ltr">.c-tag--orange.is-focused</span></div>
+            </div>
+          </div>
+          <div class="col-2">
+            <div class="u-mb">
+              <div class="c-tag c-tag--green is-focused"><span dir="ltr">.c-tag--green.is-focused</span></div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--mint is-focused"><span dir="ltr">.c-tag--mint.is-focused</span></div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--lime is-focused"><span dir="ltr">.c-tag--lime.is-focused</span></div>
+            </div>
+          </div>
+          <div class="col-2">
+            <div class="u-mb">
+              <div class="c-tag c-tag--blue is-focused"><span dir="ltr">.c-tag--blue.is-focused</span></div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--azure is-focused"><span dir="ltr">.c-tag--azure.is-focused</span></div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--royal is-focused"><span dir="ltr">.c-tag--royal.is-focused</span></div>
+            </div>
+          </div>
+          <div class="col-2">
+            <div class="u-mb">
+              <div class="c-tag c-tag--grey is-focused"><span dir="ltr">.c-tag--grey.is-focused</span></div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--purple is-focused"><span dir="ltr">.c-tag--purple.is-focused</span></div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--fuschia is-focused"><span dir="ltr">.c-tag--fuschia.is-focused</span></div>
+            </div>
+          </div>
+          <div class="col-2">
+            <div class="u-mb">
+              <div class="c-tag is-focused"><span dir="ltr">.c-tag.is-focused</span></div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--kale is-focused"><span dir="ltr">.c-tag--kale.is-focused</span></div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--teal is-focused"><span dir="ltr">.c-tag--teal.is-focused</span></div>
+            </div>
           </div>
         </div>
         <p class="u-mb">The hover state for the tag's remove icon is shown
         below.</p>
-        <div class="l-grid u-mb">
-          <div class="l-grid__item u-1/4">
-            <div class="c-tag">
-              <span dir="ltr">.c-tag .c-tag__remove.is-hovered</span>
-              <button class="c-tag__remove is-hovered" tabindex="-1"></button>
+        <div class="row">
+          <div class="col-2">
+            <div class="u-mb">
+              <div class="c-tag c-tag--red">
+                <span dir="ltr">.c-tag__remove.is-hovered</span>
+                <button class="c-tag__remove is-hovered" tabindex="-1"></button>
+              </div>
             </div>
-          </div
-          ><div class="l-grid__item u-1/4">
-            <div class="c-tag c-tag--grey">
-              <span dir="ltr">.c-tag .c-tag__remove.is-hovered</span>
-              <button class="c-tag__remove is-hovered" tabindex="-1"></button>
+            <div class="u-mb">
+              <div class="c-tag c-tag--crimson">
+                <span dir="ltr">.c-tag__remove.is-hovered</span>
+                <button class="c-tag__remove is-hovered" tabindex="-1"></button>
+              </div>
             </div>
-          </div
-          ><div class="l-grid__item u-1/4">
-            <div class="c-tag c-tag--blue">
-              <span dir="ltr">.c-tag .c-tag__remove.is-hovered</span>
-              <button class="c-tag__remove is-hovered" tabindex="-1"></button>
-            </div>
-          </div
-          ><div class="l-grid__item u-1/4">
-            <div class="c-tag c-tag--kale">
-              <span dir="ltr">.c-tag .c-tag__remove.is-hovered</span>
-              <button class="c-tag__remove is-hovered" tabindex="-1"></button>
+            <div class="u-mb">
+              <div class="c-tag c-tag--pink">
+                <span dir="ltr">.c-tag__remove.is-hovered</span>
+                <button class="c-tag__remove is-hovered" tabindex="-1"></button>
+              </div>
             </div>
           </div>
-        </div>
-        <div class="l-grid u-mb">
-          <div class="l-grid__item u-1/4">
-            <div class="c-tag c-tag--red">
-              <span dir="ltr">.c-tag .c-tag__remove.is-hovered</span>
-              <button class="c-tag__remove is-hovered" tabindex="-1"></button>
+          <div class="col-2">
+            <div class="u-mb">
+              <div class="c-tag c-tag--yellow">
+                <span dir="ltr">.c-tag__remove.is-hovered</span>
+                <button class="c-tag__remove is-hovered" tabindex="-1"></button>
+              </div>
             </div>
-          </div
-          ><div class="l-grid__item u-1/4">
-            <div class="c-tag c-tag--green">
-              <span dir="ltr">.c-tag .c-tag__remove.is-hovered</span>
-              <button class="c-tag__remove is-hovered" tabindex="-1"></button>
+            <div class="u-mb">
+              <div class="c-tag c-tag--lemon">
+                <span dir="ltr">.c-tag__remove.is-hovered</span>
+                <button class="c-tag__remove is-hovered" tabindex="-1"></button>
+              </div>
             </div>
-          </div
-          ><div class="l-grid__item u-1/4">
-            <div class="c-tag c-tag--yellow">
-              <span dir="ltr">.c-tag .c-tag__remove.is-hovered</span>
-              <button class="c-tag__remove is-hovered" tabindex="-1"></button>
+            <div class="u-mb">
+              <div class="c-tag c-tag--orange">
+                <span dir="ltr">.c-tag__remove.is-hovered</span>
+                <button class="c-tag__remove is-hovered" tabindex="-1"></button>
+              </div>
+            </div>
+          </div>
+          <div class="col-2">
+            <div class="u-mb">
+              <div class="c-tag c-tag--green">
+                <span dir="ltr">.c-tag__remove.is-hovered</span>
+                <button class="c-tag__remove is-hovered" tabindex="-1"></button>
+              </div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--mint">
+                <span dir="ltr">.c-tag__remove.is-hovered</span>
+                <button class="c-tag__remove is-hovered" tabindex="-1"></button>
+              </div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--lime">
+                <span dir="ltr">.c-tag__remove.is-hovered</span>
+                <button class="c-tag__remove is-hovered" tabindex="-1"></button>
+              </div>
+            </div>
+          </div>
+          <div class="col-2">
+            <div class="u-mb">
+              <div class="c-tag c-tag--blue">
+                <span dir="ltr">.c-tag__remove.is-hovered</span>
+                <button class="c-tag__remove is-hovered" tabindex="-1"></button>
+              </div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--azure">
+                <span dir="ltr">.c-tag__remove.is-hovered</span>
+                <button class="c-tag__remove is-hovered" tabindex="-1"></button>
+              </div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--royal">
+                <span dir="ltr">.c-tag__remove.is-hovered</span>
+                <button class="c-tag__remove is-hovered" tabindex="-1"></button>
+              </div>
+            </div>
+          </div>
+          <div class="col-2">
+            <div class="u-mb">
+              <div class="c-tag c-tag--grey">
+                <span dir="ltr">.c-tag__remove.is-hovered</span>
+                <button class="c-tag__remove is-hovered" tabindex="-1"></button>
+              </div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--purple">
+                <span dir="ltr">.c-tag__remove.is-hovered</span>
+                <button class="c-tag__remove is-hovered" tabindex="-1"></button>
+              </div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--fuschia">
+                <span dir="ltr">.c-tag__remove.is-hovered</span>
+                <button class="c-tag__remove is-hovered" tabindex="-1"></button>
+              </div>
+            </div>
+          </div>
+          <div class="col-2">
+            <div class="u-mb">
+              <div class="c-tag">
+                <span dir="ltr">.c-tag__remove.is-hovered</span>
+                <button class="c-tag__remove is-hovered" tabindex="-1"></button>
+              </div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--kale">
+                <span dir="ltr">.c-tag__remove.is-hovered</span>
+                <button class="c-tag__remove is-hovered" tabindex="-1"></button>
+              </div>
+            </div>
+            <div class="u-mb">
+              <div class="c-tag c-tag--teal">
+                <span dir="ltr">.c-tag__remove.is-hovered</span>
+                <button class="c-tag__remove is-hovered" tabindex="-1"></button>
+              </div>
             </div>
           </div>
         </div>

--- a/packages/tags/src/_color.css
+++ b/packages/tags/src/_color.css
@@ -3,17 +3,37 @@
 @import '_selectors';
 
 :root {
+  --zd-tag--azure-background-color: var(--zd-color-secondary-azure-600);
   --zd-tag--blue-background-color: var(--zd-color-blue-600);
+  --zd-tag--crimson-background-color: var(--zd-color-secondary-crimson-600);
+  --zd-tag--fuschia-background-color: var(--zd-color-secondary-fuschia-600);
   --zd-tag--green-background-color: var(--zd-color-green-600);
   --zd-tag--grey-background-color: var(--zd-color-grey-600);
   --zd-tag--kale-background-color: var(--zd-color-kale-600);
+  --zd-tag--lemon-background-color: var(--zd-color-secondary-lemon-600);
+  --zd-tag--lime-background-color: var(--zd-color-secondary-lime-600);
+  --zd-tag--mint-background-color: var(--zd-color-secondary-mint-600);
+  --zd-tag--orange-background-color: var(--zd-color-secondary-orange-600);
+  --zd-tag--pink-background-color: var(--zd-color-secondary-pink-600);
+  --zd-tag--purple-background-color: var(--zd-color-secondary-purple-600);
   --zd-tag--red-background-color: var(--zd-color-red-600);
+  --zd-tag--royal-background-color: var(--zd-color-secondary-royal-600);
+  --zd-tag--teal-background-color: var(--zd-color-secondary-teal-600);
   --zd-tag--yellow-background-color: var(--zd-color-yellow-400);
   --zd-tag--color-color: var(--zd-color-white);
   --zd-tag--yellow-color: var(--zd-color-yellow-800);
+  --zd-tag--azure-focused-box-shadow:
+    var(--zd-tag-focused-box-shadow)
+    color-mod(var(--zd-tag--azure-background-color) alpha(35%));
   --zd-tag--blue-focused-box-shadow:
     var(--zd-tag-focused-box-shadow)
     color-mod(var(--zd-tag--blue-background-color) alpha(35%));
+  --zd-tag--crimson-focused-box-shadow:
+    var(--zd-tag-focused-box-shadow)
+    color-mod(var(--zd-tag--crimson-background-color) alpha(35%));
+  --zd-tag--fuschia-focused-box-shadow:
+    var(--zd-tag-focused-box-shadow)
+    color-mod(var(--zd-tag--fuschia-background-color) alpha(35%));
   --zd-tag--green-focused-box-shadow:
     var(--zd-tag-focused-box-shadow)
     color-mod(var(--zd-tag--green-background-color) alpha(35%));
@@ -23,16 +43,55 @@
   --zd-tag--kale-focused-box-shadow:
     var(--zd-tag-focused-box-shadow)
     color-mod(var(--zd-tag--kale-background-color) alpha(35%));
+  --zd-tag--lemon-focused-box-shadow:
+    var(--zd-tag-focused-box-shadow)
+    color-mod(var(--zd-tag--lemon-background-color) alpha(35%));
+  --zd-tag--lime-focused-box-shadow:
+    var(--zd-tag-focused-box-shadow)
+    color-mod(var(--zd-tag--lime-background-color) alpha(35%));
+  --zd-tag--mint-focused-box-shadow:
+    var(--zd-tag-focused-box-shadow)
+    color-mod(var(--zd-tag--mint-background-color) alpha(35%));
+  --zd-tag--orange-focused-box-shadow:
+    var(--zd-tag-focused-box-shadow)
+    color-mod(var(--zd-tag--orange-background-color) alpha(35%));
+  --zd-tag--pink-focused-box-shadow:
+    var(--zd-tag-focused-box-shadow)
+    color-mod(var(--zd-tag--pink-background-color) alpha(35%));
+  --zd-tag--purple-focused-box-shadow:
+    var(--zd-tag-focused-box-shadow)
+    color-mod(var(--zd-tag--purple-background-color) alpha(35%));
   --zd-tag--red-focused-box-shadow:
     var(--zd-tag-focused-box-shadow)
     color-mod(var(--zd-tag--red-background-color) alpha(35%));
+  --zd-tag--royal-focused-box-shadow:
+    var(--zd-tag-focused-box-shadow)
+    color-mod(var(--zd-tag--royal-background-color) alpha(35%));
+  --zd-tag--teal-focused-box-shadow:
+    var(--zd-tag-focused-box-shadow)
+    color-mod(var(--zd-tag--teal-background-color) alpha(35%));
   --zd-tag--yellow-focused-box-shadow:
     var(--zd-tag-focused-box-shadow)
     color-mod(var(--zd-tag--yellow-background-color) alpha(35%));
 }
 
+.c-tag.c-tag--azure {
+  background-color: var(--zd-tag--azure-background-color);
+  color: var(--zd-tag--color-color);
+}
+
 .c-tag.c-tag--blue {
   background-color: var(--zd-tag--blue-background-color);
+  color: var(--zd-tag--color-color);
+}
+
+.c-tag.c-tag--crimson {
+  background-color: var(--zd-tag--crimson-background-color);
+  color: var(--zd-tag--color-color);
+}
+
+.c-tag.c-tag--fuschia {
+  background-color: var(--zd-tag--fuschia-background-color);
   color: var(--zd-tag--color-color);
 }
 
@@ -51,8 +110,48 @@
   color: var(--zd-tag--color-color);
 }
 
+.c-tag.c-tag--lemon {
+  background-color: var(--zd-tag--lemon-background-color);
+  color: var(--zd-tag--yellow-color);
+}
+
+.c-tag.c-tag--lime {
+  background-color: var(--zd-tag--lime-background-color);
+  color: var(--zd-tag--color-color);
+}
+
+.c-tag.c-tag--mint {
+  background-color: var(--zd-tag--mint-background-color);
+  color: var(--zd-tag--color-color);
+}
+
+.c-tag.c-tag--orange {
+  background-color: var(--zd-tag--orange-background-color);
+  color: var(--zd-tag--color-color);
+}
+
+.c-tag.c-tag--pink {
+  background-color: var(--zd-tag--pink-background-color);
+  color: var(--zd-tag--color-color);
+}
+
+.c-tag.c-tag--purple {
+  background-color: var(--zd-tag--purple-background-color);
+  color: var(--zd-tag--color-color);
+}
+
 .c-tag.c-tag--red {
   background-color: var(--zd-tag--red-background-color);
+  color: var(--zd-tag--color-color);
+}
+
+.c-tag.c-tag--royal {
+  background-color: var(--zd-tag--royal-background-color);
+  color: var(--zd-tag--color-color);
+}
+
+.c-tag.c-tag--teal {
+  background-color: var(--zd-tag--teal-background-color);
   color: var(--zd-tag--color-color);
 }
 
@@ -61,8 +160,20 @@
   color: var(--zd-tag--yellow-color);
 }
 
+.c-tag.c-tag--azure:--tag-focused {
+  box-shadow: var(--zd-tag--azure-focused-box-shadow);
+}
+
 .c-tag.c-tag--blue:--tag-focused {
   box-shadow: var(--zd-tag--blue-focused-box-shadow);
+}
+
+.c-tag.c-tag--crimson:--tag-focused {
+  box-shadow: var(--zd-tag--crimson-focused-box-shadow);
+}
+
+.c-tag.c-tag--fuschia:--tag-focused {
+  box-shadow: var(--zd-tag--fuschia-focused-box-shadow);
 }
 
 .c-tag.c-tag--green:--tag-focused {
@@ -77,8 +188,40 @@
   box-shadow: var(--zd-tag--kale-focused-box-shadow);
 }
 
+.c-tag.c-tag--lemon:--tag-focused {
+  box-shadow: var(--zd-tag--lemon-focused-box-shadow);
+}
+
+.c-tag.c-tag--lime:--tag-focused {
+  box-shadow: var(--zd-tag--lime-focused-box-shadow);
+}
+
+.c-tag.c-tag--mint:--tag-focused {
+  box-shadow: var(--zd-tag--mint-focused-box-shadow);
+}
+
+.c-tag.c-tag--orange:--tag-focused {
+  box-shadow: var(--zd-tag--orange-focused-box-shadow);
+}
+
+.c-tag.c-tag--pink:--tag-focused {
+  box-shadow: var(--zd-tag--pink-focused-box-shadow);
+}
+
+.c-tag.c-tag--purple:--tag-focused {
+  box-shadow: var(--zd-tag--purple-focused-box-shadow);
+}
+
 .c-tag.c-tag--red:--tag-focused {
   box-shadow: var(--zd-tag--red-focused-box-shadow);
+}
+
+.c-tag.c-tag--royal:--tag-focused {
+  box-shadow: var(--zd-tag--royal-focused-box-shadow);
+}
+
+.c-tag.c-tag--teal:--tag-focused {
+  box-shadow: var(--zd-tag--teal-focused-box-shadow);
 }
 
 .c-tag.c-tag--yellow:--tag-focused {

--- a/packages/tags/src/_remove.css
+++ b/packages/tags/src/_remove.css
@@ -72,16 +72,29 @@
 }
 
 .c-tag:matches(
+.c-tag--azure,
 .c-tag--blue,
+.c-tag--crimson,
+.c-tag--fuschia,
 .c-tag--green,
 .c-tag--grey,
 .c-tag--kale,
-.c-tag--red
+.c-tag--lime,
+.c-tag--mint,
+.c-tag--orange,
+.c-tag--pink,
+.c-tag--purple,
+.c-tag--red,
+.c-tag--royal,
+.c-tag--teal
 ) .c-tag__remove {
   background-image: var(--zd-tag--color__remove-background-image);
 }
 
-.c-tag.c-tag--yellow .c-tag__remove {
+.c-tag:matches(
+.c-tag--lemon,
+.c-tag--yellow
+) .c-tag__remove {
   background-image: var(--zd-tag--yellow__remove-background-image);
 }
 


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Adds:

* `.c-tag--azure`
* `.c-tag--crimson`
* `.c-tag--fuschia`
* `.c-tag--lemon`
* `.c-tag--lime`
* `.c-tag--mint`
* `.c-tag--orange`
* `.c-tag--pink`
* `.c-tag--purple`
* `.c-tag--royal`
* `.c-tag--teal`

## Detail

Demo pre-published for review: https://garden.zendesk.com/css-components/tags/

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
