### PR TITLE
fix(avatars): adjust SVG sizing

### DIFF
--- a/demo/avatars/index.html
+++ b/demo/avatars/index.html
@@ -198,6 +198,28 @@
         <li class="l-grid u-mb-sm">
           <div class="l-flag l-grid__item u-1/2">
             <div class="l-flag__figure">
+              <figure class="c-avatar">
+                <img alt="user" src="images/user.svg">
+              </figure>
+            </div>
+            <div class="l-flag__body">
+              <code class="c-code u-ml-sm">.c-avatar</code>
+            </div>
+          </div
+          ><div class="l-flag l-grid__item u-1/2">
+            <div class="l-flag__figure">
+              <figure class="c-avatar c-avatar--system">
+                <img alt="system" src="images/system.png">
+              </figure>
+            </div>
+            <div class="l-flag__body">
+              <code class="c-code u-ml-sm">.c-avatar.c-avatar--system</code>
+            </div>
+          </div>
+        </li>
+        <li class="l-grid u-mb-sm">
+          <div class="l-flag l-grid__item u-1/2">
+            <div class="l-flag__figure">
               <figure class="c-avatar c-avatar--lg">
                 <img alt="user" src="images/user.svg">
               </figure>

--- a/demo/avatars/index.html
+++ b/demo/avatars/index.html
@@ -345,9 +345,9 @@
         </li
         ><li class="l-grid__item u-1/2 u-mb-sm">
           <div class="l-flag__figure">
-            <figure class="c-avatar c-avatar--system c-avatar--xs u-bg-grey-600">
+            <figure class="c-avatar c-avatar--system c-avatar--xs u-bg-kale-800">
               <svg>
-                <use xlink:href="../index.svg#zd-svg-icon-16-user-solo-stroke">
+                <use xlink:href="../index.svg#zd-svg-icon-26-zendesk">
               </svg>
             </figure>
           </div>
@@ -369,9 +369,9 @@
         </li
         ><li class="l-grid__item u-1/2 u-mb-sm">
           <div class="l-flag__figure">
-            <figure class="c-avatar c-avatar--system c-avatar--sm u-bg-grey-600">
+            <figure class="c-avatar c-avatar--system c-avatar--sm u-bg-kale-800">
               <svg>
-                <use xlink:href="../index.svg#zd-svg-icon-16-user-solo-stroke">
+                <use xlink:href="../index.svg#zd-svg-icon-26-zendesk">
               </svg>
             </figure>
           </div>
@@ -393,9 +393,9 @@
         </li
         ><li class="l-grid__item u-1/2 u-mb-sm">
           <div class="l-flag__figure">
-            <figure class="c-avatar c-avatar--system u-bg-grey-600">
+            <figure class="c-avatar c-avatar--system u-bg-kale-800">
               <svg>
-                <use xlink:href="../index.svg#zd-svg-icon-16-user-solo-stroke">
+                <use xlink:href="../index.svg#zd-svg-icon-26-zendesk">
               </svg>
             </figure>
           </div>
@@ -417,9 +417,9 @@
         </li
         ><li class="l-grid__item u-1/2 u-mb-sm">
           <div class="l-flag__figure">
-            <figure class="c-avatar c-avatar--system c-avatar--lg u-bg-grey-600">
+            <figure class="c-avatar c-avatar--system c-avatar--lg u-bg-kale-800">
               <svg>
-                <use xlink:href="../index.svg#zd-svg-icon-16-user-solo-stroke">
+                <use xlink:href="../index.svg#zd-svg-icon-26-zendesk">
               </svg>
             </figure>
           </div>

--- a/packages/avatars/src/_base.css
+++ b/packages/avatars/src/_base.css
@@ -8,7 +8,7 @@
     color calc(var(--zd-avatar-transition-duration) * .4) ease-in-out;
   --zd-avatar-size: 40px;
   --zd-avatar__img-border-radius: 50%;
-  --zd-avatar__svg-size: 22px;
+  --zd-avatar__svg-size: 16px;
   --zd-avatar__txt-color: var(--zd-color-white);
   --zd-avatar__txt-font-size: var(--zd-font-size-lg);
 }
@@ -69,6 +69,7 @@
 
 .c-avatar__svg,
 .c-avatar > svg {
-  width: var(--zd-avatar__svg-size);
-  height: var(--zd-avatar__svg-size);
+  width: 1em;
+  height: 1em;
+  font-size: var(--zd-avatar__svg-size);
 }

--- a/packages/avatars/src/_size.css
+++ b/packages/avatars/src/_size.css
@@ -5,10 +5,10 @@
   --zd-avatar--xs__svg-size: 12px;
   --zd-avatar--xs__txt-font-size: var(--zd-font-size-sm);
   --zd-avatar--sm-size: 32px;
-  --zd-avatar--sm__svg-size: 18px;
+  --zd-avatar--sm__svg-size: 12px;
   --zd-avatar--sm__txt-font-size: var(--zd-font-size-md);
   --zd-avatar--lg-size: 48px;
-  --zd-avatar--lg__svg-size: 26px;
+  --zd-avatar--lg__svg-size: 24px;
   --zd-avatar--lg__txt-font-size: var(--zd-font-size-xl);
 }
 
@@ -24,8 +24,7 @@
 
 .c-avatar--lg .c-avatar__svg,
 .c-avatar--lg > svg {
-  width: var(--zd-avatar--lg__svg-size);
-  height: var(--zd-avatar--lg__svg-size);
+  font-size: var(--zd-avatar--lg__svg-size);
 }
 
 .c-avatar--sm {
@@ -40,8 +39,7 @@
 
 .c-avatar--sm .c-avatar__svg,
 .c-avatar--sm > svg {
-  width: var(--zd-avatar--sm__svg-size);
-  height: var(--zd-avatar--sm__svg-size);
+  font-size: var(--zd-avatar--sm__svg-size);
 }
 
 .c-avatar--xs {
@@ -56,6 +54,5 @@
 
 .c-avatar--xs .c-avatar__svg,
 .c-avatar--xs > svg {
-  width: var(--zd-avatar--xs__svg-size);
-  height: var(--zd-avatar--xs__svg-size);
+  font-size: var(--zd-avatar--xs__svg-size);
 }


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Use base-4 SVG sizing:
- xs = 12px
- sm = 12px
- md = 16px
- lg = 24px

## Detail

Demo pre-published for review at: https://garden.zendesk.com/css-components/avatars/

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [ ] :nail_care: ~provides `custom.css` example for modifying the
  primary accent color~
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
