### PR TITLE
fix(avatars): add object-fit cover to prevent broken image ratios

### DIFF
--- a/packages/avatars/src/_base.css
+++ b/packages/avatars/src/_base.css
@@ -51,6 +51,7 @@
   height: 100%;
   box-sizing: inherit;
   vertical-align: bottom;
+  object-fit: cover;
 }
 
 .c-avatar__txt {


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "fix(buttons):
     increase specificity for disabled state". the title informs the
     semantic version bump if this PR is merged. -->

- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->
Add object-fit cover to prevent broken image ratios

## Detail
When using the `Avatar` component the image ratios should be kept. Adding `object-fit:cover` to the `img` would ensure that ratios are kept and it wouldn't affect the current behavior.

<!-- supporting details; screen shot, code, etc. -->
### Before
<img width="616" alt="Screen Shot 2019-11-06 at 12 45 52 PM" src="https://user-images.githubusercontent.com/13528474/68348645-598e5b80-00af-11ea-8ea9-c8111e8005cb.png">

### After
<img width="632" alt="Screen Shot 2019-11-06 at 12 46 12 PM" src="https://user-images.githubusercontent.com/13528474/68348653-5eeba600-00af-11ea-8896-21f35f7868b1.png">

### Closes GITHUB_ISSUE
#248 

## Checklist

* [ ] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [ ] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [ ] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [ ] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
