### PR TITLE
fix(forms): apply default cursor to disabled select chevron

### DIFF
--- a/packages/forms/src/_text/_select.css
+++ b/packages/forms/src/_text/_select.css
@@ -98,6 +98,7 @@ select.c-txt__input--select:--txt-focused {
 .c-txt__input--select:--txt-disabled:not(select)::before,
 select.c-txt__input--select[disabled] {
   background-image: var(--zd-txt__input--select__chevron-disabled-background-image);
+  cursor: default;
 }
 /* stylelint-enable selector-no-qualifying-type */
 


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Detail

Fix for zendeskgarden/react-components#500

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [ ] :nail_care: ~provides `custom.css` example for modifying the
  primary accent color~
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
