### PR TITLE
chore: update product colors

### DIFF
--- a/demo/utilities/color/index.html
+++ b/demo/utilities/color/index.html
@@ -64,13 +64,12 @@
             <div class="c-swatch__color u-bg-support-green">
               <svg class="c-swatch__color__product">
                 <use xlink:href="../../index.svg#zd-svg-icon-26-relationshape-support">
-                  <title>Support Green</title>
+                  <title>Support</title>
                 </use>
               </svg>
             </div>
             <figcaption class="c-swatch__info">
-              <bold class="c-swatch__info__name">support-green</bold>
-              <span class="c-swatch__info__hex">78a300</span>
+              <bold class="c-swatch__info__name">support</bold>
             </figcaption>
           </figure>
         </div
@@ -79,13 +78,12 @@
             <div class="c-swatch__color u-bg-explore-blue">
               <svg class="c-swatch__color__product">
                 <use xlink:href="../../index.svg#zd-svg-icon-26-relationshape-explore">
-                  <title>Explore Blue</title>
+                  <title>Explore</title>
                 </use>
               </svg>
             </div>
             <figcaption class="c-swatch__info">
-              <bold class="c-swatch__info__name">explore-blue</bold>
-              <span class="c-swatch__info__hex">30aabc</span>
+              <bold class="c-swatch__info__name">explore</bold>
             </figcaption>
           </figure>
         </div
@@ -94,13 +92,12 @@
             <div class="c-swatch__color u-bg-gather-pink">
               <svg class="c-swatch__color__product">
                 <use xlink:href="../../index.svg#zd-svg-icon-26-relationshape-gather">
-                  <title>Gather Pink</title>
+                  <title>Gather</title>
                 </use>
               </svg>
             </div>
             <figcaption class="c-swatch__info">
-              <bold class="c-swatch__info__name">gather-pink</bold>
-              <span class="c-swatch__info__hex">e7afa2</span>
+              <bold class="c-swatch__info__name">gather</bold>
             </figcaption>
           </figure>
         </div
@@ -109,13 +106,12 @@
             <div class="c-swatch__color u-bg-guide-pink">
               <svg class="c-swatch__color__product">
                 <use xlink:href="../../index.svg#zd-svg-icon-26-relationshape-guide">
-                  <title>Guide Pink</title>
+                  <title>Guide</title>
                 </use>
               </svg>
             </div>
             <figcaption class="c-swatch__info">
-              <bold class="c-swatch__info__name">guide-pink</bold>
-              <span class="c-swatch__info__hex">eb4962</span>
+              <bold class="c-swatch__info__name">guide</bold>
             </figcaption>
           </figure>
         </div
@@ -124,13 +120,12 @@
             <div class="c-swatch__color u-bg-connect-red">
               <svg class="c-swatch__color__product">
                 <use xlink:href="../../index.svg#zd-svg-icon-26-relationshape-connect">
-                  <title>Connect Red</title>
+                  <title>Connect</title>
                 </use>
               </svg>
             </div>
             <figcaption class="c-swatch__info">
-              <bold class="c-swatch__info__name">connect-red</bold>
-              <span class="c-swatch__info__hex">eb6651</span>
+              <bold class="c-swatch__info__name">connect</bold>
             </figcaption>
           </figure>
         </div
@@ -139,13 +134,12 @@
             <div class="c-swatch__color u-bg-chat-orange">
               <svg class="c-swatch__color__product">
                 <use xlink:href="../../index.svg#zd-svg-icon-26-relationshape-chat">
-                  <title>Chat Orange</title>
+                  <title>Chat</title>
                 </use>
               </svg>
             </div>
             <figcaption class="c-swatch__info">
-              <bold class="c-swatch__info__name">chat-orange</bold>
-              <span class="c-swatch__info__hex">f79a3e</span>
+              <bold class="c-swatch__info__name">chat</bold>
             </figcaption>
           </figure>
         </div
@@ -154,13 +148,12 @@
             <div class="c-swatch__color u-bg-talk-yellow">
               <svg class="c-swatch__color__product">
                 <use xlink:href="../../index.svg#zd-svg-icon-26-relationshape-talk">
-                  <title>Talk Yellow</title>
+                  <title>Talk</title>
                 </use>
               </svg>
             </div>
             <figcaption class="c-swatch__info">
-              <bold class="c-swatch__info__name">talk-yellow</bold>
-              <span class="c-swatch__info__hex">efc93d</span>
+              <bold class="c-swatch__info__name">talk</bold>
             </figcaption>
           </figure>
         </div
@@ -169,13 +162,12 @@
             <div class="c-swatch__color u-bg-sell-gold">
               <svg class="c-swatch__color__product">
                 <use xlink:href="../../index.svg#zd-svg-icon-26-relationshape-sell">
-                  <title>Sell Gold</title>
+                  <title>Sell</title>
                 </use>
               </svg>
             </div>
             <figcaption class="c-swatch__info">
-              <bold class="c-swatch__info__name">sell-gold</bold>
-              <span class="c-swatch__info__hex">d4ae5e</span>
+              <bold class="c-swatch__info__name">sell</bold>
             </figcaption>
           </figure>
         </div>
@@ -189,7 +181,6 @@
               <div class="c-swatch__color u-bg-grey-800"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">grey-800</bold>
-                <span class="c-swatch__info__hex">2f3941</span>
               </figcaption>
             </figure>
           </div
@@ -198,7 +189,6 @@
               <div class="c-swatch__color u-bg-grey-700"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">grey-700</bold>
-                <span class="c-swatch__info__hex">49545c</span>
               </figcaption>
             </figure>
           </div
@@ -207,7 +197,6 @@
               <div class="c-swatch__color u-bg-grey-600"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">grey-600</bold>
-                <span class="c-swatch__info__hex">68737d</span>
               </figcaption>
             </figure>
           </div
@@ -216,7 +205,6 @@
               <div class="c-swatch__color u-bg-grey-500"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">grey-500</bold>
-                <span class="c-swatch__info__hex">87929d</span>
               </figcaption>
             </figure>
           </div
@@ -225,7 +213,6 @@
               <div class="c-swatch__color u-bg-grey-400"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">grey-400</bold>
-                <span class="c-swatch__info__hex">c2c8cc</span>
               </figcaption>
             </figure>
           </div
@@ -234,7 +221,6 @@
               <div class="c-swatch__color u-bg-grey-300"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">grey-300</bold>
-                <span class="c-swatch__info__hex">d8dcde</span>
               </figcaption>
             </figure>
           </div
@@ -243,7 +229,6 @@
               <div class="c-swatch__color u-bg-grey-200"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">grey-200</bold>
-                <span class="c-swatch__info__hex">e9ebed</span>
               </figcaption>
             </figure>
           </div
@@ -252,7 +237,6 @@
               <div class="c-swatch__color u-bg-grey-100"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">grey-100</bold>
-                <span class="c-swatch__info__hex">f8f9f9</span>
               </figcaption>
             </figure>
           </div>
@@ -266,7 +250,6 @@
               <div class="c-swatch__color u-bg-blue-800"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">blue-800</bold>
-                <span class="c-swatch__info__hex">0f3554</span>
               </figcaption>
             </figure>
           </div
@@ -275,7 +258,6 @@
               <div class="c-swatch__color u-bg-blue-700"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">blue-700</bold>
-                <span class="c-swatch__info__hex">144a75</span>
               </figcaption>
             </figure>
           </div
@@ -284,7 +266,6 @@
               <div class="c-swatch__color u-bg-blue-600"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">blue-600</bold>
-                <span class="c-swatch__info__hex">1f73b7</span>
               </figcaption>
             </figure>
           </div
@@ -293,7 +274,6 @@
               <div class="c-swatch__color u-bg-blue-500"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">blue-500</bold>
-                <span class="c-swatch__info__hex">337fbd</span>
               </figcaption>
             </figure>
           </div
@@ -302,7 +282,6 @@
               <div class="c-swatch__color u-bg-blue-400"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">blue-400</bold>
-                <span class="c-swatch__info__hex">5293c7</span>
               </figcaption>
             </figure>
           </div
@@ -311,7 +290,6 @@
               <div class="c-swatch__color u-bg-blue-300"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">blue-300</bold>
-                <span class="c-swatch__info__hex">adcce4</span>
               </figcaption>
             </figure>
           </div
@@ -320,7 +298,6 @@
               <div class="c-swatch__color u-bg-blue-200"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">blue-200</bold>
-                <span class="c-swatch__info__hex">cee2f2</span>
               </figcaption>
             </figure>
           </div
@@ -329,7 +306,6 @@
               <div class="c-swatch__color u-bg-blue-100"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">blue-100</bold>
-                <span class="c-swatch__info__hex">edf7ff</span>
               </figcaption>
             </figure>
           </div>
@@ -343,7 +319,6 @@
               <div class="c-swatch__color u-bg-kale-800"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">kale-800</bold>
-                <span class="c-swatch__info__hex">012b30</span>
               </figcaption>
             </figure>
           </div
@@ -352,7 +327,6 @@
               <div class="c-swatch__color u-bg-kale-700"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">kale-700</bold>
-                <span class="c-swatch__info__hex">03363d</span>
               </figcaption>
             </figure>
           </div
@@ -361,7 +335,6 @@
               <div class="c-swatch__color u-bg-kale-600"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">kale-600</bold>
-                <span class="c-swatch__info__hex">04444d</span>
               </figcaption>
             </figure>
           </div
@@ -370,7 +343,6 @@
               <div class="c-swatch__color u-bg-kale-500"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">kale-500</bold>
-                <span class="c-swatch__info__hex">335d63</span>
               </figcaption>
             </figure>
           </div
@@ -379,7 +351,6 @@
               <div class="c-swatch__color u-bg-kale-400"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">kale-400</bold>
-                <span class="c-swatch__info__hex">56777a</span>
               </figcaption>
             </figure>
           </div
@@ -388,7 +359,6 @@
               <div class="c-swatch__color u-bg-kale-300"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">kale-300</bold>
-                <span class="c-swatch__info__hex">819a9e</span>
               </figcaption>
             </figure>
           </div
@@ -397,7 +367,6 @@
               <div class="c-swatch__color u-bg-kale-200"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">kale-200</bold>
-                <span class="c-swatch__info__hex">c1d6d9</span>
               </figcaption>
             </figure>
           </div
@@ -406,7 +375,6 @@
               <div class="c-swatch__color u-bg-kale-100"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">kale-100</bold>
-                <span class="c-swatch__info__hex">f5fbfc</span>
               </figcaption>
             </figure>
           </div>
@@ -420,7 +388,6 @@
               <div class="c-swatch__color u-bg-red-800"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">red-800</bold>
-                <span class="c-swatch__info__hex">681219</span>
               </figcaption>
             </figure>
           </div
@@ -429,7 +396,6 @@
               <div class="c-swatch__color u-bg-red-700"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">red-700</bold>
-                <span class="c-swatch__info__hex">8c232c</span>
               </figcaption>
             </figure>
           </div
@@ -438,7 +404,6 @@
               <div class="c-swatch__color u-bg-red-600"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">red-600</bold>
-                <span class="c-swatch__info__hex">cc3340</span>
               </figcaption>
             </figure>
           </div
@@ -447,7 +412,6 @@
               <div class="c-swatch__color u-bg-red-500"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">red-500</bold>
-                <span class="c-swatch__info__hex">d93f4c</span>
               </figcaption>
             </figure>
           </div
@@ -456,7 +420,6 @@
               <div class="c-swatch__color u-bg-red-400"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">red-400</bold>
-                <span class="c-swatch__info__hex">e35b66</span>
               </figcaption>
             </figure>
           </div
@@ -465,7 +428,6 @@
               <div class="c-swatch__color u-bg-red-300"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">red-300</bold>
-                <span class="c-swatch__info__hex">f5b5ba</span>
               </figcaption>
             </figure>
           </div
@@ -474,7 +436,6 @@
               <div class="c-swatch__color u-bg-red-200"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">red-200</bold>
-                <span class="c-swatch__info__hex">f5d5d8</span>
               </figcaption>
             </figure>
           </div
@@ -483,7 +444,6 @@
               <div class="c-swatch__color u-bg-red-100"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">red-100</bold>
-                <span class="c-swatch__info__hex">fff0f1</span>
               </figcaption>
             </figure>
           </div>
@@ -497,7 +457,6 @@
               <div class="c-swatch__color u-bg-green-800"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">green-800</bold>
-                <span class="c-swatch__info__hex">0b3b29</span>
               </figcaption>
             </figure>
           </div
@@ -506,7 +465,6 @@
               <div class="c-swatch__color u-bg-green-700"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">green-700</bold>
-                <span class="c-swatch__info__hex">186146</span>
               </figcaption>
             </figure>
           </div
@@ -515,7 +473,6 @@
               <div class="c-swatch__color u-bg-green-600"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">green-600</bold>
-                <span class="c-swatch__info__hex">038153</span>
               </figcaption>
             </figure>
           </div
@@ -524,7 +481,6 @@
               <div class="c-swatch__color u-bg-green-500"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">green-500</bold>
-                <span class="c-swatch__info__hex">228f67</span>
               </figcaption>
             </figure>
           </div
@@ -533,7 +489,6 @@
               <div class="c-swatch__color u-bg-green-400"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">green-400</bold>
-                <span class="c-swatch__info__hex">5eae91</span>
               </figcaption>
             </figure>
           </div
@@ -542,7 +497,6 @@
               <div class="c-swatch__color u-bg-green-300"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">green-300</bold>
-                <span class="c-swatch__info__hex">aecfc2</span>
               </figcaption>
             </figure>
           </div
@@ -551,7 +505,6 @@
               <div class="c-swatch__color u-bg-green-200"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">green-200</bold>
-                <span class="c-swatch__info__hex">d1e8df</span>
               </figcaption>
             </figure>
           </div
@@ -560,7 +513,6 @@
               <div class="c-swatch__color u-bg-green-100"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">green-100</bold>
-                <span class="c-swatch__info__hex">edf8f4</span>
               </figcaption>
             </figure>
           </div>
@@ -574,7 +526,6 @@
               <div class="c-swatch__color u-bg-yellow-800"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">yellow-800</bold>
-                <span class="c-swatch__info__hex">703b15</span>
               </figcaption>
             </figure>
           </div
@@ -583,7 +534,6 @@
               <div class="c-swatch__color u-bg-yellow-700"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">yellow-700</bold>
-                <span class="c-swatch__info__hex">ad5e18</span>
               </figcaption>
             </figure>
           </div
@@ -592,7 +542,6 @@
               <div class="c-swatch__color u-bg-yellow-600"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">yellow-600</bold>
-                <span class="c-swatch__info__hex">ed961c</span>
               </figcaption>
             </figure>
           </div
@@ -601,7 +550,6 @@
               <div class="c-swatch__color u-bg-yellow-500"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">yellow-500</bold>
-                <span class="c-swatch__info__hex">f5a133</span>
               </figcaption>
             </figure>
           </div
@@ -610,7 +558,6 @@
               <div class="c-swatch__color u-bg-yellow-400"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">yellow-400</bold>
-                <span class="c-swatch__info__hex">ffb648</span>
               </figcaption>
             </figure>
           </div
@@ -619,7 +566,6 @@
               <div class="c-swatch__color u-bg-yellow-300"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">yellow-300</bold>
-                <span class="c-swatch__info__hex">fcdba9</span>
               </figcaption>
             </figure>
           </div
@@ -628,7 +574,6 @@
               <div class="c-swatch__color u-bg-yellow-200"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">yellow-200</bold>
-                <span class="c-swatch__info__hex">fff0db</span>
               </figcaption>
             </figure>
           </div
@@ -637,7 +582,6 @@
               <div class="c-swatch__color u-bg-yellow-100"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">yellow-100</bold>
-                <span class="c-swatch__info__hex">fff8ed</span>
               </figcaption>
             </figure>
           </div>
@@ -657,7 +601,6 @@
               <div class="c-swatch__color u-bg-fuschia-600"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">fuschia-600</bold>
-                <span class="c-swatch__info__hex">a81897</span>
               </figcaption>
             </figure>
           </div
@@ -666,7 +609,6 @@
               <div class="c-swatch__color u-bg-fuschia-M600"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">fuschia-M600</bold>
-                <span class="c-swatch__info__hex">a8458c</span>
               </figcaption>
             </figure>
           </div
@@ -675,7 +617,6 @@
               <div class="c-swatch__color u-bg-fuschia-400"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">fuschia-400</bold>
-                <span class="c-swatch__info__hex">d653c2</span>
               </figcaption>
             </figure>
           </div
@@ -684,7 +625,6 @@
               <div class="c-swatch__color u-bg-fuschia-M400"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">fuschia-M400</bold>
-                <span class="c-swatch__info__hex">cf62a8</span>
               </figcaption>
             </figure>
           </div>
@@ -698,7 +638,6 @@
               <div class="c-swatch__color u-bg-pink-600"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">pink-600</bold>
-                <span class="c-swatch__info__hex">d42054</span>
               </figcaption>
             </figure>
           </div
@@ -707,7 +646,6 @@
               <div class="c-swatch__color u-bg-pink-M600"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">pink-M600</bold>
-                <span class="c-swatch__info__hex">b23a5d</span>
               </figcaption>
             </figure>
           </div
@@ -716,7 +654,6 @@
               <div class="c-swatch__color u-bg-pink-400"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">pink-400</bold>
-                <span class="c-swatch__info__hex">ec4d63</span>
               </figcaption>
             </figure>
           </div
@@ -725,7 +662,6 @@
               <div class="c-swatch__color u-bg-pink-M400"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">pink-M400</bold>
-                <span class="c-swatch__info__hex">d57287</span>
               </figcaption>
             </figure>
           </div>
@@ -739,7 +675,6 @@
               <div class="c-swatch__color u-bg-crimson-600"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">crimson-600</bold>
-                <span class="c-swatch__info__hex">c72a1c</span>
               </figcaption>
             </figure>
           </div
@@ -748,7 +683,6 @@
               <div class="c-swatch__color u-bg-crimson-M600"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">crimson-M600</bold>
-                <span class="c-swatch__info__hex">b24a3c</span>
               </figcaption>
             </figure>
           </div
@@ -757,7 +691,6 @@
               <div class="c-swatch__color u-bg-crimson-400"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">crimson-400</bold>
-                <span class="c-swatch__info__hex">e34f32</span>
               </figcaption>
             </figure>
           </div
@@ -766,7 +699,6 @@
               <div class="c-swatch__color u-bg-crimson-M400"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">crimson-M400</bold>
-                <span class="c-swatch__info__hex">cc6c5b</span>
               </figcaption>
             </figure>
           </div>
@@ -780,7 +712,6 @@
               <div class="c-swatch__color u-bg-orange-600"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">orange-600</bold>
-                <span class="c-swatch__info__hex">bf5000</span>
               </figcaption>
             </figure>
           </div
@@ -789,7 +720,6 @@
               <div class="c-swatch__color u-bg-orange-M600"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">orange-M600</bold>
-                <span class="c-swatch__info__hex">b35827</span>
               </figcaption>
             </figure>
           </div
@@ -798,7 +728,6 @@
               <div class="c-swatch__color u-bg-orange-400"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">orange-400</bold>
-                <span class="c-swatch__info__hex">de701d</span>
               </figcaption>
             </figure>
           </div
@@ -807,7 +736,6 @@
               <div class="c-swatch__color u-bg-orange-M400"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">orange-M400</bold>
-                <span class="c-swatch__info__hex">d4772c</span>
               </figcaption>
             </figure>
           </div>
@@ -821,7 +749,6 @@
               <div class="c-swatch__color u-bg-lemon-600"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">lemon-600</bold>
-                <span class="c-swatch__info__hex">ffbb10</span>
               </figcaption>
             </figure>
           </div
@@ -830,7 +757,6 @@
               <div class="c-swatch__color u-bg-lemon-M600"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">lemon-M600</bold>
-                <span class="c-swatch__info__hex">c38f00</span>
               </figcaption>
             </figure>
           </div
@@ -839,7 +765,6 @@
               <div class="c-swatch__color u-bg-lemon-400"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">lemon-400</bold>
-                <span class="c-swatch__info__hex">ffd424</span>
               </figcaption>
             </figure>
           </div
@@ -848,7 +773,6 @@
               <div class="c-swatch__color u-bg-lemon-M400"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">lemon-M400</bold>
-                <span class="c-swatch__info__hex">e7a500</span>
               </figcaption>
             </figure>
           </div>
@@ -862,7 +786,6 @@
               <div class="c-swatch__color u-bg-lime-600"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">lime-600</bold>
-                <span class="c-swatch__info__hex">2e8200</span>
               </figcaption>
             </figure>
           </div
@@ -871,7 +794,6 @@
               <div class="c-swatch__color u-bg-lime-M600"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">lime-M600</bold>
-                <span class="c-swatch__info__hex">47782c</span>
               </figcaption>
             </figure>
           </div
@@ -880,7 +802,6 @@
               <div class="c-swatch__color u-bg-lime-400"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">lime-400</bold>
-                <span class="c-swatch__info__hex">43b324</span>
               </figcaption>
             </figure>
           </div
@@ -889,7 +810,6 @@
               <div class="c-swatch__color u-bg-lime-M400"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">lime-M400</bold>
-                <span class="c-swatch__info__hex">519e2d</span>
               </figcaption>
             </figure>
           </div>
@@ -903,7 +823,6 @@
               <div class="c-swatch__color u-bg-mint-600"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">mint-600</bold>
-                <span class="c-swatch__info__hex">058541</span>
               </figcaption>
             </figure>
           </div
@@ -912,7 +831,6 @@
               <div class="c-swatch__color u-bg-mint-M600"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">mint-M600</bold>
-                <span class="c-swatch__info__hex">2e8057</span>
               </figcaption>
             </figure>
           </div
@@ -921,7 +839,6 @@
               <div class="c-swatch__color u-bg-mint-400"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">mint-400</bold>
-                <span class="c-swatch__info__hex">00a656</span>
               </figcaption>
             </figure>
           </div
@@ -930,7 +847,6 @@
               <div class="c-swatch__color u-bg-mint-M400"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">mint-M400</bold>
-                <span class="c-swatch__info__hex">299c66</span>
               </figcaption>
             </figure>
           </div>
@@ -944,7 +860,6 @@
               <div class="c-swatch__color u-bg-teal-600"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">teal-600</bold>
-                <span class="c-swatch__info__hex">028079</span>
               </figcaption>
             </figure>
           </div
@@ -953,7 +868,6 @@
               <div class="c-swatch__color u-bg-teal-M600"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">teal-M600</bold>
-                <span class="c-swatch__info__hex">3c7873</span>
               </figcaption>
             </figure>
           </div
@@ -962,7 +876,6 @@
               <div class="c-swatch__color u-bg-teal-400"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">teal-400</bold>
-                <span class="c-swatch__info__hex">02a191</span>
               </figcaption>
             </figure>
           </div
@@ -971,7 +884,6 @@
               <div class="c-swatch__color u-bg-teal-M400"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">teal-M400</bold>
-                <span class="c-swatch__info__hex">2d9e8f</span>
               </figcaption>
             </figure>
           </div>
@@ -985,7 +897,6 @@
               <div class="c-swatch__color u-bg-azure-600"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">azure-600</bold>
-                <span class="c-swatch__info__hex">1371d6</span>
               </figcaption>
             </figure>
           </div
@@ -994,7 +905,6 @@
               <div class="c-swatch__color u-bg-azure-M600"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">azure-M600</bold>
-                <span class="c-swatch__info__hex">3a70b2</span>
               </figcaption>
             </figure>
           </div
@@ -1003,7 +913,6 @@
               <div class="c-swatch__color u-bg-azure-400"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">azure-400</bold>
-                <span class="c-swatch__info__hex">3091ec</span>
               </figcaption>
             </figure>
           </div
@@ -1012,7 +921,6 @@
               <div class="c-swatch__color u-bg-azure-M400"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">azure-M400</bold>
-                <span class="c-swatch__info__hex">5f8dcf</span>
               </figcaption>
             </figure>
           </div>
@@ -1026,7 +934,6 @@
               <div class="c-swatch__color u-bg-royal-600"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">royal-600</bold>
-                <span class="c-swatch__info__hex">3353e2</span>
               </figcaption>
             </figure>
           </div
@@ -1035,7 +942,6 @@
               <div class="c-swatch__color u-bg-royal-M600"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">royal-M600</bold>
-                <span class="c-swatch__info__hex">4b61c3</span>
               </figcaption>
             </figure>
           </div
@@ -1044,7 +950,6 @@
               <div class="c-swatch__color u-bg-royal-400"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">royal-400</bold>
-                <span class="c-swatch__info__hex">5d7df5</span>
               </figcaption>
             </figure>
           </div
@@ -1053,7 +958,6 @@
               <div class="c-swatch__color u-bg-royal-M400"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">royal-M400</bold>
-                <span class="c-swatch__info__hex">7986d8</span>
               </figcaption>
             </figure>
           </div>
@@ -1067,7 +971,6 @@
               <div class="c-swatch__color u-bg-purple-600"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">purple-600</bold>
-                <span class="c-swatch__info__hex">6a27b8</span>
               </figcaption>
             </figure>
           </div
@@ -1076,7 +979,6 @@
               <div class="c-swatch__color u-bg-purple-M600"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">purple-M600</bold>
-                <span class="c-swatch__info__hex">9358b0</span>
               </figcaption>
             </figure>
           </div
@@ -1085,7 +987,6 @@
               <div class="c-swatch__color u-bg-purple-400"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">purple-400</bold>
-                <span class="c-swatch__info__hex">b552e2</span>
               </figcaption>
             </figure>
           </div
@@ -1094,7 +995,6 @@
               <div class="c-swatch__color u-bg-purple-M400"></div>
               <figcaption class="c-swatch__info">
                 <bold class="c-swatch__info__name">purple-M400</bold>
-                <span class="c-swatch__info__hex">b072cc</span>
               </figcaption>
             </figure>
           </div>

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "devDependencies": {
     "@zendeskgarden/eslint-config": "15.0.0",
-    "@zendeskgarden/react-theming": "8.22.0",
+    "@zendeskgarden/react-theming": "8.24.0",
     "@zendeskgarden/scripts": "0.1.11",
     "@zendeskgarden/stylelint-config": "14.0.0",
     "@zendeskgarden/svg-icons": "6.22.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1411,10 +1411,10 @@
   resolved "https://registry.yarnpkg.com/@zendeskgarden/eslint-config/-/eslint-config-15.0.0.tgz#b05982801029e1b1d5ec5a435d7e95dc8733dda3"
   integrity sha512-NfHIJgd/7G4UtR0SSFThp8rOtr85DZDWnFbhSDPeUF3c8qVAhcAy46+Unl5LJteBgQwTNOgM/puw3VCUdl9EMQ==
 
-"@zendeskgarden/react-theming@8.22.0":
-  version "8.22.0"
-  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.22.0.tgz#5bb3bcdb251b2a45b37288c58168eb5ef2775cd7"
-  integrity sha512-Wjg30Xim8GzQA9W7TeNSO82ER1iCi19wwjhxm99Jf58CgUy3GOTGxXc0IWBnk/05x35X6GW+RqENsU3N8xJjkA==
+"@zendeskgarden/react-theming@8.24.0":
+  version "8.24.0"
+  resolved "https://registry.yarnpkg.com/@zendeskgarden/react-theming/-/react-theming-8.24.0.tgz#f3d0657715779d5216239ee41722301b39098ce4"
+  integrity sha512-UVDMCdycN5ewiglqD9MfE5HehlafGydQAcng4zBDC8zqqvpCxtVFDWNE249M9BtRdgq9QaIQphsnI9xjN88o8A==
   dependencies:
     "@zendeskgarden/container-focusvisible" "^0.4.3"
     "@zendeskgarden/container-utilities" "^0.5.1"


### PR DESCRIPTION
- [ ] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

This PR:

- Utilizes current `react-components` theming variables with updated brand colors
- Removes manually added (and out-of-date) hex values from the deprecated `css-utilities` demo page

## Checklist

* [x] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [ ] :white_check_mark: ~all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)~
* [ ] :arrow_left: ~renders as expected with reversed (RTL) direction~
* [ ] :metal: ~renders as expected sans Bedrock (`?bedrock=false`)~
* [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
