### PR TITLE
fix(avatars): use `::after` psuedo for status badge information

### DIFF
--- a/demo/avatars/index.html
+++ b/demo/avatars/index.html
@@ -130,7 +130,7 @@
       <ul class="u-mb-lg">
         <li class="l-flag u-mb-sm">
           <div class="l-flag__figure">
-            <figure class="c-avatar" aria-live="polite">
+            <figure class="c-avatar">
               <img alt="user" src="images/user.svg">
             </figure>
           </div>

--- a/demo/avatars/index.html
+++ b/demo/avatars/index.html
@@ -130,9 +130,8 @@
       <ul class="u-mb-lg">
         <li class="l-flag u-mb-sm">
           <div class="l-flag__figure">
-            <figure class="c-avatar">
+            <figure class="c-avatar" aria-live="polite">
               <img alt="user" src="images/user.svg">
-              <figcaption class="c-avatar__badge"></figcaption>
             </figure>
           </div>
           <div class="l-flag__body">
@@ -143,7 +142,6 @@
           <div class="l-flag__figure">
             <figure class="c-avatar c-avatar--system">
               <img alt="system" src="images/system.png">
-              <figcaption class="c-avatar__badge"></figcaption>
             </figure>
           </div>
           <div class="l-flag__body">
@@ -158,7 +156,6 @@
             <div class="l-flag__figure">
               <figure class="c-avatar c-avatar--xs">
                 <img alt="user" src="images/user.svg">
-                <figcaption class="c-avatar__badge"></figcaption>
               </figure>
             </div>
             <div class="l-flag__body">
@@ -169,7 +166,6 @@
             <div class="l-flag__figure">
               <figure class="c-avatar c-avatar--xs c-avatar--system">
                 <img alt="system" src="images/system.png">
-                <figcaption class="c-avatar__badge"></figcaption>
               </figure>
             </div>
             <div class="l-flag__body">
@@ -182,7 +178,6 @@
             <div class="l-flag__figure">
               <figure class="c-avatar c-avatar--sm">
                 <img alt="user" src="images/user.svg">
-                <figcaption class="c-avatar__badge"></figcaption>
               </figure>
             </div>
             <div class="l-flag__body">
@@ -193,7 +188,6 @@
             <div class="l-flag__figure">
               <figure class="c-avatar c-avatar--sm c-avatar--system">
                 <img alt="system" src="images/system.png">
-                <figcaption class="c-avatar__badge"></figcaption>
               </figure>
             </div>
             <div class="l-flag__body">
@@ -206,7 +200,6 @@
             <div class="l-flag__figure">
               <figure class="c-avatar c-avatar--lg">
                 <img alt="user" src="images/user.svg">
-                <figcaption class="c-avatar__badge"></figcaption>
               </figure>
             </div>
             <div class="l-flag__body">
@@ -217,7 +210,6 @@
             <div class="l-flag__figure">
               <figure class="c-avatar c-avatar--lg c-avatar--system">
                 <img alt="system" src="images/system.png">
-                <figcaption class="c-avatar__badge"></figcaption>
               </figure>
             </div>
             <div class="l-flag__body">
@@ -239,7 +231,6 @@
           <div class="l-flag__figure">
             <figure class="c-avatar c-avatar--xs u-bg-fuschia-600">
               <span class="c-avatar__txt">G</span>
-              <figcaption class="c-avatar__badge"></figcaption>
             </figure>
           </div>
           <div class="l-flag__body">
@@ -250,7 +241,6 @@
           <div class="l-flag__figure">
             <figure class="c-avatar c-avatar--system c-avatar--xs u-bg-fuschia-600">
               <span class="c-avatar__txt">ZD</span>
-              <figcaption class="c-avatar__badge"></figcaption>
             </figure>
           </div>
           <div class="l-flag__body">
@@ -261,7 +251,6 @@
           <div class="l-flag__figure">
             <figure class="c-avatar c-avatar--sm u-bg-purple-600">
               <span class="c-avatar__txt">A</span>
-              <figcaption class="c-avatar__badge"></figcaption>
             </figure>
           </div>
           <div class="l-flag__body">
@@ -272,7 +261,6 @@
           <div class="l-flag__figure">
             <figure class="c-avatar c-avatar--system c-avatar--sm u-bg-purple-600">
               <span class="c-avatar__txt">ZD</span>
-              <figcaption class="c-avatar__badge"></figcaption>
             </figure>
           </div>
           <div class="l-flag__body">
@@ -283,7 +271,6 @@
           <div class="l-flag__figure">
             <figure class="c-avatar u-bg-royal-600">
               <span class="c-avatar__txt">R</span>
-              <figcaption class="c-avatar__badge"></figcaption>
             </figure>
           </div>
           <div class="l-flag__body">
@@ -294,7 +281,6 @@
           <div class="l-flag__figure">
             <figure class="c-avatar c-avatar--system u-bg-royal-600">
               <span class="c-avatar__txt">ZD</span>
-              <figcaption class="c-avatar__badge"></figcaption>
             </figure>
           </div>
           <div class="l-flag__body">
@@ -305,7 +291,6 @@
           <div class="l-flag__figure">
             <figure class="c-avatar c-avatar--lg u-bg-azure-600">
               <span class="c-avatar__txt">DN</span>
-              <figcaption class="c-avatar__badge"></figcaption>
             </figure>
           </div>
           <div class="l-flag__body">
@@ -316,7 +301,6 @@
           <div class="l-flag__figure">
             <figure class="c-avatar c-avatar--system c-avatar--lg u-bg-azure-600">
               <span class="c-avatar__txt">ZD</span>
-              <figcaption class="c-avatar__badge"></figcaption>
             </figure>
           </div>
           <div class="l-flag__body">
@@ -331,7 +315,6 @@
               <svg>
                 <use xlink:href="../index.svg#zd-svg-icon-16-user-solo-stroke">
               </svg>
-              <figcaption class="c-avatar__badge"></figcaption>
             </figure>
           </div>
           <div class="l-flag__body">
@@ -344,7 +327,6 @@
               <svg>
                 <use xlink:href="../index.svg#zd-svg-icon-16-user-solo-stroke">
               </svg>
-              <figcaption class="c-avatar__badge"></figcaption>
             </figure>
           </div>
           <div class="l-flag__body">
@@ -357,7 +339,6 @@
               <svg>
                 <use xlink:href="../index.svg#zd-svg-icon-16-user-solo-stroke">
               </svg>
-              <figcaption class="c-avatar__badge"></figcaption>
             </figure>
           </div>
           <div class="l-flag__body">
@@ -370,7 +351,6 @@
               <svg>
                 <use xlink:href="../index.svg#zd-svg-icon-16-user-solo-stroke">
               </svg>
-              <figcaption class="c-avatar__badge"></figcaption>
             </figure>
           </div>
           <div class="l-flag__body">
@@ -383,7 +363,6 @@
               <svg>
                 <use xlink:href="../index.svg#zd-svg-icon-16-user-solo-stroke">
               </svg>
-              <figcaption class="c-avatar__badge"></figcaption>
             </figure>
           </div>
           <div class="l-flag__body">
@@ -396,7 +375,6 @@
               <svg>
                 <use xlink:href="../index.svg#zd-svg-icon-16-user-solo-stroke">
               </svg>
-              <figcaption class="c-avatar__badge"></figcaption>
             </figure>
           </div>
           <div class="l-flag__body">
@@ -409,7 +387,6 @@
               <svg>
                 <use xlink:href="../index.svg#zd-svg-icon-16-user-solo-stroke">
               </svg>
-              <figcaption class="c-avatar__badge"></figcaption>
             </figure>
           </div>
           <div class="l-flag__body">
@@ -422,7 +399,6 @@
               <svg>
                 <use xlink:href="../index.svg#zd-svg-icon-16-user-solo-stroke">
               </svg>
-              <figcaption class="c-avatar__badge"></figcaption>
             </figure>
           </div>
           <div class="l-flag__body">
@@ -445,7 +421,6 @@
                 <button class="c-chrome__body__header__item c-chrome__body__header__item--round">
                   <figure class="c-avatar c-avatar--xs u-fg-white">
                     <img alt="user" src="images/jz.png">
-                    <figcaption class="c-avatar__badge"></figcaption>
                   </figure>
                 </button>
               </header>
@@ -463,7 +438,6 @@
                       <div class="c-menu__item--media__figure">
                         <figure class="c-avatar c-avatar--sm">
                           <img alt="user" src="images/user.svg">
-                          <figcaption class="c-avatar__badge"></figcaption>
                         </figure>
                       </div>
                       <div class="c-menu__item--media__body">
@@ -475,7 +449,6 @@
                       <div class="c-menu__item--media__figure">
                         <figure class="c-avatar c-avatar--sm">
                           <img alt="user" src="images/user.svg">
-                          <figcaption class="c-avatar__badge"></figcaption>
                         </figure>
                       </div>
                       <div class="c-menu__item--media__body">
@@ -487,7 +460,6 @@
                       <div class="c-menu__item--media__figure">
                         <figure class="c-avatar c-avatar--sm">
                           <img alt="user" src="images/user.svg">
-                          <figcaption class="c-avatar__badge"></figcaption>
                         </figure>
                       </div>
                       <div class="c-menu__item--media__body">
@@ -508,7 +480,6 @@
                       <div class="c-menu__item--media__figure">
                         <figure class="c-avatar c-avatar--xs">
                           <img alt="user" src="images/user.svg">
-                          <figcaption class="c-avatar__badge"></figcaption>
                         </figure>
                       </div>
                       <div class="c-menu__item--media__body">
@@ -520,7 +491,6 @@
                       <div class="c-menu__item--media__figure">
                         <figure class="c-avatar c-avatar--xs">
                           <img alt="user" src="images/user.svg">
-                          <figcaption class="c-avatar__badge"></figcaption>
                         </figure>
                       </div>
                       <div class="c-menu__item--media__body">
@@ -532,7 +502,6 @@
                       <div class="c-menu__item--media__figure">
                         <figure class="c-avatar c-avatar--xs">
                           <img alt="user" src="images/user.svg">
-                          <figcaption class="c-avatar__badge"></figcaption>
                         </figure>
                       </div>
                       <div class="c-menu__item--media__body">
@@ -568,13 +537,11 @@
 </div>
 
 <div class="u-mb">
-  <figure class="c-avatar c-avatar--lg is-active u-mr">
+  <figure class="c-avatar c-avatar--lg is-active u-mr" data-badge="3">
     <img alt="user" src="images/ma.png">
-    <figcaption class="c-avatar__badge">3</figcaption>
   </figure>
   <figure class="c-avatar is-available u-mr">
     <img alt="user" src="images/ma.png">
-    <figcaption class="c-avatar__badge"></figcaption>
   </figure>
   <figure class="c-avatar c-avatar--sm is-away u-mr">
     <img alt="user" src="images/ma.png">

--- a/demo/avatars/index.js
+++ b/demo/avatars/index.js
@@ -14,13 +14,13 @@ $(document).ready(function() {
   $('.js-count')
     .on('change input', function() {
       var count = $(this).val();
-      var text = count > 0 ? count : '';
+      var data = count > 0 ? count : '';
 
       if (count > 9) {
-        text = '9+';
+        data = '9+';
       }
 
-      $('.c-avatar:not(.c-playground .c-avatar) .c-avatar__badge').text(text);
+      $('.c-avatar:not(.c-playground .c-avatar)').attr('data-badge', data);
     })
     .click(function() {
       return false;

--- a/packages/avatars/src/_badge.css
+++ b/packages/avatars/src/_badge.css
@@ -35,7 +35,7 @@
    3. Fallback for IE 11 (which will set border).
    4. Improve animation easing. */
 
-.c-avatar__badge {
+.c-avatar::after {
   display: inline-block;
   position: absolute;
   right: var(--zd-avatar__badge-position);
@@ -54,35 +54,36 @@
   font-size: 0;
   font-weight: var(--zd-avatar__badge-font-weight);
   -webkit-text-fill-color: var(--zd-avatar__badge-color); /* [2] */
+  content: '';
 }
 
 /* stylelint-disable selector-type-no-unknown, selector-no-vendor-prefix */
-_:-ms-input-placeholder, .c-avatar__badge {
+_:-ms-input-placeholder, .c-avatar::after {
   color: var(--zd-avatar__badge-color); /* [3] */
 }
 /* stylelint-enable selector-type-no-unknown, selector-no-vendor-prefix */
 
-.c-avatar--lg .c-avatar__badge {
+.c-avatar--lg::after {
   right: var(--zd-avatar--lg__badge-position);
   bottom: var(--zd-avatar--lg__badge-position);
 }
 
-.c-avatar--sm .c-avatar__badge {
+.c-avatar--sm::after {
   right: var(--zd-avatar--sm__badge-position);
   bottom: var(--zd-avatar--sm__badge-position);
 }
 
-.c-avatar--xs .c-avatar__badge {
+.c-avatar--xs::after {
   right: var(--zd-avatar--xs__badge-position);
   bottom: var(--zd-avatar--xs__badge-position);
 }
 
-.c-avatar.is-active .c-avatar__badge,
-.c-avatar.is-available .c-avatar__badge {
+.c-avatar.is-active::after,
+.c-avatar.is-available::after {
   opacity: 1;
 }
 
-.c-avatar.is-active .c-avatar__badge {
+.c-avatar.is-active::after {
   right: var(--zd-avatar--active__badge-position);
   bottom: var(--zd-avatar--active__badge-position);
   animation: var(--zd-avatar--active__badge-animation);
@@ -93,7 +94,7 @@ _:-ms-input-placeholder, .c-avatar__badge {
   line-height: var(--zd-avatar--active__badge-size);
 }
 
-.c-avatar.is-available .c-avatar__badge {
+.c-avatar.is-available::after {
   right: var(--zd-avatar--available__badge-position);
   bottom: var(--zd-avatar--available__badge-position);
   background-color: var(--zd-avatar--available-color);
@@ -102,72 +103,71 @@ _:-ms-input-placeholder, .c-avatar__badge {
   line-height: var(--zd-avatar--available__badge-size); /* [4] */
 }
 
-.c-avatar--xs.is-active .c-avatar__badge {
+.c-avatar--xs.is-active::after {
   padding: 0;
   min-width: var(--zd-avatar--xs--active__badge-min-width);
   height: var(--zd-avatar--xs--active__badge-size);
   line-height: var(--zd-avatar--xs--active__badge-size);
 }
 
-.c-avatar--xs.is-available .c-avatar__badge {
+.c-avatar--xs.is-available::after {
   min-width: var(--zd-avatar--xs--available__badge-size);
   height: var(--zd-avatar--xs--available__badge-size);
   line-height: var(--zd-avatar--xs--available__badge-size); /* [4] */
 }
 
-.c-avatar--sm.is-active .c-avatar__badge {
+.c-avatar--sm.is-active::after {
   padding: var(--zd-avatar--sm--active__badge-padding);
   height: var(--zd-avatar--sm--active__badge-size);
   line-height: var(--zd-avatar--sm--active__badge-size);
 }
 
-.c-avatar--sm.is-available .c-avatar__badge {
+.c-avatar--sm.is-available::after {
   min-width: var(--zd-avatar--sm--available__badge-size);
   height: var(--zd-avatar--sm--available__badge-size);
   line-height: var(--zd-avatar--sm--available__badge-size); /* [4] */
 }
 
-.c-avatar--lg.is-active .c-avatar__badge {
+.c-avatar--lg.is-active::after {
   padding: var(--zd-avatar--lg--active__badge-padding);
 }
 
-.c-avatar--lg.is-available .c-avatar__badge {
+.c-avatar--lg.is-available::after {
   min-width: var(--zd-avatar--lg--available__badge-size);
   height: var(--zd-avatar--lg--available__badge-size);
   line-height: var(--zd-avatar--lg--available__badge-size); /* [4] */
 }
 
-.c-avatar.is-rtl .c-avatar__badge {
+.c-avatar.is-rtl::after {
   right: auto;
   left: var(--zd-avatar__badge-position);
 }
 
-.c-avatar--lg.is-rtl .c-avatar__badge {
+.c-avatar--lg.is-rtl::after {
   left: var(--zd-avatar--lg__badge-position);
 }
 
-.c-avatar--sm.is-rtl .c-avatar__badge {
+.c-avatar--sm.is-rtl::after {
   left: var(--zd-avatar--sm__badge-position);
 }
 
-.c-avatar--xs.is-rtl .c-avatar__badge {
+.c-avatar--xs.is-rtl::after {
   left: var(--zd-avatar--xs__badge-position);
 }
 
-/* stylelint-disable selector-max-specificity */
-
-.c-avatar.is-active.is-rtl .c-avatar__badge {
+.c-avatar.is-active.is-rtl::after {
   left: var(--zd-avatar--active__badge-position);
 }
 
-.c-avatar.is-available.is-rtl .c-avatar__badge {
+.c-avatar.is-available.is-rtl::after {
   left: var(--zd-avatar--available__badge-position);
 }
 
-.c-avatar:not(.c-avatar--xs).is-active .c-avatar__badge {
+.c-avatar:not(.c-avatar--xs).is-active::after {
   max-width: 2em;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   font-size: var(--zd-avatar__badge-font-size);
+  content: attr(data-badge);
 }


### PR DESCRIPTION
- [x] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

BREAKING CHANGE: removes `.c-avatar__badge` element in favor of expressing badge information via `data-badge` attribute. This change provides improved animation between statuses by not encouraging a re-render in React.

## Detail

- Accessibility is precisely the same as before with `aria-live="polite"` added to the `.c-avatar` figure element.
- While this introduces a breaking change on the CSS side, the associated React component will be a patch version update as the contained badge element is an implementation detail.

## Checklist

* [ ] :ok_hand: style ~updates are Garden Designer approved (add the
  designer as a reviewer)~
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
