### PR TITLE
fix(breadcrumbs): update breadcrumb icon size

### DIFF
--- a/packages/breadcrumbs/src/_item.css
+++ b/packages/breadcrumbs/src/_item.css
@@ -4,7 +4,7 @@
   --zd-breadcrumb__item-background:
     no-repeat center / 1em
     var(--zd-breadcrumb__item-background-image);
-  --zd-breadcrumb__item-background-image: svg-load('16/chevron-right-stroke.svg', color: var(--zd-color-grey-600));
+  --zd-breadcrumb__item-background-image: svg-load('12/chevron-right-stroke.svg', color: var(--zd-color-grey-600));
   --zd-breadcrumb__item-background-margin: 0 calc(8 / 14 * 1em);
   --zd-breadcrumb__item-background-width: 1em;
   --zd-breadcrumb__item-line-height: calc(20 / 14);


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "fix(buttons):
     increase specificity for disabled state". the title informs the
     semantic version bump if this PR is merged. -->

- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Brought the chevron sizing down from `16px -> 12px`

Demo pre-published for review: https://garden.zendesk.com/css-components/breadcrumbs/

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

## Detail

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

* [ ] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [ ] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [ ] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [ ] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [ ] :nail_care: provides `custom.css` example for modifying the
  primary accent color
* [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
