### PR TITLE
fix: update style pkg field to built files

### DIFF
--- a/packages/.template/package.json
+++ b/packages/.template/package.json
@@ -33,5 +33,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "style": "src/index.css"
+  "style": "dist/index.css"
 }

--- a/packages/arrows/package.json
+++ b/packages/arrows/package.json
@@ -30,5 +30,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "style": "src/index.css"
+  "style": "dist/index.css"
 }

--- a/packages/avatars/package.json
+++ b/packages/avatars/package.json
@@ -33,5 +33,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "style": "src/index.css"
+  "style": "dist/index.css"
 }

--- a/packages/bedrock/package.json
+++ b/packages/bedrock/package.json
@@ -34,5 +34,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "style": "src/index.css"
+  "style": "dist/index.css"
 }

--- a/packages/breadcrumbs/package.json
+++ b/packages/breadcrumbs/package.json
@@ -33,5 +33,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "style": "src/index.css"
+  "style": "dist/index.css"
 }

--- a/packages/buttons/package.json
+++ b/packages/buttons/package.json
@@ -33,5 +33,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "style": "src/index.css"
+  "style": "dist/index.css"
 }

--- a/packages/callouts/package.json
+++ b/packages/callouts/package.json
@@ -33,5 +33,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "style": "src/index.css"
+  "style": "dist/index.css"
 }

--- a/packages/chrome/package.json
+++ b/packages/chrome/package.json
@@ -33,5 +33,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "style": "src/index.css"
+  "style": "dist/index.css"
 }

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -33,5 +33,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "style": "src/index.css"
+  "style": "dist/index.css"
 }

--- a/packages/menus/package.json
+++ b/packages/menus/package.json
@@ -36,5 +36,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "style": "src/index.css"
+  "style": "dist/index.css"
 }

--- a/packages/modals/package.json
+++ b/packages/modals/package.json
@@ -33,5 +33,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "style": "src/index.css"
+  "style": "dist/index.css"
 }

--- a/packages/pagination/package.json
+++ b/packages/pagination/package.json
@@ -33,5 +33,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "style": "src/index.css"
+  "style": "dist/index.css"
 }

--- a/packages/scrollbars/package.json
+++ b/packages/scrollbars/package.json
@@ -33,5 +33,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "style": "src/index.css"
+  "style": "dist/index.css"
 }

--- a/packages/tables/package.json
+++ b/packages/tables/package.json
@@ -33,5 +33,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "style": "src/index.css"
+  "style": "dist/index.css"
 }

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -33,5 +33,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "style": "src/index.css"
+  "style": "dist/index.css"
 }

--- a/packages/tags/package.json
+++ b/packages/tags/package.json
@@ -33,5 +33,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "style": "src/index.css"
+  "style": "dist/index.css"
 }

--- a/packages/tooltips/package.json
+++ b/packages/tooltips/package.json
@@ -36,5 +36,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "style": "src/index.css"
+  "style": "dist/index.css"
 }

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -33,5 +33,5 @@
   "publishConfig": {
     "access": "public"
   },
-  "style": "src/index.css"
+  "style": "dist/index.css"
 }


### PR DESCRIPTION
<!-- structure the Title above as the first line of a
     https://conventionalcommits.org/ message. example: "fix(buttons):
     increase specificity for disabled state". the title informs the
     semantic version bump if this PR is merged. -->

- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

<!-- a summary of the changes introduced by this PR. this description
     may populate the commit body and versioned changelog if the PR is
     merged. -->

This updates the `package.json` `style` field to point to the _built_ CSS files. This file is used by `postcss-import` along with other CSS pre-processors. It should be pointed to the built files so the end user does not have to setup their CSS workflow to compile all of your files.

## Detail

Just what I wrote above.

<!-- supporting details; screen shot, code, etc. -->

<!-- closes GITHUB_ISSUE -->

## Checklist

* [-] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [-] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [-] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [-] :arrow_left: renders as expected with reversed (RTL) direction
* [-] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [-] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
