### PR TITLE
chore(docs): deprecate css-utilities

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -127,9 +127,6 @@
             <div class="u-mb-sm">
               <a class="u-fg-inherit" href="forms/text">Text & Textarea</a>
             </div>
-            <div class="u-mb-sm">
-              <a class="u-fg-inherit" href="utilities">Utilities</a>
-            </div>
           </div>
         </div>
         <div class="row">
@@ -174,8 +171,11 @@
             <div class="u-mb-sm">
               <a class="u-fg-inherit" href="tooltips">Tooltips</a>
             </div>
+            <div class="u-mb-sm">
+              <a class="u-fg-inherit" href="utilities">Utilities</a>
+            </div>
           </div>
-        </div>  
+        </div>
       </div>
     </div>
   </main>

--- a/demo/utilities/index.html
+++ b/demo/utilities/index.html
@@ -10,6 +10,7 @@
   </script>
   <title>Utilities / CSS Components / Zendesk Garden</title>
   <link href="../bedrock/index.css" rel="stylesheet">
+  <link href="../callouts/index.css" rel="stylesheet">
   <link href="../forms/checkbox/index.css" rel="stylesheet">
   <link href="//zendeskgarden.github.io/index.css" rel="stylesheet">
   <link href="index.css" rel="stylesheet">
@@ -32,6 +33,13 @@
     <a href="https://github.com/zendeskgarden/css-components/tree/main/packages/utilities"><img class="u-float-right u-ml-sm u-mt-sm" src="../github.svg"></a>
     <a href="https://www.npmjs.com/package/@zendeskgarden/css-utilities"><img class="u-float-right u-mt-sm" src="https://img.shields.io/npm/v/@zendeskgarden/css-utilities.svg?style=flat-square"></a>
     <h1 class="c-main__title">Utilities</h1>
+    <div class="c-callout c-callout--error u-mb-xl" style="max-width: 576px;">
+      <strong class="c-callout__title">This package has been deprecated</strong>
+      <p class="c-callout__paragraph">See the <a
+        href="https://github.com/zendeskgarden/tailwindcss">design token utilities</a>
+        in Garden's <code class="c-code">@zendeskgarden/tailwindcss</code>
+        plugin for the latest updates.</p>
+    </div>
     <div class="c-main__body">
       <p class="u-mb-lg">A collection of single purpose utility classes. In most
         cases, a utility class applies a single CSS property and makes use of


### PR DESCRIPTION
## Description

This PR updates the documentation to reflect that `css-utilities` is now deprecated in favor of our [TailwindCSS plugin](https://github.com/zendeskgarden/tailwindcss).

## Checklist

* [ ] ~:ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)~
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [ ] ~:white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)~
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [ ] ~:metal: renders as expected sans Bedrock (`?bedrock=false`)~
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
