### PR TITLE
fix: use default CircleCI node_modules cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,6 @@ jobs:
       - checkout
       - node/with-cache:
           cache-key: yarn.lock
-          dir: ~/.cache/yarn
           steps:
             - run: yarn --frozen-lockfile --ignore-scripts
             - run: yarn lerna bootstrap


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Follow-on from zendeskgarden/react-components#683

