### PR TITLE
fix(menus): prevent menu padding from clipping scrolled items

### DIFF
--- a/demo/menus/index.html
+++ b/demo/menus/index.html
@@ -274,27 +274,37 @@
         <p class="u-mb">By default, a menu will expand to accommodate the width
         of it's items. Override the menu's <code class="c-code">min-width</code>
         to increase the container size. Overriding <code class="c-code">max-width</code>
-        can force longer items to wrap.</p>
+        can force longer items to wrap. Override <code class="c-code">max-height</code>
+        in order to scroll menu items.</p>
         <div class="l-grid">
-          <div class="l-grid__item u-1/3">
+          <div class="l-grid__item u-1/4">
             <ul class="c-menu u-opacity-opaque u-visibility-visible u-position-static">
               <li class="c-menu__item c-menu__item--header">Standard Menu</li>
               <li class="c-menu__separator">
               <li class="c-menu__item">...with a very, very, very long menu item</li>
             </ul>
           </div
-          ><div class="l-grid__item u-1/3">
+          ><div class="l-grid__item u-1/4">
             <ul class="c-menu u-opacity-opaque u-visibility-visible u-position-static" style="min-width:270px">
               <li class="c-menu__item c-menu__item--header">Override min-width</li>
               <li class="c-menu__separator">
               <li class="c-menu__item">short item</li>
             </ul>
           </div
-          ><div class="l-grid__item u-1/3">
+          ><div class="l-grid__item u-1/4">
             <ul class="c-menu u-opacity-opaque u-visibility-visible u-position-static" style="max-width:200px">
               <li class="c-menu__item c-menu__item--header">Override max-width</li>
               <li class="c-menu__separator">
               <li class="c-menu__item">...in order to force a very long item to wrap</li>
+            </ul>
+          </div
+          ><div class="l-grid__item u-1/4">
+            <ul class="c-menu u-opacity-opaque u-visibility-visible u-position-static" style="max-height:120px">
+              <li class="c-menu__item c-menu__item--header">Override max-height</li>
+              <li class="c-menu__separator">
+              <li class="c-menu__item">scroll to</li>
+              <li class="c-menu__item">view additional</li>
+              <li class="c-menu__item">menu items</li>
             </ul>
           </div>
         </div>

--- a/demo/menus/index.html
+++ b/demo/menus/index.html
@@ -272,10 +272,15 @@
       <div class="u-mb-lg">
         <h2 class="c-main__subtitle u-fs-lg u-mb">Sizing</h2>
         <p class="u-mb">By default, a menu will expand to accommodate the width
-        of it's items. Override the menu's <code class="c-code">min-width</code>
+        of its items. Override the menu's <code class="c-code">min-width</code>
         to increase the container size. Overriding <code class="c-code">max-width</code>
-        can force longer items to wrap. Override <code class="c-code">max-height</code>
-        in order to scroll menu items.</p>
+        can force longer items to wrap. The override for <code class="c-code">max-height</code>
+        is a bit different. In order for the menu to support its optional
+        <code class="c-code">.c-arrow</code> treatment, it must not hide overflow content.
+        The solution is to apply both <code class="c-code">max-height</code> and
+        <code class="c-code">overflow-y: auto</code> to a child
+        <code class="c-code">&lt;div&gt;</code> that contains the menu items to scroll. See the
+        source code for the following menu examples for details.</p>
         <div class="l-grid">
           <div class="l-grid__item u-1/4">
             <ul class="c-menu u-opacity-opaque u-visibility-visible u-position-static">
@@ -299,12 +304,14 @@
             </ul>
           </div
           ><div class="l-grid__item u-1/4">
-            <ul class="c-menu u-opacity-opaque u-visibility-visible u-position-static" style="max-height:120px">
-              <li class="c-menu__item c-menu__item--header">Override max-height</li>
-              <li class="c-menu__separator">
-              <li class="c-menu__item">scroll to</li>
-              <li class="c-menu__item">view additional</li>
-              <li class="c-menu__item">menu items</li>
+            <ul class="c-menu c-arrow c-arrow--t u-opacity-opaque u-visibility-visible u-position-relative">
+              <div style="max-height: 120px; overflow-y: auto">
+                <li class="c-menu__item c-menu__item--header">Override max-height</li>
+                <li class="c-menu__separator">
+                <li class="c-menu__item">scroll to</li>
+                <li class="c-menu__item">view additional</li>
+                <li class="c-menu__item">menu items</li>
+              </div>
             </ul>
           </div>
         </div>

--- a/packages/menus/src/_base.css
+++ b/packages/menus/src/_base.css
@@ -11,14 +11,13 @@
   --zd-menu-font-size: var(--zd-font-size-md);
   --zd-menu-font-weight: var(--zd-font-weight-regular);
   --zd-menu-min-width: 180px;
-  --zd-menu-padding: 8px 0;
+  --zd-menu-padding: 8px;
 }
 
 /* 1. Positioned relative to controlling item.
  * 2. Opt out of browser default list margin.
  * 3. Prevent controlling item cursor inheritance.
- * 4. Vertically, add extra space;
- *    horizontally, opt out of browser default list padding.
+ * 4. Opt out of browser default list padding.
  * 5. Prevent controlling item whitespace inheritance.
  */
 .c-menu {
@@ -31,8 +30,9 @@
   box-shadow: var(--zd-menu-box-shadow);
   background-color: var(--zd-menu-background-color);
   cursor: default; /* [3] */
-  padding: var(--zd-menu-padding); /* [4] */
+  padding: 0; /* [4] */
   min-width: var(--zd-menu-min-width);
+  overflow-y: auto;
   text-align: left;
   white-space: normal; /* [5] */
   font-size: var(--zd-menu-font-size);

--- a/packages/menus/src/_base.css
+++ b/packages/menus/src/_base.css
@@ -32,7 +32,6 @@
   cursor: default; /* [3] */
   padding: 0; /* [4] */
   min-width: var(--zd-menu-min-width);
-  overflow-y: auto;
   text-align: left;
   white-space: normal; /* [5] */
   font-size: var(--zd-menu-font-size);

--- a/packages/menus/src/_item.css
+++ b/packages/menus/src/_item.css
@@ -59,6 +59,14 @@
   user-select: none;
 }
 
+.c-menu__item:first-child {
+  margin-top: var(--zd-menu-padding);
+}
+
+.c-menu__item:last-child {
+  margin-bottom: var(--zd-menu-padding);
+}
+
 .c-menu__item::before {
   position: absolute;
   top: 0;


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Add `margin` to first and last menuitem instead of adding top/bottom padding to the menu container.

## Detail

Demo pre-published for review: https://garden.zendesk.com/css-components/menus/ (see `max-height` example under "Sizing" section).

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
