### PR TITLE
fix(avatars): force `content-box` sizing for the badge

### DIFF
--- a/packages/avatars/src/_badge.css
+++ b/packages/avatars/src/_badge.css
@@ -48,7 +48,8 @@
   padding: 0;
   min-width: 0;
   height: 0;
-  box-sizing: content-box;
+  /* stylelint-disable-next-line declaration-no-important */
+  box-sizing: content-box !important;
   text-align: center;
   line-height: 1px; /* [4] */
   font-size: 0;


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

This fix is meant to prevent `box-sizing: border-box;` overrides that we are seeing when this component is used with `css-bedrock` in conjunction with other component CSS cascades.

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [ ] :nail_care: ~provides `custom.css` example for modifying the
  primary accent color~
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
