### PR TITLE
fix(chrome): prevent half pixel header item padding

### DIFF
--- a/packages/chrome/src/_header.css
+++ b/packages/chrome/src/_header.css
@@ -18,7 +18,7 @@
   --zd-chrome__body__header__item-line-height: calc(30 / 14);
   --zd-chrome__body__header__item-margin: 0 12px;
   --zd-chrome__body__header__item-size: 30px;
-  --zd-chrome__body__header__item-padding: 0 calc(calc(var(--zd-chrome__body__header__item-size) - var(--zd-chrome__body__header__item__icon-size)) / 4);
+  --zd-chrome__body__header__item-padding: 0 4px;
   --zd-chrome__body__header__item-transition:
     box-shadow .1s ease-in-out,
     color .1s ease-in-out;


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

## Detail

Addresses issue discussed under https://github.com/zendeskgarden/css-components/pull/186#pullrequestreview-229676833

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
