### PR TITLE
chore: restore deprecated "breadcrumbs" demo link

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -143,6 +143,9 @@
               <a class="u-fg-inherit" href="arrows">Arrows</a>
             </div>
             <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="breadcrumbs">Breadcrumbs</a>
+            </div>
+            <div class="u-mb-sm">
               <a class="u-fg-inherit" href="chrome">Chrome</a>
             </div>
             <div class="u-mb-sm">


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Put the `breadcrumbs` link back so that folks can navigate to the deprecated component – inadvertently removed in #274.
