### PR TITLE
feat(variables|utilities): add font sizes for monospace typography

### DIFF
--- a/demo/utilities/typography/index.html
+++ b/demo/utilities/typography/index.html
@@ -15,6 +15,11 @@
   <link href="../index.css" rel="stylesheet">
   <style>
   .u-border.u-display-inline-block { line-height: 1; }
+  .c-code {
+    padding: 0 2px;
+    background-color: #E9EBED;
+    color: #49545C;
+  }
   </style>
 </head>
 <body class="u-font-family-system">
@@ -105,17 +110,17 @@
 
       <div class="u-ml u-mb-lg">
         <h4 class="u-fs-md u-mb">Monospace
-          <code class="c-code">.u-fs-sm-monospace</code>
+          <code class="c-code">.u-font-family-monospace</code>
           <span>(11px)</span></h4>
-        <ul class="u-font-family-monospace u-fs-sm-monospace">
+        <ul class="u-font-family-monospace u-fs-sm">
           <li class="u-regular u-mb-sm">
-            <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">MONOSPACE</span>
+            <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">REGULAR</span>
             <code class="c-code">.u-regular</code>
             <p class="js-sample u-lh-sm"></p>
             <p><i class="js-sample u-lh-sm"></i></p>
           </li>
           <li class="u-semibold u-mb-sm">
-            <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">MONOSPACE</span>
+            <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">SEMIBOLD</span>
             <code class="c-code">.u-semibold</code>
             <p class="js-sample u-lh-sm"></p>
             <p><i class="js-sample u-lh-sm"></i></p>
@@ -143,20 +148,20 @@
 
       <div class="u-ml u-mb-lg">
         <h4 class="u-fs-md u-mb">Monospace
-          <code class="c-code">.u-fs-md-monospace</code>
-          <span>(11px)</span></h4>
-        <ul class="u-font-family-monospace u-fs-md-monospace">
+          <code class="c-code">.u-font-family-monospace</code>
+          <span>(13px)</span></h4>
+        <ul class="u-font-family-monospace u-fs-md">
           <li class="u-regular u-mb-sm">
-            <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">MONOSPACE</span>
+            <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">REGULAR</span>
             <code class="c-code">.u-regular</code>
-            <p class="js-sample u-lh-sm"></p>
-            <p><i class="js-sample u-lh-sm"></i></p>
+            <p class="js-sample u-lh-md"></p>
+            <p><i class="js-sample u-lh-md"></i></p>
           </li>
           <li class="u-semibold u-mb-sm">
-            <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">MONOSPACE</span>
+            <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">SEMIBOLD</span>
             <code class="c-code">.u-semibold</code>
-            <p class="js-sample u-lh-sm"></p>
-            <p><i class="js-sample u-lh-sm"></i></p>
+            <p class="js-sample u-lh-md"></p>
+            <p><i class="js-sample u-lh-md"></i></p>
           </li>
         </ul>
       </div>
@@ -181,20 +186,20 @@
 
       <div class="u-ml u-mb-lg">
         <h4 class="u-fs-md u-mb">Monospace
-          <code class="c-code">.u-fs-lg-monospace</code>
-          <span>(11px)</span></h4>
-        <ul class="u-font-family-monospace u-fs-lg-monospace">
+          <code class="c-code">.u-font-family-monospace</code>
+          <span>(17px)</span></h4>
+        <ul class="u-font-family-monospace u-fs-lg">
           <li class="u-regular u-mb-sm">
-            <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">MONOSPACE</span>
+            <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">REGULAR</span>
             <code class="c-code">.u-regular</code>
-            <p class="js-sample u-lh-sm"></p>
-            <p><i class="js-sample u-lh-sm"></i></p>
+            <p class="js-sample u-lh-lg"></p>
+            <p><i class="js-sample u-lh-lg"></i></p>
           </li>
           <li class="u-semibold u-mb-sm">
-            <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">MONOSPACE</span>
+            <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">SEMIBOLD</span>
             <code class="c-code">.u-semibold</code>
-            <p class="js-sample u-lh-sm"></p>
-            <p><i class="js-sample u-lh-sm"></i></p>
+            <p class="js-sample u-lh-lg"></p>
+            <p><i class="js-sample u-lh-lg"></i></p>
           </li>
         </ul>
       </div>

--- a/demo/utilities/typography/index.html
+++ b/demo/utilities/typography/index.html
@@ -88,7 +88,7 @@
       <h3 class="u-fs-lg u-mb"><span id="small">Small</span>
         <code class="c-code">.u-fs-sm</code>
         <span>(12px)</span></h3>
-      <ul class="u-fs-sm u-mb-lg">
+      <ul class="u-fs-sm u-mb">
         <li class="u-regular u-mb-sm">
           <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">REGULAR</span>
           <code class="c-code">.u-regular</code>
@@ -102,11 +102,31 @@
           <p><i class="js-sample u-lh-sm"></i></p>
         </li>
       </ul>
+
+      <div class="u-ml u-mb-lg">
+        <h4 class="u-fs-md u-mb">Monospace
+          <code class="c-code">.u-fs-sm-monospace</code>
+          <span>(11px)</span></h4>
+        <ul class="u-font-family-monospace u-fs-sm-monospace">
+          <li class="u-regular u-mb-sm">
+            <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">MONOSPACE</span>
+            <code class="c-code">.u-regular</code>
+            <p class="js-sample u-lh-sm"></p>
+            <p><i class="js-sample u-lh-sm"></i></p>
+          </li>
+          <li class="u-semibold u-mb-sm">
+            <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">MONOSPACE</span>
+            <code class="c-code">.u-semibold</code>
+            <p class="js-sample u-lh-sm"></p>
+            <p><i class="js-sample u-lh-sm"></i></p>
+          </li>
+        </ul>
+      </div>
 
       <h3 class="u-fs-lg u-mb"><span id="medium">Medium</span>
         <code class="c-code">.u-fs-md</code>
         <span>(14px)</span></h3>
-      <ul class="u-fs-md u-mb-lg">
+      <ul class="u-fs-md u-mb">
         <li class="u-regular u-mb-sm">
           <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">REGULAR</span>
           <code class="c-code">.u-regular</code>
@@ -121,10 +141,30 @@
         </li>
       </ul>
 
+      <div class="u-ml u-mb-lg">
+        <h4 class="u-fs-md u-mb">Monospace
+          <code class="c-code">.u-fs-md-monospace</code>
+          <span>(11px)</span></h4>
+        <ul class="u-font-family-monospace u-fs-md-monospace">
+          <li class="u-regular u-mb-sm">
+            <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">MONOSPACE</span>
+            <code class="c-code">.u-regular</code>
+            <p class="js-sample u-lh-sm"></p>
+            <p><i class="js-sample u-lh-sm"></i></p>
+          </li>
+          <li class="u-semibold u-mb-sm">
+            <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">MONOSPACE</span>
+            <code class="c-code">.u-semibold</code>
+            <p class="js-sample u-lh-sm"></p>
+            <p><i class="js-sample u-lh-sm"></i></p>
+          </li>
+        </ul>
+      </div>
+
       <h3 class="u-fs-lg u-mb"><span id="large">Large</span>
         <code class="c-code">.u-fs-lg</code>
         <span>(18px)</span></h3>
-      <ul class="u-fs-lg u-mb-lg">
+      <ul class="u-fs-lg u-mb">
         <li class="u-regular u-mb-sm">
           <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">REGULAR</span>
           <code class="c-code">.u-regular</code>
@@ -138,6 +178,26 @@
           <p><i class="js-sample u-lh-lg"></i></p>
         </li>
       </ul>
+
+      <div class="u-ml u-mb-lg">
+        <h4 class="u-fs-md u-mb">Monospace
+          <code class="c-code">.u-fs-lg-monospace</code>
+          <span>(11px)</span></h4>
+        <ul class="u-font-family-monospace u-fs-lg-monospace">
+          <li class="u-regular u-mb-sm">
+            <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">MONOSPACE</span>
+            <code class="c-code">.u-regular</code>
+            <p class="js-sample u-lh-sm"></p>
+            <p><i class="js-sample u-lh-sm"></i></p>
+          </li>
+          <li class="u-semibold u-mb-sm">
+            <span class="u-border u-bc-grey-400 u-mb-xs u-display-inline-block u-ph-xxs">MONOSPACE</span>
+            <code class="c-code">.u-semibold</code>
+            <p class="js-sample u-lh-sm"></p>
+            <p><i class="js-sample u-lh-sm"></i></p>
+          </li>
+        </ul>
+      </div>
 
       <h3 class="u-fs-lg u-mb"><span id="xl">Extra-Large</span>
         <code class="c-code">.u-fs-xl</code>
@@ -196,7 +256,8 @@
         <h1 class="c-main__subtitle u-fs-xl u-mb">Playground</h1>
         <div class="c-playground">
           <div class="c-playground__preview"></div>
-<textarea class="c-playground__code"><pre class="u-font-family-inherit u-fs-lg">é - accent acute
+<textarea class="c-playground__code"><div class="u-font-family-system u-fs-lg">
+<pre class="u-font-family-inherit">é - accent acute
 è - accent grave
 ê - circumflex
 ë - umlaut or diaerisis
@@ -209,7 +270,8 @@
 œ - ligature
 ē - macron
 č - háček
-ŭ - crescent</pre></textarea>
+ŭ - crescent</pre>
+</div></textarea>
         </div>
       </section>
     </div>

--- a/demo/utilities/typography/index.html
+++ b/demo/utilities/typography/index.html
@@ -15,11 +15,6 @@
   <link href="../index.css" rel="stylesheet">
   <style>
   .u-border.u-display-inline-block { line-height: 1; }
-  .c-code {
-    padding: 0 2px;
-    background-color: #E9EBED;
-    color: #49545C;
-  }
   </style>
 </head>
 <body class="u-font-family-system">

--- a/packages/utilities/src/font-size.css
+++ b/packages/utilities/src/font-size.css
@@ -25,10 +25,13 @@
 
 /* Monospace Font Sizes */
 
-.u-fs-sm-monospace { font-size: var(--zd-font-size-sm-monospace) !important; }
+.u-fs-sm.u-font-family-monospace,
+.u-fs-sm .u-font-family-monospace { font-size: var(--zd-font-size-sm-monospace) !important; }
 
-.u-fs-md-monospace { font-size: var(--zd-font-size-md-monospace) !important; }
+.u-fs-md.u-font-family-monospace,
+.u-fs-md .u-font-family-monospace { font-size: var(--zd-font-size-md-monospace) !important; }
 
-.u-fs-lg-monospace { font-size: var(--zd-font-size-lg-monospace) !important; }
+.u-fs-lg.u-font-family-monospace,
+.u-fs-lg .u-font-family-monospace { font-size: var(--zd-font-size-lg-monospace) !important; }
 
 /* stylelint-enable declaration-no-important */

--- a/packages/utilities/src/font-size.css
+++ b/packages/utilities/src/font-size.css
@@ -23,4 +23,12 @@
 
 .u-fs-xxxl { font-size: var(--zd-font-size-xxxl) !important; }
 
+/* Monospace Font Sizes */
+
+.u-fs-sm-monospace { font-size: var(--zd-font-size-sm-monospace) !important; }
+
+.u-fs-md-monospace { font-size: var(--zd-font-size-md-monospace) !important; }
+
+.u-fs-lg-monospace { font-size: var(--zd-font-size-lg-monospace) !important; }
+
 /* stylelint-enable declaration-no-important */

--- a/packages/variables/src/_font-size.js
+++ b/packages/variables/src/_font-size.js
@@ -5,7 +5,7 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-const retVal = {
+let retVal = {
   sm: '12px',
   md: '14px',
   lg: '18px',
@@ -13,5 +13,12 @@ const retVal = {
   xxl: '26px',
   xxxl: '36px'
 };
+
+/* Monospace font sizes */
+retVal = Object.assign(retVal, {
+  'sm-monospace': '11px',
+  'md-monospace': '13px',
+  'lg-monospace': '17px'
+});
 
 module.exports = retVal;


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Adds `sm`, `md`, and `lg` font sizing for the monospace font family.

## Detail

The demo has been pre-published for review: https://garden.zendesk.com/css-components/utilities/typography/

A couple of items to note:
* We're testing more class combinations than Garden cares to utilize in product
* The existing `code` treatment is limited to the demo site but was updated to be very nearly accurate with updated designs

Both of these items will be 100% solved under `react-components`.

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [ ] :nail_care: ~provides `custom.css` example for modifying the
  primary accent color~
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
