### PR TITLE
fix(forms): disabled multi-range slider cursor

### DIFF
--- a/packages/forms/src/_range/_slider.css
+++ b/packages/forms/src/_range/_slider.css
@@ -90,7 +90,7 @@
   box-shadow: none;
 }
 
-.c-range__slider.is-disabled .c-range__slider {
+.c-range__slider.is-disabled {
   cursor: default;
 }
 


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Set to `default` (vs. `pointer`).

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
