### PR TITLE
feat(bedrock)!: apply opinionated semantic vs stylistic text markup defaults

### DIFF
--- a/demo/bedrock/index.html
+++ b/demo/bedrock/index.html
@@ -50,7 +50,11 @@
       </div>
 
       <div class="u-mb">
+        <b>&lt;b&gt;</b>
+        <em>&lt;em&gt;</em>
         <ins>&lt;ins&gt;</ins>
+        <i>&lt;i&gt;</i>
+        <strong>&lt;strong&gt;</strong>
         <u>&lt;u&gt;</u>
       </div>
 
@@ -88,6 +92,18 @@
         <fieldset>&lt;fieldset&gt;</fieldset>
         <figure>&lt;figure&gt;</figure>
       </div>
+      <section id="playground">
+        <h1 class="c-main__subtitle u-fs-xl u-mb">Playground</h1>
+        <div class="c-playground">
+          <div class="c-playground__preview"></div>
+<textarea class="c-playground__code"><ul>
+  <li><b>bold</b></li>
+  <li><em>emphasized</em></li>
+  <li><i>italics</i></li>
+  <li><strong>strong</strong></li>
+</ul></textarea>
+        </div>
+      </section>
     </div>
   </main>
   <script src="//zendeskgarden.github.io/index.js"></script>

--- a/packages/bedrock/src/_base.css
+++ b/packages/bedrock/src/_base.css
@@ -48,6 +48,8 @@ a:focus {
 
 a:focus { outline: none; }
 
+b { font-weight: var(--zd-font-weight-semibold); }
+
 button {
   cursor: pointer;
   padding: 0;
@@ -68,6 +70,8 @@ code,
 kbd,
 pre,
 samp { font-family: var(--zd-font-family-monospace); }
+
+em { font-style: inherit; }
 
 fieldset,
 iframe { border: 0; }
@@ -108,6 +112,8 @@ ol,
 ul { list-style: none; }
 
 img { max-width: 100%; }
+
+strong { font-weight: inherit; }
 
 svg { max-height: 100%; }
 


### PR DESCRIPTION
- [x] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Bedrock is updated with the following:

- `<b>` = semibold (stylistic); currently **bold**
- `<em>` = normal/inherit (semantic); currently _italic_
- `<strong>` = regular/inherit (semantic); currently **bold**

Note

- `<i>` remains stylistic with _italic_

These changes will result in [`@zendeskgarden/css-bedrock`](https://www.npmjs.com/package/@zendeskgarden/css-bedrock) being upgraded to v8.0.0.

## Detail

Demo pre-published for review with added tag treatments and playground: https://garden.zendesk.com/css-components/bedrock/

See UA defaults by turning off bedrock: https://garden.zendesk.com/css-components/bedrock/?bedrock=false

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
* [ ] :metal: ~renders as expected sans Bedrock (`?bedrock=false`)~
* [ ] :nail_care: ~provides `custom.css` example for modifying the
  primary accent color~
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
