### PR TITLE
chore: deprecate non-native components

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,32 +17,17 @@ repository.
 See the individual package README for the CSS component you would like
 to install.
 
-| Package                                                  | Version                                                         | Dependencies                                                                       |
-| -------------------------------------------------------- | --------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| [`@zendeskgarden/css-arrows`](packages/arrows)           | [![npm version][arrows npm version]][arrows npm link]           | [![Dependency Status][arrows dependency status]][arrows dependency link]           |
-| [`@zendeskgarden/css-avatars`](packages/avatars)         | [![npm version][avatars npm version]][avatars npm link]         | [![Dependency Status][avatars dependency status]][avatars dependency link]         |
-| [`@zendeskgarden/css-bedrock`](packages/bedrock)         | [![npm version][bedrock npm version]][bedrock npm link]         | [![Dependency Status][bedrock dependency status]][bedrock dependency link]         |
-| [`@zendeskgarden/css-breadcrumbs`](packages/breadcrumbs) | [![npm version][breadcrumbs npm version]][breadcrumbs npm link] | [![Dependency Status][breadcrumbs dependency status]][breadcrumbs dependency link] |
-| [`@zendeskgarden/css-buttons`](packages/buttons)         | [![npm version][buttons npm version]][buttons npm link]         | [![Dependency Status][buttons dependency status]][buttons dependency link]         |
-| [`@zendeskgarden/css-callouts`](packages/callouts)       | [![npm version][callouts npm version]][callouts npm link]       | [![Dependency Status][callouts dependency status]][callouts dependency link]       |
-| [`@zendeskgarden/css-chrome`](packages/chrome)           | [![npm version][chrome npm version]][chrome npm link]           | [![Dependency Status][chrome dependency status]][chrome dependency link]           |
-| [`@zendeskgarden/css-forms`](packages/forms)             | [![npm version][forms npm version]][forms npm link]             | [![Dependency Status][forms dependency status]][forms dependency link]             |
-| [`@zendeskgarden/css-grid`](packages/grid)               | [![npm version][grid npm version]][grid npm link]               | [![Dependency Status][grid dependency status]][grid dependency link]               |
-| [`@zendeskgarden/css-menus`](packages/menus)             | [![npm version][menus npm version]][menus npm link]             | [![Dependency Status][menus dependency status]][menus dependency link]             |
-| [`@zendeskgarden/css-modals`](packages/modals)           | [![npm version][modals npm version]][modals npm link]           | [![Dependency Status][modals dependency status]][modals dependency link]           |
-| [`@zendeskgarden/css-pagination`](packages/pagination)   | [![npm version][pagination npm version]][pagination npm link]   | [![Dependency Status][pagination dependency status]][pagination dependency link]   |
-| [`@zendeskgarden/css-scrollbars`](packages/scrollbars)   | [![npm version][scrollbars npm version]][scrollbars npm link]   | [![Dependency Status][scrollbars dependency status]][scrollbars dependency link]   |
-| [`@zendeskgarden/css-tables`](packages/tables)           | [![npm version][tables npm version]][tables npm link]           | [![Dependency Status][tables dependency status]][tables dependency link]           |
-| [`@zendeskgarden/css-tabs`](packages/tabs)               | [![npm version][tabs npm version]][tabs npm link]               | [![Dependency Status][tabs dependency status]][tabs dependency link]               |
-| [`@zendeskgarden/css-tags`](packages/tags)               | [![npm version][tags npm version]][tags npm link]               | [![Dependency Status][tags dependency status]][tags dependency link]               |
-| [`@zendeskgarden/css-tooltips`](packages/tooltips)       | [![npm version][tooltips npm version]][tooltips npm link]       | [![Dependency Status][tooltips dependency status]][tooltips dependency link]       |
-| [`@zendeskgarden/css-utilities`](packages/utilities)     | [![npm version][utilities npm version]][utilities npm link]     | [![Dependency Status][utilities dependency status]][utilities dependency link]     |
-| [`@zendeskgarden/css-variables`](packages/variables)     | [![npm version][variables npm version]][variables npm link]     | [![Dependency Status][variables dependency status]][variables dependency link]     |
+| Package                                              | Version                                                     | Dependencies                                                                   |
+| ---------------------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| [`@zendeskgarden/css-avatars`](packages/avatars)     | [![npm version][avatars npm version]][avatars npm link]     | [![Dependency Status][avatars dependency status]][avatars dependency link]     |
+| [`@zendeskgarden/css-bedrock`](packages/bedrock)     | [![npm version][bedrock npm version]][bedrock npm link]     | [![Dependency Status][bedrock dependency status]][bedrock dependency link]     |
+| [`@zendeskgarden/css-buttons`](packages/buttons)     | [![npm version][buttons npm version]][buttons npm link]     | [![Dependency Status][buttons dependency status]][buttons dependency link]     |
+| [`@zendeskgarden/css-callouts`](packages/callouts)   | [![npm version][callouts npm version]][callouts npm link]   | [![Dependency Status][callouts dependency status]][callouts dependency link]   |
+| [`@zendeskgarden/css-forms`](packages/forms)         | [![npm version][forms npm version]][forms npm link]         | [![Dependency Status][forms dependency status]][forms dependency link]         |
+| [`@zendeskgarden/css-tags`](packages/tags)           | [![npm version][tags npm version]][tags npm link]           | [![Dependency Status][tags dependency status]][tags dependency link]           |
+| [`@zendeskgarden/css-utilities`](packages/utilities) | [![npm version][utilities npm version]][utilities npm link] | [![Dependency Status][utilities dependency status]][utilities dependency link] |
+| [`@zendeskgarden/css-variables`](packages/variables) | [![npm version][variables npm version]][variables npm link] | [![Dependency Status][variables dependency status]][variables dependency link] |
 
-[arrows npm version]: https://flat.badgen.net/npm/v/@zendeskgarden/css-arrows
-[arrows npm link]: https://www.npmjs.com/package/@zendeskgarden/css-arrows
-[arrows dependency status]: https://flat.badgen.net/david/dep/zendeskgarden/css-components/packages/arrows
-[arrows dependency link]: https://david-dm.org/zendeskgarden/css-components?path=packages/arrows
 [avatars npm version]: https://flat.badgen.net/npm/v/@zendeskgarden/css-avatars
 [avatars npm link]: https://www.npmjs.com/package/@zendeskgarden/css-avatars
 [avatars dependency status]: https://flat.badgen.net/david/dep/zendeskgarden/css-components/packages/avatars
@@ -51,10 +36,6 @@ to install.
 [bedrock npm link]: https://www.npmjs.com/package/@zendeskgarden/css-bedrock
 [bedrock dependency status]: https://flat.badgen.net/david/dep/zendeskgarden/css-components/packages/bedrock
 [bedrock dependency link]: https://david-dm.org/zendeskgarden/css-components?path=packages/bedrock
-[breadcrumbs npm version]: https://flat.badgen.net/npm/v/@zendeskgarden/css-breadcrumbs
-[breadcrumbs npm link]: https://www.npmjs.com/package/@zendeskgarden/css-breadcrumbs
-[breadcrumbs dependency status]: https://flat.badgen.net/david/dep/zendeskgarden/css-components/packages/breadcrumbs
-[breadcrumbs dependency link]: https://david-dm.org/zendeskgarden/css-components?path=packages/breadcrumbs
 [buttons npm version]: https://flat.badgen.net/npm/v/@zendeskgarden/css-buttons
 [buttons npm link]: https://www.npmjs.com/package/@zendeskgarden/css-buttons
 [buttons dependency status]: https://flat.badgen.net/david/dep/zendeskgarden/css-components/packages/buttons
@@ -63,50 +44,14 @@ to install.
 [callouts npm link]: https://www.npmjs.com/package/@zendeskgarden/css-callouts
 [callouts dependency status]: https://flat.badgen.net/david/dep/zendeskgarden/css-components/packages/callouts
 [callouts dependency link]: https://david-dm.org/zendeskgarden/css-components?path=packages/callouts
-[chrome npm version]: https://flat.badgen.net/npm/v/@zendeskgarden/css-chrome
-[chrome npm link]: https://www.npmjs.com/package/@zendeskgarden/css-chrome
-[chrome dependency status]: https://flat.badgen.net/david/dep/zendeskgarden/css-components/packages/chrome
-[chrome dependency link]: https://david-dm.org/zendeskgarden/css-components?path=packages/chrome
 [forms npm version]: https://flat.badgen.net/npm/v/@zendeskgarden/css-forms
 [forms npm link]: https://www.npmjs.com/package/@zendeskgarden/css-forms
 [forms dependency status]: https://flat.badgen.net/david/dep/zendeskgarden/css-components/packages/forms
 [forms dependency link]: https://david-dm.org/zendeskgarden/css-components?path=packages/forms
-[grid npm version]: https://flat.badgen.net/npm/v/@zendeskgarden/css-grid
-[grid npm link]: https://www.npmjs.com/package/@zendeskgarden/css-grid
-[grid dependency status]: https://flat.badgen.net/david/dep/zendeskgarden/css-components/packages/grid
-[grid dependency link]: https://david-dm.org/zendeskgarden/css-components?path=packages/grid
-[menus npm version]: https://flat.badgen.net/npm/v/@zendeskgarden/css-menus
-[menus npm link]: https://www.npmjs.com/package/@zendeskgarden/css-menus
-[menus dependency status]: https://flat.badgen.net/david/dep/zendeskgarden/css-components/packages/menus
-[menus dependency link]: https://david-dm.org/zendeskgarden/css-components?path=packages/menus
-[modals npm version]: https://flat.badgen.net/npm/v/@zendeskgarden/css-modals
-[modals npm link]: https://www.npmjs.com/package/@zendeskgarden/css-modals
-[modals dependency status]: https://flat.badgen.net/david/dep/zendeskgarden/css-components/packages/modals
-[modals dependency link]: https://david-dm.org/zendeskgarden/css-components?path=packages/modals
-[pagination npm version]: https://flat.badgen.net/npm/v/@zendeskgarden/css-pagination
-[pagination npm link]: https://www.npmjs.com/package/@zendeskgarden/css-pagination
-[pagination dependency status]: https://flat.badgen.net/david/dep/zendeskgarden/css-components/packages/pagination
-[pagination dependency link]: https://david-dm.org/zendeskgarden/css-components?path=packages/pagination
-[scrollbars npm version]: https://flat.badgen.net/npm/v/@zendeskgarden/css-scrollbars
-[scrollbars npm link]: https://www.npmjs.com/package/@zendeskgarden/css-scrollbars
-[scrollbars dependency status]: https://flat.badgen.net/david/dep/zendeskgarden/css-components/packages/scrollbars
-[scrollbars dependency link]: https://david-dm.org/zendeskgarden/css-components?path=packages/scrollbars
-[tables npm version]: https://flat.badgen.net/npm/v/@zendeskgarden/css-tables
-[tables npm link]: https://www.npmjs.com/package/@zendeskgarden/css-tables
-[tables dependency status]: https://flat.badgen.net/david/dep/zendeskgarden/css-components/packages/tables
-[tables dependency link]: https://david-dm.org/zendeskgarden/css-components?path=packages/tables
-[tabs npm version]: https://flat.badgen.net/npm/v/@zendeskgarden/css-tabs
-[tabs npm link]: https://www.npmjs.com/package/@zendeskgarden/css-tabs
-[tabs dependency status]: https://flat.badgen.net/david/dep/zendeskgarden/css-components/packages/tabs
-[tabs dependency link]: https://david-dm.org/zendeskgarden/css-components?path=packages/tabs
 [tags npm version]: https://flat.badgen.net/npm/v/@zendeskgarden/css-tags
 [tags npm link]: https://www.npmjs.com/package/@zendeskgarden/css-tags
 [tags dependency status]: https://flat.badgen.net/david/dep/zendeskgarden/css-components/packages/tags
 [tags dependency link]: https://david-dm.org/zendeskgarden/css-components?path=packages/tags
-[tooltips npm version]: https://flat.badgen.net/npm/v/@zendeskgarden/css-tooltips
-[tooltips npm link]: https://www.npmjs.com/package/@zendeskgarden/css-tooltips
-[tooltips dependency status]: https://flat.badgen.net/david/dep/zendeskgarden/css-components/packages/tooltips
-[tooltips dependency link]: https://david-dm.org/zendeskgarden/css-components?path=packages/tooltips
 [utilities npm version]: https://flat.badgen.net/npm/v/@zendeskgarden/css-utilities
 [utilities npm link]: https://www.npmjs.com/package/@zendeskgarden/css-utilities
 [utilities dependency status]: https://flat.badgen.net/david/dep/zendeskgarden/css-components/packages/utilities

--- a/demo/arrows/index.html
+++ b/demo/arrows/index.html
@@ -10,6 +10,7 @@
   </script>
   <title>Arrows / CSS Components / Zendesk Garden</title>
   <link href="../bedrock/index.css" rel="stylesheet">
+  <link href="../callouts/index.css" rel="stylesheet">
   <link href="../menus/index.css" rel="stylesheet">
   <link href="../forms/checkbox/index.css" rel="stylesheet">
   <link href="//zendeskgarden.github.io/index.css" rel="stylesheet">
@@ -68,6 +69,13 @@
     <a href="https://github.com/zendeskgarden/css-components/tree/master/packages/arrows"><img class="u-float-right u-ml-sm u-mt-sm" src="../github.svg"></a>
     <a href="https://www.npmjs.com/package/@zendeskgarden/css-arrows"><img class="u-float-right u-mt-sm" src="https://img.shields.io/npm/v/@zendeskgarden/css-arrows.svg?style=flat-square"></a>
     <h1 class="c-main__title">Arrows</h1>
+    <div class="c-callout c-callout--error u-mb-xl" style="max-width: 576px;">
+      <strong class="c-callout__title">This component has been deprecated</strong>
+      <p class="c-callout__paragraph">See the <a
+        href="https://garden.zendesk.com/react-components/theming/#arrowstyles">arrowStyles</a>
+        function in Garden's <code class="c-code">@zendeskgarden/react-theming</code>
+        package for the latest updates.</p>
+    </div>
     <div class="c-main__body">
       <p class="u-mb">Component classes for adding arrows to other elements
       (typically used in conjunction with with the menu and tooltip

--- a/demo/breadcrumbs/index.html
+++ b/demo/breadcrumbs/index.html
@@ -10,6 +10,7 @@
   </script>
   <title>Breadcrumbs / CSS Components / Zendesk Garden</title>
   <link href="../bedrock/index.css" rel="stylesheet">
+  <link href="../callouts/index.css" rel="stylesheet">
   <link href="../menus/index.css" rel="stylesheet">
   <link href="../forms/checkbox/index.css" rel="stylesheet">
   <link href="//zendeskgarden.github.io/index.css" rel="stylesheet">
@@ -45,6 +46,13 @@
     <a href="https://github.com/zendeskgarden/css-components/tree/master/packages/breadcrumbs"><img class="u-float-right u-ml-sm u-mt-sm" src="../github.svg"></a>
     <a href="https://www.npmjs.com/package/@zendeskgarden/css-breadcrumbs"><img class="u-float-right u-mt-sm" src="https://img.shields.io/npm/v/@zendeskgarden/css-breadcrumbs.svg?style=flat-square"></a>
     <h1 class="c-main__title">Breadcrumbs</h1>
+    <div class="c-callout c-callout--error u-mb-xl" style="max-width: 576px;">
+      <strong class="c-callout__title">This component has been deprecated</strong>
+      <p class="c-callout__paragraph">See the <a
+        href="https://garden.zendesk.com/react-components/breadcrumbs/">Breadcrumb</a>
+        component in Garden's <code class="c-code">@zendeskgarden/react-breadcrumbs</code>
+        package for the latest updates.</p>
+    </div>
     <div class="c-main__body">
       <p class="u-mb-lg">The <code class="c-code">.c-breadcrumb</code>
         component classes are used to style breadcrumb navigation. Use

--- a/demo/chrome/index.html
+++ b/demo/chrome/index.html
@@ -10,6 +10,7 @@
   </script>
   <title>Chrome / CSS Components / Zendesk Garden</title>
   <link href="../bedrock/index.css" rel="stylesheet">
+  <link href="../callouts/index.css" rel="stylesheet">
   <link href="../arrows/index.css" rel="stylesheet">
   <link href="../buttons/index.css" rel="stylesheet">
   <link href="../menus/index.css" rel="stylesheet">
@@ -76,6 +77,13 @@
     <a href="https://github.com/zendeskgarden/css-components/tree/master/packages/chrome"><img class="u-float-right u-ml-sm u-mt-sm" src="../github.svg"></a>
     <a href="https://www.npmjs.com/package/@zendeskgarden/css-chrome"><img class="u-float-right u-mt-sm" src="https://img.shields.io/npm/v/@zendeskgarden/css-chrome.svg?style=flat-square"></a>
     <h1 class="c-main__title">Chrome</h1>
+    <div class="c-callout c-callout--error u-mb-xl" style="max-width: 576px;">
+      <strong class="c-callout__title">This component has been deprecated</strong>
+      <p class="c-callout__paragraph">See the <a
+        href="https://garden.zendesk.com/react-components/chrome/#chrome">Chrome</a>
+        component in Garden's <code class="c-code">@zendeskgarden/react-chrome</code>
+        package for the latest updates.</p>
+    </div>
     <div class="c-main__body">
       <p class="u-mb-lg">The <code class="c-code">.c-chrome</code> component
       classes are used to style Zendesk product chrome: navigation, header and

--- a/demo/grid/index.html
+++ b/demo/grid/index.html
@@ -10,6 +10,7 @@
   </script>
   <title>Grid / CSS Components / Zendesk Garden</title>
   <link href="../bedrock/index.css" rel="stylesheet">
+  <link href="../callouts/index.css" rel="stylesheet">
   <link href="../forms/checkbox/index.css" rel="stylesheet">
   <link href="//zendeskgarden.github.io/index.css" rel="stylesheet">
   <link href="index.css" rel="stylesheet">
@@ -41,6 +42,13 @@
     <a href="https://github.com/zendeskgarden/css-components/tree/master/packages/grid"><img class="u-float-right u-ml-sm u-mt-sm" src="../github.svg"></a>
     <a href="https://www.npmjs.com/package/@zendeskgarden/css-grid"><img class="u-float-right u-mt-sm" src="https://img.shields.io/npm/v/@zendeskgarden/css-grid.svg?style=flat-square"></a>
     <h1 class="c-main__title">Grid</h1>
+    <div class="c-callout c-callout--error u-mb-xl" style="max-width: 576px;">
+      <strong class="c-callout__title">This component has been deprecated</strong>
+      <p class="c-callout__paragraph">See the <a
+        href="https://garden.zendesk.com/react-components/grid/">Grid</a>
+        component in Garden's <code class="c-code">@zendeskgarden/react-grid</code>
+        package for the latest updates.</p>
+    </div>
     <div class="c-main__body">
       <p class="u-mb"><code class="c-code">@zendeskgarden/css-grid</code> is an opinionated customization of the Bootstrap v4 flexbox grid.
         All classes are consistent with the

--- a/demo/index.html
+++ b/demo/index.html
@@ -99,16 +99,10 @@
         <div class="row">
           <div class="col-sm-4">
             <div class="u-mb-sm">
-              <a class="u-fg-inherit" href="arrows">Arrows</a>
-            </div>
-            <div class="u-mb-sm">
               <a class="u-fg-inherit" href="avatars">Avatars</a>
             </div>
             <div class="u-mb-sm">
               <a class="u-fg-inherit" href="bedrock">Bedrock</a>
-            </div>
-            <div class="u-mb-sm">
-              <a class="u-fg-inherit" href="breadcrumbs">Breadcrumbs</a>
             </div>
             <div class="u-mb-sm">
               <a class="u-fg-inherit" href="buttons">Buttons</a>
@@ -122,45 +116,16 @@
           </div>
           <div class="col-sm-4">
             <div class="u-mb-sm">
-              <a class="u-fg-inherit" href="chrome">Chrome</a>
-            </div>
-            <div class="u-mb-sm">
               <a class="u-fg-inherit" href="forms/dropdown">Dropdowns</a>
             </div>
             <div class="u-mb-sm">
-              <a class="u-fg-inherit" href="grid">Grid</a>
-            </div>
-            <div class="u-mb-sm">
-              <a class="u-fg-inherit" href="menus">Menus</a>
-            </div>
-            <div class="u-mb-sm">
-              <a class="u-fg-inherit" href="modals">Modals</a>
-            </div>
-            <div class="u-mb-sm">
-              <a class="u-fg-inherit" href="pagination">Pagination</a>
-            </div>
-            <div class="u-mb-sm">
               <a class="u-fg-inherit" href="forms/range">Ranges</a>
-            </div>
-          </div>
-          <div class="col-sm-4">
-            <div class="u-mb-sm">
-              <a class="u-fg-inherit" href="scrollbars">Scrollbars</a>
-            </div>
-            <div class="u-mb-sm">
-              <a class="u-fg-inherit" href="tabs">Tabs</a>
-            </div>
-            <div class="u-mb-sm">
-              <a class="u-fg-inherit" href="tables">Tables</a>
             </div>
             <div class="u-mb-sm">
               <a class="u-fg-inherit" href="tags">Tags</a>
             </div>
             <div class="u-mb-sm">
               <a class="u-fg-inherit" href="forms/text">Text & Textarea</a>
-            </div>
-            <div class="u-mb-sm">
-              <a class="u-fg-inherit" href="tooltips">Tooltips</a>
             </div>
             <div class="u-mb-sm">
               <a class="u-fg-inherit" href="utilities">Utilities</a>

--- a/demo/index.html
+++ b/demo/index.html
@@ -97,7 +97,7 @@
     <div class="c-main__body l-wrapper-720">
       <div class="container-fluid">
         <div class="row">
-          <div class="col-sm-4">
+          <div class="col-sm-6">
             <div class="u-mb-sm">
               <a class="u-fg-inherit" href="avatars">Avatars</a>
             </div>
@@ -114,7 +114,7 @@
               <a class="u-fg-inherit" href="forms/checkbox">Checkboxes, Toggles, & Radios</a>
             </div>
           </div>
-          <div class="col-sm-4">
+          <div class="col-sm-6">
             <div class="u-mb-sm">
               <a class="u-fg-inherit" href="forms/dropdown">Dropdowns</a>
             </div>
@@ -132,6 +132,47 @@
             </div>
           </div>
         </div>
+        <div class="row">
+          <div class="col">
+            <h2 class="c-main__subtitle u-mt u-fg-grey-700">Deprecated</h2>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-sm-6">
+            <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="arrows">Arrows</a>
+            </div>
+            <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="chrome">Chrome</a>
+            </div>
+            <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="grid">Grid</a>
+            </div>
+            <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="menus">Menus</a>
+            </div>
+            <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="modals">Modals</a>
+            </div>
+          </div>
+          <div class="col-sm-6">
+            <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="pagination">Pagination</a>
+            </div>
+            <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="scrollbars">Scrollbars</a>
+            </div>
+            <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="tables">Tables</a>
+            </div>
+            <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="tabs">Tabs</a>
+            </div>
+            <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="tooltips">Tooltips</a>
+            </div>
+          </div>
+        </div>  
       </div>
     </div>
   </main>

--- a/demo/menus/index.html
+++ b/demo/menus/index.html
@@ -10,6 +10,7 @@
   </script>
   <title>Menus / CSS Components / Zendesk Garden</title>
   <link href="../bedrock/index.css" rel="stylesheet">
+  <link href="../callouts/index.css" rel="stylesheet">
   <link href="../arrows/index.css" rel="stylesheet">
   <link href="../buttons/index.css" rel="stylesheet">
   <link href="../forms/checkbox/index.css" rel="stylesheet">
@@ -82,6 +83,13 @@
     <a href="https://github.com/zendeskgarden/css-components/tree/master/packages/menus"><img class="u-float-right u-ml-sm u-mt-sm" src="../github.svg"></a>
     <a href="https://www.npmjs.com/package/@zendeskgarden/css-menus"><img class="u-float-right u-mt-sm" src="https://img.shields.io/npm/v/@zendeskgarden/css-menus.svg?style=flat-square"></a>
     <h1 class="c-main__title">Menus</h1>
+    <div class="c-callout c-callout--error u-mb-xl" style="max-width: 576px;">
+      <strong class="c-callout__title">This component has been deprecated</strong>
+      <p class="c-callout__paragraph">See the <a
+        href="https://garden.zendesk.com/react-components/dropdowns/">Menu</a>
+        component in Garden's <code class="c-code">@zendeskgarden/react-dropdowns</code>
+        package for the latest updates.</p>
+    </div>
     <div class="c-main__body">
       <p class="u-mb-lg">The
         <code class="c-code">.c-menu</code>

--- a/demo/modals/index.html
+++ b/demo/modals/index.html
@@ -10,6 +10,7 @@
   </script>
   <title>Modals / CSS Components / Zendesk Garden</title>
   <link href="../bedrock/index.css" rel="stylesheet">
+  <link href="../callouts/index.css" rel="stylesheet">
   <link href="../buttons/index.css" rel="stylesheet">
   <link href="../forms/index.css" rel="stylesheet">
   <link href="//zendeskgarden.github.io/index.css" rel="stylesheet">
@@ -42,6 +43,13 @@
     <a href="https://github.com/zendeskgarden/css-components/tree/master/packages/modals"><img class="u-float-right u-ml-sm u-mt-sm" src="../github.svg"></a>
     <a href="https://www.npmjs.com/package/@zendeskgarden/css-modals"><img class="u-float-right u-mt-sm" src="https://img.shields.io/npm/v/@zendeskgarden/css-modals.svg?style=flat-square"></a>
     <h1 class="c-main__title">Modals</h1>
+    <div class="c-callout c-callout--error u-mb-xl" style="max-width: 576px;">
+      <strong class="c-callout__title">This component has been deprecated</strong>
+      <p class="c-callout__paragraph">See the <a
+        href="https://garden.zendesk.com/react-components/modals/">Modal</a>
+        component in Garden's <code class="c-code">@zendeskgarden/react-modals</code>
+        package for the latest updates.</p>
+    </div>
     <div class="c-main__body">
       <p class="u-mb-lg">Use
         <code class="c-code">.c-dialog</code>

--- a/demo/pagination/index.html
+++ b/demo/pagination/index.html
@@ -10,6 +10,7 @@
   </script>
   <title>Pagination / CSS Components / Zendesk Garden</title>
   <link href="../bedrock/index.css" rel="stylesheet">
+  <link href="../callouts/index.css" rel="stylesheet">
   <link href="../menus/index.css" rel="stylesheet">
   <link href="../forms/checkbox/index.css" rel="stylesheet">
   <link href="//zendeskgarden.github.io/index.css" rel="stylesheet">
@@ -64,6 +65,13 @@
     <a href="https://github.com/zendeskgarden/css-components/tree/master/packages/pagination"><img class="u-float-right u-ml-sm u-mt-sm" src="../github.svg"></a>
     <a href="https://www.npmjs.com/package/@zendeskgarden/css-pagination"><img class="u-float-right u-mt-sm" src="https://img.shields.io/npm/v/@zendeskgarden/css-pagination.svg?style=flat-square"></a>
     <h1 class="c-main__title">Pagination</h1>
+    <div class="c-callout c-callout--error u-mb-xl" style="max-width: 576px;">
+      <strong class="c-callout__title">This component has been deprecated</strong>
+      <p class="c-callout__paragraph">See the <a
+        href="https://garden.zendesk.com/react-components/pagination/">Pagination</a>
+        component in Garden's <code class="c-code">@zendeskgarden/react-pagination</code>
+        package for the latest updates.</p>
+    </div>
     <div class="c-main__body">
       <p class="u-mb-lg">The pagination component provides styling for a
       multi-page control used to navigate long content lists such as data

--- a/demo/scrollbars/index.html
+++ b/demo/scrollbars/index.html
@@ -10,6 +10,7 @@
   </script>
   <title>Scrollbars / CSS Components / Zendesk Garden</title>
   <link href="../bedrock/index.css" rel="stylesheet">
+  <link href="../callouts/index.css" rel="stylesheet">
   <link href="../menus/index.css" rel="stylesheet">
   <link href="../forms/checkbox/index.css" rel="stylesheet">
   <link href="../forms/range/index.css" rel="stylesheet">
@@ -51,6 +52,12 @@
     <a href="https://github.com/zendeskgarden/css-components/tree/master/packages/scrollbars"><img class="u-float-right u-ml-sm u-mt-sm" src="../github.svg"></a>
     <a href="https://www.npmjs.com/package/@zendeskgarden/css-scrollbars"><img class="u-float-right u-mt-sm" src="https://img.shields.io/npm/v/@zendeskgarden/css-scrollbars.svg?style=flat-square"></a>
     <h1 class="c-main__title">Scrollbars</h1>
+    <div class="c-callout c-callout--error u-mb-xl" style="max-width: 576px;">
+      <strong class="c-callout__title">This component has been deprecated</strong>
+      <p class="c-callout__paragraph">The
+        <code class="c-code">@zendeskgarden/css-scrollbars</code>
+        package is no longer supported.</p>
+    </div>
     <div class="c-main__body">
       <p class="u-mb-lg">The <code class="c-code">.c-scrollbar</code> component
         classes are used to style custom scrollbars. This component comes with

--- a/demo/tables/index.html
+++ b/demo/tables/index.html
@@ -10,6 +10,7 @@
   </script>
   <title>Tables / CSS Components / Zendesk Garden</title>
   <link href="../bedrock/index.css" rel="stylesheet">
+  <link href="../callouts/index.css" rel="stylesheet">
   <link href="../menus/index.css" rel="stylesheet">
   <link href="../forms/checkbox/index.css" rel="stylesheet">
   <link href="//zendeskgarden.github.io/index.css" rel="stylesheet">
@@ -98,6 +99,13 @@
     <a href="https://github.com/zendeskgarden/css-components/tree/master/packages/tables"><img class="u-float-right u-ml-sm u-mt-sm" src="../github.svg"></a>
     <a href="https://www.npmjs.com/package/@zendeskgarden/css-tables"><img class="u-float-right u-mt-sm" src="https://img.shields.io/npm/v/@zendeskgarden/css-tables.svg?style=flat-square"></a>
     <h1 class="c-main__title">Tables</h1>
+    <div class="c-callout c-callout--error u-mb-xl" style="max-width: 576px;">
+      <strong class="c-callout__title">This component has been deprecated</strong>
+      <p class="c-callout__paragraph">See the <a
+        href="https://garden.zendesk.com/react-components/tables/">Table</a>
+        component in Garden's <code class="c-code">@zendeskgarden/react-tables</code>
+        package for the latest updates.</p>
+    </div>
     <div class="c-main__body">
       <p class="u-mb">The <code class="c-code">.c-table</code> components are
       intended to provide consistent styling for HTML

--- a/demo/tabs/index.html
+++ b/demo/tabs/index.html
@@ -10,6 +10,7 @@
   </script>
   <title>Tabs / CSS Components / Zendesk Garden</title>
   <link href="../bedrock/index.css" rel="stylesheet">
+  <link href="../callouts/index.css" rel="stylesheet">
   <link href="../menus/index.css" rel="stylesheet">
   <link href="../forms/checkbox/index.css" rel="stylesheet">
   <link href="//zendeskgarden.github.io/index.css" rel="stylesheet">
@@ -64,6 +65,13 @@
     <a href="https://github.com/zendeskgarden/css-components/tree/master/packages/tabs"><img class="u-float-right u-ml-sm u-mt-sm" src="../github.svg"></a>
     <a href="https://www.npmjs.com/package/@zendeskgarden/css-tabs"><img class="u-float-right u-mt-sm" src="https://img.shields.io/npm/v/@zendeskgarden/css-tabs.svg?style=flat-square"></a>
     <h1 class="c-main__title">Tabs</h1>
+    <div class="c-callout c-callout--error u-mb-xl" style="max-width: 576px;">
+      <strong class="c-callout__title">This component has been deprecated</strong>
+      <p class="c-callout__paragraph">See the <a
+        href="https://garden.zendesk.com/react-components/tabs/">Tabs</a>
+        component in Garden's <code class="c-code">@zendeskgarden/react-tabs</code>
+        package for the latest updates.</p>
+    </div>
     <div class="c-main__body">
       <p class="u-mb-lg">Use the
         <code class="c-code">.c-tab</code>

--- a/demo/tooltips/index.html
+++ b/demo/tooltips/index.html
@@ -10,6 +10,7 @@
   </script>
   <title>Tooltips / CSS Components / Zendesk Garden</title>
   <link href="../bedrock/index.css" rel="stylesheet">
+  <link href="../callouts/index.css" rel="stylesheet">
   <link href="../forms/checkbox/index.css" rel="stylesheet">
   <link href="../arrows/index.css" rel="stylesheet">
   <link href="../tags/index.css" rel="stylesheet">
@@ -43,6 +44,13 @@
     <a href="https://github.com/zendeskgarden/css-components/tree/master/packages/tooltips"><img class="u-float-right u-ml-sm u-mt-sm" src="../github.svg"></a>
     <a href="https://www.npmjs.com/package/@zendeskgarden/css-tooltips"><img class="u-float-right u-mt-sm" src="https://img.shields.io/npm/v/@zendeskgarden/css-tooltips.svg?style=flat-square"></a>
     <h1 class="c-main__title">Tooltips</h1>
+    <div class="c-callout c-callout--error u-mb-xl" style="max-width: 576px;">
+      <strong class="c-callout__title">This component has been deprecated</strong>
+      <p class="c-callout__paragraph">See the <a
+        href="https://garden.zendesk.com/react-components/tooltips/">Tooltip</a>
+        component in Garden's <code class="c-code">@zendeskgarden/react-tooltips</code>
+        package for the latest updates.</p>
+    </div>
     <div class="c-main__body">
       <p class="u-mb-lg">The
         <code class="c-code">.c-tooltip</code>


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

The following CSS components have been deprecated in favor of fully-functional solutions provided by @zendeskgarden/react-components:

- Arrows
- Breadcrumbs
- Chrome
- Grid
- Menus
- Modals
- Pagination
- Scrollbars (no Garden alternative)
- Tables
- Tabs
- Tooltips

Although there will be no ongoing maintenance, these components will remain here indefinitely (several continue to be used to support website scaffold styling). However, each component will be marked with a message using `npm-deprecate` similar to https://www.npmjs.com/package/@zendeskgarden/react-autocomplete.

## Detail

Demo pre-published to https://garden.zendesk.com/css-components/ for review.

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [ ] :white_check_mark: ~all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)~
* [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
* [ ] :metal: ~renders as expected sans Bedrock (`?bedrock=false`)~
* [ ] :nail_care: ~provides `custom.css` example for modifying the
  primary accent color~
* [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
