### PR TITLE
fix(chrome): prevent body overflow due to wide header item

### DIFF
--- a/demo/chrome/index.html
+++ b/demo/chrome/index.html
@@ -912,7 +912,24 @@
                   </svg>
                   <span class="c-chrome__body__header__item__text">Zendesk Message</span>
                 </div>
-                <div class="c-chrome__body__header__item c-chrome__body__header__item--max-x"></div>
+                <button class="c-chrome__body__header__item c-chrome__body__header__item--max-x">
+                  <span class="c-chrome__body__header__item__text u-truncate">Lorem ipsum dolor sit amet,
+                    consectetur adipiscing elit, sed do eiusmod tempor
+                    incididunt ut labore et dolore magna aliqua. Ut aliquam
+                    purus sit amet. Cum sociis natoque penatibus et magnis.
+                    Semper auctor neque vitae tempus. Id cursus metus aliquam
+                    eleifend mi. Nibh cras pulvinar mattis nunc sed.</span>
+                  <svg class="c-chrome__body__header__item__icon">
+                    <use xlink:href="../index.svg#zd-svg-icon-16-chevron-down-stroke" />
+                  </svg>
+                  <div class="menu-container" style="right:0">
+                    <ul aria-hidden="true" class="c-menu c-menu--down c-arrow c-arrow--tr">
+                      <li class="c-menu__item" role="menuitem">Thing 1</li>
+                      <li class="c-menu__item is-checked" role="menuitem">Thing 2</li>
+                      <li class="c-menu__item" role="menuitem">Thing 3</li>
+                    </ul>
+                  </div>
+                </button>
                 <div class="c-chrome__body__header__item c-chrome__body__header__item--max-y">
                   <div class="c-txt c-txt--sm">
                     <input class="c-txt__input" placeholder="Search" type="text">

--- a/packages/chrome/src/_base.css
+++ b/packages/chrome/src/_base.css
@@ -33,6 +33,7 @@
   flex: 1;
   order: var(--zd-chrome__body-order);
   background-color: var(--zd-chrome__body-color);
+  min-width: 0;
 }
 
 .c-chrome__body__content {

--- a/packages/chrome/src/_header.css
+++ b/packages/chrome/src/_header.css
@@ -152,6 +152,7 @@
   transition: var(--zd-chrome__body__header__item__icon-transition);
   margin: var(--zd-chrome__body__header__item__icon-margin);
   width: var(--zd-chrome__body__header__item__icon-size);
+  min-width: var(--zd-chrome__body__header__item__icon-size);
   height: var(--zd-chrome__body__header__item__icon-size);
 }
 


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Addresses https://github.com/zendeskgarden/react-components/issues/423. After this modification, the issue screenshot looks like this:

![Screen Shot 2019-08-22 at 7 34 04 AM](https://user-images.githubusercontent.com/143773/63523822-b0709580-c4af-11e9-8d67-07ce9bc28fbc.png)

## Detail

Please note that the header item structure is expected to be something like the following:

```html
<div class="c-chrome__body__header__item c-chrome__body__header__item--max-x">
  <span class="u-truncate">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</span>
</div>
```

...where the text content of the long header item is surrounded by a `<span>` that truncates with an ellipsis. Garden does not prevent overflow on Chrome header items because, in many cases, those items are meant to be menu triggers and `overflow: hidden` prevents a menu from being displayed.

## Checklist

* [ ] :ok_hand: ~style updates are Garden Designer approved (add the
  designer as a reviewer)~
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [ ] :nail_care: ~provides `custom.css` example for modifying the
  primary accent color~
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
