### PR TITLE
fix(bedrock): remove text-rendering property

### DIFF
--- a/packages/bedrock/src/_base.css
+++ b/packages/bedrock/src/_base.css
@@ -7,7 +7,7 @@
   --zd-html-font-family: var(--zd-font-family-system);
   --zd-html-font-feature-settings: 'kern';
   --zd-html-font-kerning: normal;
-  --zd-html-font-size: 14px;
+  --zd-html-font-size: var(--zd-font-size-md);
   --zd-html-line-height: var(--zd-spacing);
   --zd-html-text-color: var(--zd-color-grey-800);
 }

--- a/packages/bedrock/src/_base.css
+++ b/packages/bedrock/src/_base.css
@@ -10,7 +10,6 @@
   --zd-html-font-size: 14px;
   --zd-html-line-height: var(--zd-spacing);
   --zd-html-text-color: var(--zd-color-grey-800);
-  --zd-html-text-rendering: optimizeLegibility;
 }
 
 /* 1. Ensure the page always fills at least the entire viewport height.
@@ -21,7 +20,6 @@ html {
   min-height: 100%; /* [1] */
   box-sizing: var(--zd-html-box-sizing);
   overflow-y: scroll; /* [2] */
-  text-rendering: var(--zd-html-text-rendering);
   line-height: var(--zd-html-line-height);
   color: var(--zd-html-text-color);
   font-feature-settings: var(--zd-html-font-feature-settings);


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

The addition of `text-rendering: optimizeLegibility` can seriously impact load times for certain pages, especially when non-english character sets are involved.

## Detail

Fixes #245.

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [ ] :white_check_mark: ~all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)~
* [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [ ] :nail_care: ~provides `custom.css` example for modifying the
  primary accent color~
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
