### PR TITLE
feat: add `gather-pink` variable and color utilities

### DIFF
--- a/demo/utilities/color/index.html
+++ b/demo/utilities/color/index.html
@@ -76,21 +76,6 @@
         </div
         ><div class="l-grid__item u-1/8 u-mb">
           <figure class="c-swatch">
-            <div class="c-swatch__color u-bg-message-green">
-              <svg class="c-swatch__color__product">
-                <use xlink:href="../../index.svg#zd-svg-icon-26-relationshape-message">
-                  <title>Message Green</title>
-                </use>
-              </svg>
-            </div>
-            <figcaption class="c-swatch__info">
-              <bold class="c-swatch__info__name">message-green</bold>
-              <span class="c-swatch__info__hex">37b8af</span>
-            </figcaption>
-          </figure>
-        </div
-        ><div class="l-grid__item u-1/8 u-mb">
-          <figure class="c-swatch">
             <div class="c-swatch__color u-bg-explore-blue">
               <svg class="c-swatch__color__product">
                 <use xlink:href="../../index.svg#zd-svg-icon-26-relationshape-explore">
@@ -101,6 +86,21 @@
             <figcaption class="c-swatch__info">
               <bold class="c-swatch__info__name">explore-blue</bold>
               <span class="c-swatch__info__hex">30aabc</span>
+            </figcaption>
+          </figure>
+        </div
+        ><div class="l-grid__item u-1/8 u-mb">
+          <figure class="c-swatch">
+            <div class="c-swatch__color u-bg-gather-pink">
+              <svg class="c-swatch__color__product">
+                <use xlink:href="../../index.svg#zd-svg-icon-26-relationshape-gather">
+                  <title>Gather Pink</title>
+                </use>
+              </svg>
+            </div>
+            <figcaption class="c-swatch__info">
+              <bold class="c-swatch__info__name">gather-pink</bold>
+              <span class="c-swatch__info__hex">e7afa2</span>
             </figcaption>
           </figure>
         </div

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "devDependencies": {
     "@zendeskgarden/eslint-config": "10.0.0",
     "@zendeskgarden/stylelint-config": "11.0.0",
-    "@zendeskgarden/svg-icons": "6.3.1",
+    "@zendeskgarden/svg-icons": "6.6.0",
     "babel-eslint": "10.0.3",
     "chalk": "2.4.2",
     "cssnano": "4.1.10",

--- a/packages/utilities/src/color.css
+++ b/packages/utilities/src/color.css
@@ -219,6 +219,8 @@
 
 .u-bg-explore-blue { background-color: var(--zd-color-explore-blue) !important; }
 
+.u-bg-gather-pink { background-color: var(--zd-color-gather-pink) !important; }
+
 .u-bg-guide-pink { background-color: var(--zd-color-guide-pink) !important; }
 
 .u-bg-message-green { background-color: var(--zd-color-message-green) !important; }
@@ -436,6 +438,8 @@
 .u-fg-connect-red { color: var(--zd-color-connect-red) !important; }
 
 .u-fg-explore-blue { color: var(--zd-color-explore-blue) !important; }
+
+.u-fg-gather-pink { color: var(--zd-color-gather-pink) !important; }
 
 .u-fg-guide-pink { color: var(--zd-color-guide-pink) !important; }
 
@@ -656,6 +660,8 @@
 .u-bc-connect-red { border-color: var(--zd-color-connect-red) !important; }
 
 .u-bc-explore-blue { border-color: var(--zd-color-explore-blue) !important; }
+
+.u-bc-gather-pink { border-color: var(--zd-color-gather-pink) !important; }
 
 .u-bc-guide-pink { border-color: var(--zd-color-guide-pink) !important; }
 

--- a/packages/variables/src/_color.js
+++ b/packages/variables/src/_color.js
@@ -115,6 +115,7 @@ retVal = Object.assign(retVal, {
   'chat-orange': { r: 247, g: 154, b: 62 },
   'connect-red': { r: 235, g: 102, b: 81 },
   'explore-blue': { r: 48, g: 170, b: 188 },
+  'gather-pink': { r: 231, g: 175, b: 162 },
   'guide-pink': { r: 235, g: 73, b: 98 },
   'message-green': { r: 55, g: 184, b: 175 },
   'sell-gold': { r: 212, g: 174, b: 94 },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1064,10 +1064,10 @@
   resolved "https://registry.yarnpkg.com/@zendeskgarden/stylelint-config/-/stylelint-config-11.0.0.tgz#eec2926fa0ed1f95b9b13c5788a67dabcb3400c3"
   integrity sha512-HZFLo8pIwiL3WuLMDTrhPqqM6aALXRcJqiqbHZfwqRmABHtjqlIGxj835BnZ2rxylkWY9JSKF/eLmgB77Xq/Xg==
 
-"@zendeskgarden/svg-icons@6.3.1":
-  version "6.3.1"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.3.1.tgz#76e02e1ffab8a608212114fa92f467f22bd2e1b3"
-  integrity sha512-qsRHhEXHHZLftW8tlf5F0Q59N4capJUhJJkXq1qW+kNJNFrWhFQeV7weg1eNZUVHdiSFLdphpMEO9Ir3gE9rVg==
+"@zendeskgarden/svg-icons@6.6.0":
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/svg-icons/-/svg-icons-6.6.0.tgz#09fcbeaaa6cc33a15aa30a37159b6f400dafe2e7"
+  integrity sha512-fBRnPQ4zfy01tLt4X612bUkK+Irr14GDUIXmJXqQ8/hGbImJWRC3CHoaMGoGaSB6mxVk0GPHhVSwusYelsrO8Q==
 
 "@zkochan/cmd-shim@^3.1.0":
   version "3.1.0"


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

## Detail

Demo pre-published for review: https://garden.zendesk.com/css-components/utilities/color/

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [ ] :white_check_mark: ~all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)~
* [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [ ] :nail_care: ~provides `custom.css` example for modifying the
  primary accent color~
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
