### PR TITLE
fix: use camel case for React dom attributes

### DIFF
--- a/packages/avatars/demo/avatars.stories.mdx
+++ b/packages/avatars/demo/avatars.stories.mdx
@@ -22,21 +22,21 @@ Component classes for styling your avatars.
     }}
   >
     {({ size }) => (
-      <div class="container">
-        <div class="row">
-          <div class="col u-mt">
-            <figure class={`c-avatar ${size}`}>
+      <div className="container">
+        <div className="row">
+          <div className="col u-mt">
+            <figure className={`c-avatar ${size}`}>
               <img alt="user" src={UserImage} />
             </figure>
-            <div class="u-mt-xs">
+            <div className="u-mt-xs">
               <code>.c-avatar{size && `.${size}`}</code>
             </div>
           </div>
-          <div class="col u-mt">
-            <figure class={`c-avatar c-avatar--system ${size}`}>
+          <div className="col u-mt">
+            <figure className={`c-avatar c-avatar--system ${size}`}>
               <img alt="system" src={SystemImage} />
             </figure>
-            <div class="u-mt-xs">
+            <div className="u-mt-xs">
               <code>.c-avatar.c-avatar--system{size && `.${size}`}</code>
             </div>
           </div>
@@ -66,28 +66,28 @@ color (default "white") of the child text or SVG may be overridden.
     }}
   >
     {({ size }) => (
-      <div class="container">
-        <div class="row">
-          <div class="col u-mt">
-            <figure class={`c-avatar ${size} u-bg-royal-600`}>
-              <span class="c-avatar__txt">G</span>
+      <div className="container">
+        <div className="row">
+          <div className="col u-mt">
+            <figure className={`c-avatar ${size} u-bg-royal-600`}>
+              <span className="c-avatar__txt">G</span>
             </figure>
-            <div class="u-mt-xs">
+            <div className="u-mt-xs">
               <code>.c-avatar{size && `.${size}`} .c-avatar__txt</code>
             </div>
           </div>
-          <div class="col u-mt">
-            <figure class={`c-avatar c-avatar--system ${size} u-bg-royal-600`}>
-              <span class="c-avatar__txt">ZD</span>
+          <div className="col u-mt">
+            <figure className={`c-avatar c-avatar--system ${size} u-bg-royal-600`}>
+              <span className="c-avatar__txt">ZD</span>
             </figure>
-            <div class="u-mt-xs">
+            <div className="u-mt-xs">
               <code>.c-avatar.c-avatar--system{size && `.${size}`} .c-avatar__txt</code>
             </div>
           </div>
         </div>
-        <div class="row">
-          <div class="col u-mt">
-            <figure class={`c-avatar ${size} u-bg-grey-600`}>
+        <div className="row">
+          <div className="col u-mt">
+            <figure className={`c-avatar ${size} u-bg-grey-600`}>
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 width="16"
@@ -97,16 +97,16 @@ color (default "white") of the child text or SVG may be overridden.
               >
                 <g fill="none" stroke="currentColor">
                   <circle cx="8" cy="5" r="3.5" />
-                  <path stroke-linecap="round" d="M2.5 15.5c.3-2.8 2.6-5 5.5-5s5.2 2.2 5.5 5" />
+                  <path strokeLinecap="round" d="M2.5 15.5c.3-2.8 2.6-5 5.5-5s5.2 2.2 5.5 5" />
                 </g>
               </svg>
             </figure>
-            <div class="u-mt-xs">
+            <div className="u-mt-xs">
               <code>.c-avatar{size && `.${size}`} > svg</code>
             </div>
           </div>
-          <div class="col u-mt">
-            <figure class={`c-avatar c-avatar--system ${size} u-bg-kale-800`}>
+          <div className="col u-mt">
+            <figure className={`c-avatar c-avatar--system ${size} u-bg-kale-800`}>
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 width="26"
@@ -120,7 +120,7 @@ color (default "white") of the child text or SVG may be overridden.
                 />
               </svg>
             </figure>
-            <div class="u-mt-xs">
+            <div className="u-mt-xs">
               <code>.c-avatar.c-avatar--system{size && `.${size}`} > svg</code>
             </div>
           </div>

--- a/packages/bedrock/demo/bedrock.stories.mdx
+++ b/packages/bedrock/demo/bedrock.stories.mdx
@@ -10,10 +10,10 @@ CSS adds the following element resets on top of
 
 <Canvas>
   <Story name="Bedrock">
-    <div class="u-mb">
+    <div className="u-mb">
       <a href="">&lt;a&gt;</a>
     </div>
-    <div class="u-mb">
+    <div className="u-mb">
       <b>&lt;b&gt;</b>
       <em>&lt;em&gt;</em>
       <ins>&lt;ins&gt;</ins>
@@ -21,10 +21,10 @@ CSS adds the following element resets on top of
       <strong>&lt;strong&gt;</strong>
       <u>&lt;u&gt;</u>
     </div>
-    <div class="u-mb">
+    <div className="u-mb">
       <button>&lt;button&gt;</button>
     </div>
-    <div class="u-mb">
+    <div className="u-mb">
       <h1>&lt;h1&gt;</h1>
       <h2>&lt;h2&gt;</h2>
       <h3>&lt;h3&gt;</h3>
@@ -32,23 +32,23 @@ CSS adds the following element resets on top of
       <h5>&lt;h5&gt;</h5>
       <h6>&lt;h6&gt;</h6>
     </div>
-    <div class="u-mb">
-      <ul class="u-mb-sm">
+    <div className="u-mb">
+      <ul className="u-mb-sm">
         <li>&lt;ul&gt;</li>
       </ul>
-      <ol class="u-mb-sm">
+      <ol className="u-mb-sm">
         <li>&lt;ol&gt;</li>
       </ol>
-      <dl class="u-mb-sm">
+      <dl className="u-mb-sm">
         <li>&lt;dl&gt;</li>
         <li>&lt;dl&gt;</li>
       </dl>
-      <dd class="u-mb-sm">
+      <dd className="u-mb-sm">
         <li>&lt;dd&gt;</li>
         <li>&lt;dd&gt;</li>
       </dd>
     </div>
-    <div class="u-mb">
+    <div className="u-mb">
       <p>&lt;p&gt;</p>
       <blockquote>&lt;blockquote&gt;</blockquote>
       <pre>&lt;pre&gt;</pre>

--- a/packages/buttons/demo/buttons.stories.mdx
+++ b/packages/buttons/demo/buttons.stories.mdx
@@ -34,18 +34,20 @@ together with the
     }}
   >
     {({ size, state, style }) => (
-      <div class="container">
-        <div class="row align-items-center">
-          <div class="col u-mt">
-            <button class={`c-btn ${size} ${style && style.join(' ')} ${state && state.join(' ')}`}>
+      <div className="container">
+        <div className="row align-items-center">
+          <div className="col u-mt">
+            <button
+              className={`c-btn ${size} ${style && style.join(' ')} ${state && state.join(' ')}`}
+            >
               .c-btn{size && `.${size}`}
               {style && style.length > 0 && `.${style.join('.')}`}
               {state && state.length > 0 && `.${state.join('.')}`}
             </button>
           </div>
-          <div class="col u-mt">
+          <div className="col u-mt">
             <button
-              class={`c-btn c-btn--pill ${size} ${style && style.join(' ')} ${
+              className={`c-btn c-btn--pill ${size} ${style && style.join(' ')} ${
                 state && state.join(' ')
               }`}
             >
@@ -54,9 +56,9 @@ together with the
               {state && state.length > 0 && `.${state.join('.')}`}
             </button>
           </div>
-          <div class="col u-mt">
+          <div className="col u-mt">
             <button
-              class={`c-btn c-btn--basic ${size} ${style && style.join(' ')} ${
+              className={`c-btn c-btn--basic ${size} ${style && style.join(' ')} ${
                 state && state.join(' ')
               }`}
             >
@@ -65,9 +67,9 @@ together with the
               {state && state.length > 0 && `.${state.join('.')}`}
             </button>
           </div>
-          <div class="col u-mt">
+          <div className="col u-mt">
             <button
-              class={`c-btn c-btn--anchor ${size} ${style && style.join(' ')} ${
+              className={`c-btn c-btn--anchor ${size} ${style && style.join(' ')} ${
                 state && state.join(' ')
               }`}
             >
@@ -111,12 +113,12 @@ image using the `.c-btn__icon class`. Icon rotation is achieved by adding
     }}
   >
     {({ isRotated, size, style }) => (
-      <div class="container">
-        <div class="row align-items-center">
-          <div class="col u-mt">
-            <button class={`c-btn c-btn--icon ${size} ${style && style.join(' ')}`}>
+      <div className="container">
+        <div className="row align-items-center">
+          <div className="col u-mt">
+            <button className={`c-btn c-btn--icon ${size} ${style && style.join(' ')}`}>
               <svg
-                class={`c-btn__icon ${isRotated && 'is-rotated'}`}
+                className={`c-btn__icon ${isRotated && 'is-rotated'}`}
                 xmlns="http://www.w3.org/2000/svg"
                 width="26"
                 height="26"
@@ -130,10 +132,10 @@ image using the `.c-btn__icon class`. Icon rotation is achieved by adding
               </svg>
             </button>
           </div>
-          <div class="col u-mt">
-            <button class={`c-btn c-btn--icon ${size} ${style && style.join(' ')}`}>
+          <div className="col u-mt">
+            <button className={`c-btn c-btn--icon ${size} ${style && style.join(' ')}`}>
               <svg
-                class={`c-btn__icon ${isRotated && 'is-rotated'}`}
+                className={`c-btn__icon ${isRotated && 'is-rotated'}`}
                 xmlns="http://www.w3.org/2000/svg"
                 width="16"
                 height="16"

--- a/packages/callouts/demo/callouts.stories.mdx
+++ b/packages/callouts/demo/callouts.stories.mdx
@@ -37,26 +37,26 @@ text should only receive paragraph styling when it wraps to multiple lines.
     }}
   >
     {({ isDialog, isRecessed, type }) => (
-      <div class="container">
-        <div class="row">
-          <div class="col u-mt">
+      <div className="container">
+        <div className="row">
+          <div className="col u-mt">
             <div
-              class={`c-callout ${isDialog && 'c-callout--dialog'} ${
+              className={`c-callout ${isDialog && 'c-callout--dialog'} ${
                 isRecessed && 'c-callout--recessed'
               } ${type}`}
             >
-              <strong class="c-callout__title">Callout (one-line)</strong>
+              <strong className="c-callout__title">Callout (one-line)</strong>
               <p>Paleo gochujang heirloom salvia subway tile letterpress retro.</p>
             </div>
           </div>
-          <div class="col u-mt">
+          <div className="col u-mt">
             <div
-              class={`c-callout ${isDialog && 'c-callout--dialog'} ${
+              className={`c-callout ${isDialog && 'c-callout--dialog'} ${
                 isRecessed && 'c-callout--recessed'
               } ${type}`}
             >
-              <strong class="c-callout__title">Callout (multi-line)</strong>
-              <p class="c-callout__paragraph">
+              <strong className="c-callout__title">Callout (multi-line)</strong>
+              <p className="c-callout__paragraph">
                 Chicharrones brooklyn cardigan marfa pour-over craft beer dreamcatcher cold-pressed
                 brunch meggings. Live-edge disrupt narwhal irony neutra single-origin coffee,
                 biodiesel before they sold out roof party venmo farm-to-table direct trade poke

--- a/packages/forms/README.md
+++ b/packages/forms/README.md
@@ -28,7 +28,7 @@ the following.
 ```html
 <div class="c-chk">
   <input class="c-chk__input" id="box-id" type="checkbox" />
-  <label class="c-chk__label" for="box-id">Label</label>
+  <label class="c-chk__label" htmlFor="box-id">Label</label>
 </div>
 ```
 
@@ -53,15 +53,15 @@ Use the `.c-chk--radio` modifier to style for radio button form fields.
 ```html
 <div class="c-chk c-chk--radio">
   <input class="c-chk__input" id="rdo-1" name="level" type="radio" />
-  <label class="c-chk__label" for="rdo-1">Beginner</label>
+  <label class="c-chk__label" htmlFor="rdo-1">Beginner</label>
 </div>
 <div class="c-chk c-chk--radio">
   <input class="c-chk__input" id="rdo-2" name="level" type="radio" />
-  <label class="c-chk__label" for="rdo-2">Intermediate</label>
+  <label class="c-chk__label" htmlFor="rdo-2">Intermediate</label>
 </div>
 <div class="c-chk c-chk--radio">
   <input class="c-chk__input" id="rdo-3" name="level" type="radio" />
-  <label class="c-chk__label" for="rdo-3">Advanced</label>
+  <label class="c-chk__label" htmlFor="rdo-3">Advanced</label>
 </div>
 ```
 
@@ -80,7 +80,7 @@ the following.
 
 ```html
 <div class="c-range">
-  <label class="c-range__label" for="range-id">Label</label>
+  <label class="c-range__label" htmlFor="range-id">Label</label>
   <small class="c-range__hint">Optional hint.</small>
   <input class="c-range__input" id="range-id" type="range" />
 </div>
@@ -118,7 +118,7 @@ the following.
 
 ```html
 <div class="c-txt">
-  <label class="c-txt__label" for="text-id">Label</label>
+  <label class="c-txt__label" htmlFor="text-id">Label</label>
   <small class="c-txt__hint">Optional hint.</small>
   <input class="c-txt__input" id="text-id" placeholder="[placeholder]" type="text" />
 </div>

--- a/packages/forms/demo/range.stories.mdx
+++ b/packages/forms/demo/range.stories.mdx
@@ -56,15 +56,17 @@ CSS whose size should be manipulated via JavaScript whenever the range
         return `${max ? (100 * (value - min)) / (max - min) : value}%`;
       };
       return (
-        <div class="c-range">
-          <label class={`c-range__label ${isCompact && 'c-range__label--sm'}`} for="range">
+        <div className="c-range">
+          <label className={`c-range__label ${isCompact && 'c-range__label--sm'}`} htmlFor="range">
             .c-range__label
           </label>
           {hasHint && (
-            <span class={`c-range__hint ${isCompact && 'c-range__hint--sm'}`}>.c-range__hint</span>
+            <span className={`c-range__hint ${isCompact && 'c-range__hint--sm'}`}>
+              .c-range__hint
+            </span>
           )}
           <input
-            class={`c-range__input ${isCompact && 'c-range__input--sm'} ${
+            className={`c-range__input ${isCompact && 'c-range__input--sm'} ${
               state && state.join(' ')
             }`}
             disabled={state && state.includes('is-disabled')}
@@ -80,7 +82,7 @@ CSS whose size should be manipulated via JavaScript whenever the range
             }}
           />
           {hasMessage && (
-            <small class={`c-range__message c-range__message--${validation}`}>
+            <small className={`c-range__message c-range__message--${validation}`}>
               .c-range__message
             </small>
           )}

--- a/packages/forms/demo/text.stories.mdx
+++ b/packages/forms/demo/text.stories.mdx
@@ -41,18 +41,20 @@ container.
     args={{ hasHint: true, hasMessage: true }}
   >
     {({ hasHint, hasMessage, isBare, isCompact, state, validation }) => (
-      <div class="container">
-        <div class="row">
-          <div class="col u-mt">
-            <div class="c-txt">
-              <label class={`c-txt__label ${isCompact && 'c-txt__label--sm'}`} for="text">
+      <div className="container">
+        <div className="row">
+          <div className="col u-mt">
+            <div className="c-txt">
+              <label className={`c-txt__label ${isCompact && 'c-txt__label--sm'}`} htmlFor="text">
                 .c-txt__label
               </label>
               {hasHint && (
-                <span class={`c-txt__hint ${isCompact && 'c-txt__hint--sm'}`}>.c-txt__hint</span>
+                <span className={`c-txt__hint ${isCompact && 'c-txt__hint--sm'}`}>
+                  .c-txt__hint
+                </span>
               )}
               <input
-                class={`c-txt__input ${isCompact && 'c-txt__input--sm'} ${
+                className={`c-txt__input ${isCompact && 'c-txt__input--sm'} ${
                   isBare && 'c-txt__input--bare'
                 } c-txt__input--${validation} ${state && state.join(' ')}`}
                 disabled={state && state.includes('is-disabled')}
@@ -61,22 +63,27 @@ container.
                 type="text"
               />
               {hasMessage && (
-                <small class={`c-txt__message c-txt__message--${validation}`}>
+                <small className={`c-txt__message c-txt__message--${validation}`}>
                   .c-txt__message
                 </small>
               )}
             </div>
           </div>
-          <div class="col u-mt">
-            <div class="c-txt u-mb-sm">
-              <label class={`c-txt__label ${isCompact && 'c-txt__label--sm'}`} for="textarea">
+          <div className="col u-mt">
+            <div className="c-txt u-mb-sm">
+              <label
+                className={`c-txt__label ${isCompact && 'c-txt__label--sm'}`}
+                htmlFor="textarea"
+              >
                 .c-txt__label
               </label>
               {hasHint && (
-                <span class={`c-txt__hint ${isCompact && 'c-txt__hint--sm'}`}>.c-txt__hint</span>
+                <span className={`c-txt__hint ${isCompact && 'c-txt__hint--sm'}`}>
+                  .c-txt__hint
+                </span>
               )}
               <textarea
-                class={`c-txt__input c-txt__input--area is-resizable ${
+                className={`c-txt__input c-txt__input--area is-resizable ${
                   isCompact && 'c-txt__input--sm'
                 } ${isBare && 'c-txt__input--bare'} c-txt__input--${validation} ${
                   state && state.join(' ')
@@ -87,26 +94,26 @@ container.
                 rows="1"
               ></textarea>
               {hasMessage && (
-                <small class={`c-txt__message c-txt__message--${validation}`}>
+                <small className={`c-txt__message c-txt__message--${validation}`}>
                   .c-txt__message
                 </small>
               )}
             </div>
           </div>
-          {/* <div class="col u-mt">
-            <div class="c-txt">
-              <label class={`c-txt__label ${isCompact && 'c-txt__label--sm'}`} for="media">
+          {/* <div className="col u-mt">
+            <div className="c-txt">
+              <label className={`c-txt__label ${isCompact && 'c-txt__label--sm'}`} htmlFor="media">
                 .c-txt__label
               </label>
               {hasHint && (
-                <span class={`c-txt__hint ${isCompact && 'c-txt__hint--sm'}`}>.c-txt__hint</span>
+                <span className={`c-txt__hint ${isCompact && 'c-txt__hint--sm'}`}>.c-txt__hint</span>
               )}
               <div
-                class={`c-txt__input c-txt__input--media ${isCompact && 'c-txt__input--sm'} ${
+                className={`c-txt__input c-txt__input--media ${isCompact && 'c-txt__input--sm'} ${
                   isBare && 'c-txt__input--bare'
                 } c-txt__input--${validation} ${state && state.join(' ')}`}
               >
-                <div class="c-txt__input--media__figure">
+                <div className="c-txt__input--media__figure">
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
                     width="16"
@@ -128,13 +135,13 @@ container.
                   </svg>
                 </div>
                 <input
-                  class="c-txt__input c-txt__input--bare c-txt__input--media__body"
+                  className="c-txt__input c-txt__input--bare c-txt__input--media__body"
                   disabled={state && state.includes('is-disabled')}
                   id="media"
                   placeholder=".c-txt__input.c-txt__input--media"
                   type="text"
                 />
-                <div class="c-txt__input--media__figure">
+                <div className="c-txt__input--media__figure">
                   <svg
                     xmlns="http://www.w3.org/2000/svg"
                     width="16"
@@ -152,22 +159,24 @@ container.
                 </div>
               </div>
               {hasMessage && (
-                <small class={`c-txt__message c-txt__message--${validation}`}>
+                <small className={`c-txt__message c-txt__message--${validation}`}>
                   .c-txt__message
                 </small>
               )}
             </div>
           </div> */}
-          <div class="col u-mt">
-            <div class="c-txt">
-              <label class={`c-txt__label ${isCompact && 'c-txt__label--sm'}`} for="select">
+          <div className="col u-mt">
+            <div className="c-txt">
+              <label className={`c-txt__label ${isCompact && 'c-txt__label--sm'}`} htmlFor="select">
                 .c-txt__label
               </label>
               {hasHint && (
-                <span class={`c-txt__hint ${isCompact && 'c-txt__hint--sm'}`}>.c-txt__hint</span>
+                <span className={`c-txt__hint ${isCompact && 'c-txt__hint--sm'}`}>
+                  .c-txt__hint
+                </span>
               )}
               <select
-                class={`c-txt__input c-txt__input--select ${isCompact && 'c-txt__input--sm'} ${
+                className={`c-txt__input c-txt__input--select ${isCompact && 'c-txt__input--sm'} ${
                   isBare && 'c-txt__input--bare'
                 } c-txt__input--${validation} ${state && state.join(' ')}`}
                 disabled={state && state.includes('is-disabled')}
@@ -178,7 +187,7 @@ container.
                 <option>bar</option>
               </select>
               {hasMessage && (
-                <small class={`c-txt__message c-txt__message--${validation}`}>
+                <small className={`c-txt__message c-txt__message--${validation}`}>
                   .c-txt__message
                 </small>
               )}
@@ -201,50 +210,50 @@ native calendar pickers.
 <Canvas>
   <Story name="Types">
     <form>
-      <div class="container">
-        <div class="row">
-          <div class="col u-mt">
-            <label class="c-txt__label" for="txt-type-color">
+      <div className="container">
+        <div className="row">
+          <div className="col u-mt">
+            <label className="c-txt__label" htmlFor="txt-type-color">
               Color
             </label>
             <input
-              class="c-txt__input"
+              className="c-txt__input"
               id="txt-type-color"
               placeholder="color"
               required
               type="color"
             />
           </div>
-          <div class="col u-mt">
-            <label class="c-txt__label" for="txt-type-date">
+          <div className="col u-mt">
+            <label className="c-txt__label" htmlFor="txt-type-date">
               Date
             </label>
             <input
-              class="c-txt__input c-txt__input--select"
+              className="c-txt__input c-txt__input--select"
               id="txt-type-date"
               placeholder="date"
               required
               type="date"
             />
           </div>
-          <div class="col u-mt">
-            <label class="c-txt__label" for="txt-type-datetime">
+          <div className="col u-mt">
+            <label className="c-txt__label" htmlFor="txt-type-datetime">
               Datetime-Local
             </label>
             <input
-              class="c-txt__input c-txt__input--select"
+              className="c-txt__input c-txt__input--select"
               id="txt-type-datetime"
               placeholder="datetime-local"
               required
               type="datetime-local"
             />
           </div>
-          <div class="col u-mt">
-            <label class="c-txt__label" for="txt-type-email">
+          <div className="col u-mt">
+            <label className="c-txt__label" htmlFor="txt-type-email">
               Email
             </label>
             <input
-              class="c-txt__input"
+              className="c-txt__input"
               id="txt-type-email"
               placeholder="email"
               required
@@ -252,49 +261,49 @@ native calendar pickers.
             />
           </div>
         </div>
-        <div class="row">
-          <div class="col u-mt">
-            <label class="c-txt__label" for="txt-type-file">
+        <div className="row">
+          <div className="col u-mt">
+            <label className="c-txt__label" htmlFor="txt-type-file">
               File
             </label>
             <input
-              class="c-txt__input"
+              className="c-txt__input"
               id="txt-type-file"
               placeholder="file"
               required
               type="file"
             />
           </div>
-          <div class="col u-mt">
-            <label class="c-txt__label" for="txt-type-month">
+          <div className="col u-mt">
+            <label className="c-txt__label" htmlFor="txt-type-month">
               Month
             </label>
             <input
-              class="c-txt__input c-txt__input--select"
+              className="c-txt__input c-txt__input--select"
               id="txt-type-month"
               placeholder="month"
               required
               type="month"
             />
           </div>
-          <div class="col u-mt">
-            <label class="c-txt__label" for="txt-type-number">
+          <div className="col u-mt">
+            <label className="c-txt__label" htmlFor="txt-type-number">
               Number
             </label>
             <input
-              class="c-txt__input"
+              className="c-txt__input"
               id="txt-type-number"
               placeholder="number"
               required
               type="number"
             />
           </div>
-          <div class="col u-mt">
-            <label class="c-txt__label" for="txt-type-password">
+          <div className="col u-mt">
+            <label className="c-txt__label" htmlFor="txt-type-password">
               Password
             </label>
             <input
-              class="c-txt__input"
+              className="c-txt__input"
               id="txt-type-password"
               placeholder="password"
               required
@@ -302,51 +311,63 @@ native calendar pickers.
             />
           </div>
         </div>
-        <div class="row">
-          <div class="col u-mt">
-            <label class="c-txt__label" for="txt-type-search">
+        <div className="row">
+          <div className="col u-mt">
+            <label className="c-txt__label" htmlFor="txt-type-search">
               Search
             </label>
             <input
-              class="c-txt__input"
+              className="c-txt__input"
               id="txt-type-search"
               placeholder="search"
               required
               type="search"
             />
           </div>
-          <div class="col u-mt">
-            <label class="c-txt__label" for="txt-type-tel">
+          <div className="col u-mt">
+            <label className="c-txt__label" htmlFor="txt-type-tel">
               Tel
             </label>
-            <input class="c-txt__input" id="txt-type-tel" placeholder="tel" required type="tel" />
+            <input
+              className="c-txt__input"
+              id="txt-type-tel"
+              placeholder="tel"
+              required
+              type="tel"
+            />
           </div>
-          <div class="col u-mt">
-            <label class="c-txt__label" for="txt-type-time">
+          <div className="col u-mt">
+            <label className="c-txt__label" htmlFor="txt-type-time">
               Time
             </label>
             <input
-              class="c-txt__input"
+              className="c-txt__input"
               id="txt-type-time"
               placeholder="time"
               required
               type="time"
             />
           </div>
-          <div class="col u-mt">
-            <label class="c-txt__label" for="txt-type-url">
+          <div className="col u-mt">
+            <label className="c-txt__label" htmlFor="txt-type-url">
               URL
             </label>
-            <input class="c-txt__input" id="txt-type-url" placeholder="url" required type="url" />
+            <input
+              className="c-txt__input"
+              id="txt-type-url"
+              placeholder="url"
+              required
+              type="url"
+            />
           </div>
         </div>
-        <div class="row">
-          <div class="col col-3 u-mt">
-            <label class="c-txt__label" for="txt-type-week">
+        <div className="row">
+          <div className="col col-3 u-mt">
+            <label className="c-txt__label" htmlFor="txt-type-week">
               Week
             </label>
             <input
-              class="c-txt__input c-txt__input--select"
+              className="c-txt__input c-txt__input--select"
               id="txt-type-week"
               placeholder="week"
               required
@@ -354,8 +375,8 @@ native calendar pickers.
             />
           </div>
         </div>
-        <div class="row">
-          <div class="col u-mt">
+        <div className="row">
+          <div className="col u-mt">
             <button type="submit">Test</button>
           </div>
         </div>

--- a/packages/forms/demo/toggle.stories.mdx
+++ b/packages/forms/demo/toggle.stories.mdx
@@ -36,57 +36,57 @@ shown below.
     args={{ hasHint: true, hasMessage: true }}
   >
     {({ hasHint, hasMessage, state, validation }) => (
-      <div class="container">
-        <div class="row">
-          <div class="col u-mt">
-            <div class="c-chk">
-              <input class="c-chk__input" id="checkbox" type="checkbox" />
-              <label class={`c-chk__label ${state && state.join(' ')}`} for="checkbox">
+      <div className="container">
+        <div className="row">
+          <div className="col u-mt">
+            <div className="c-chk">
+              <input className="c-chk__input" id="checkbox" type="checkbox" />
+              <label className={`c-chk__label ${state && state.join(' ')}`} htmlFor="checkbox">
                 .c-chk__label
               </label>
-              {hasHint && <span class="c-chk__hint">.c-chk__hint</span>}
+              {hasHint && <span className="c-chk__hint">.c-chk__hint</span>}
               {hasMessage && (
-                <small class={`c-chk__message c-chk__message--${validation}`}>
+                <small className={`c-chk__message c-chk__message--${validation}`}>
                   .c-chk__message
                 </small>
               )}
             </div>
           </div>
-          <div class="col u-mt">
-            <div class="c-chk">
-              <input class="c-chk__input" id="toggle" type="checkbox" />
+          <div className="col u-mt">
+            <div className="c-chk">
+              <input className="c-chk__input" id="toggle" type="checkbox" />
               <label
-                class={`c-chk__label c-chk__label--toggle ${state && state.join(' ')}`}
-                for="toggle"
+                className={`c-chk__label c-chk__label--toggle ${state && state.join(' ')}`}
+                htmlFor="toggle"
               >
                 .c-chk__label.c-chk__label--toggle
               </label>
               {hasHint && (
-                <span class="c-chk__hint c-chk__hint--toggle">
+                <span className="c-chk__hint c-chk__hint--toggle">
                   .c-chk__hint.c-chk__hint--toggle
                 </span>
               )}
               {hasMessage && (
                 <small
-                  class={`c-chk__message c-chk__message--toggle c-chk__message--${validation}`}
+                  className={`c-chk__message c-chk__message--toggle c-chk__message--${validation}`}
                 >
                   .c-chk__message.c-chk__message--toggle
                 </small>
               )}
             </div>
           </div>
-          <div class="col u-mt">
-            <div class="c-chk">
-              <input class="c-chk__input" id="radio" type="radio" />
+          <div className="col u-mt">
+            <div className="c-chk">
+              <input className="c-chk__input" id="radio" type="radio" />
               <label
-                class={`c-chk__label c-chk__label--radio ${state && state.join(' ')}`}
-                for="radio"
+                className={`c-chk__label c-chk__label--radio ${state && state.join(' ')}`}
+                htmlFor="radio"
               >
                 .c-chk__label.c-chk__label--radio
               </label>
-              {hasHint && <span class="c-chk__hint">.c-chk__hint</span>}
+              {hasHint && <span className="c-chk__hint">.c-chk__hint</span>}
               {hasMessage && (
-                <small class={`c-chk__message c-chk__message--${validation}`}>
+                <small className={`c-chk__message c-chk__message--${validation}`}>
                   .c-chk__message
                 </small>
               )}
@@ -106,46 +106,55 @@ in order to logically display under a label heading.
 <Canvas>
   <Story name="Groups">
     {() => (
-      <div class="container">
-        <div class="row">
-          <div class="col u-mt">
-            <legend class="c-txt__label">Checkbox group</legend>
-            <div class="c-chk u-mb-xs">
-              <input class="c-chk__input" id="chk-01" type="checkbox" />
-              <label class="c-chk__label c-chk__label--regular" for="chk-01">
+      <div className="container">
+        <div className="row">
+          <div className="col u-mt">
+            <legend className="c-txt__label">Checkbox group</legend>
+            <div className="c-chk u-mb-xs">
+              <input className="c-chk__input" id="chk-01" type="checkbox" />
+              <label className="c-chk__label c-chk__label--regular" htmlFor="chk-01">
                 .c-chk__label.c-chk__label--regular
               </label>
             </div>
-            <div class="c-chk u-mb-xs">
-              <input class="c-chk__input" id="chk-02" type="checkbox" />
-              <label class="c-chk__label c-chk__label--regular" for="chk-02">
+            <div className="c-chk u-mb-xs">
+              <input className="c-chk__input" id="chk-02" type="checkbox" />
+              <label className="c-chk__label c-chk__label--regular" htmlFor="chk-02">
                 .c-chk__label.c-chk__label--regular
               </label>
             </div>
-            <div class="c-chk">
-              <input class="c-chk__input" id="chk-03" type="checkbox" />
-              <label class="c-chk__label c-chk__label--regular" for="chk-03">
+            <div className="c-chk">
+              <input className="c-chk__input" id="chk-03" type="checkbox" />
+              <label className="c-chk__label c-chk__label--regular" htmlFor="chk-03">
                 .c-chk__label.c-chk__label--regular
               </label>
             </div>
           </div>
-          <div class="col u-mt">
-            <legend class="c-txt__label">Radio group</legend>
-            <div class="c-chk u-mb-xs">
-              <input class="c-chk__input" id="rdo-01" name="rdo-0" type="radio" />
-              <label class="c-chk__label c-chk__label--radio c-chk__label--regular" for="rdo-01">
+          <div className="col u-mt">
+            <legend className="c-txt__label">Radio group</legend>
+            <div className="c-chk u-mb-xs">
+              <input className="c-chk__input" id="rdo-01" name="rdo-0" type="radio" />
+              <label
+                className="c-chk__label c-chk__label--radio c-chk__label--regular"
+                htmlFor="rdo-01"
+              >
                 .c-chk__label.c-chk__label--radio.c-chk__label--regular
               </label>
             </div>
-            <div class="c-chk u-mb-xs">
-              <input class="c-chk__input" id="rdo-02" name="rdo-0" type="radio" />
-              <label class="c-chk__label c-chk__label--radio c-chk__label--regular" for="rdo-02">
+            <div className="c-chk u-mb-xs">
+              <input className="c-chk__input" id="rdo-02" name="rdo-0" type="radio" />
+              <label
+                className="c-chk__label c-chk__label--radio c-chk__label--regular"
+                htmlFor="rdo-02"
+              >
                 .c-chk__label.c-chk__label--radio.c-chk__label--regular
               </label>
             </div>
-            <div class="c-chk">
-              <input class="c-chk__input" id="rdo-03" name="rdo-0" type="radio" />
-              <label class="c-chk__label c-chk__label--radio c-chk__label--regular" for="rdo-03">
+            <div className="c-chk">
+              <input className="c-chk__input" id="rdo-03" name="rdo-0" type="radio" />
+              <label
+                className="c-chk__label c-chk__label--radio c-chk__label--regular"
+                htmlFor="rdo-03"
+              >
                 .c-chk__label.c-chk__label--radio.c-chk__label--regular
               </label>
             </div>

--- a/packages/tags/demo/tags.stories.mdx
+++ b/packages/tags/demo/tags.stories.mdx
@@ -54,13 +54,13 @@ for displaying 10+ notifications. The tag may also contain a child
     }}
   >
     {({ hasAvatar, color, size }) => (
-      <div class="container">
-        <div class="row">
-          <div class="col u-mt">
-            <div class={`c-tag ${size} ${color}`}>
+      <div className="container">
+        <div className="row">
+          <div className="col u-mt">
+            <div className={`c-tag ${size} ${color}`}>
               {hasAvatar && (
                 <svg
-                  class="c-tag__avatar u-bg-grey-600 u-fg-white"
+                  className="c-tag__avatar u-bg-grey-600 u-fg-white"
                   xmlns="http://www.w3.org/2000/svg"
                   width="26"
                   height="26"
@@ -79,11 +79,11 @@ for displaying 10+ notifications. The tag may also contain a child
               </span>
             </div>
           </div>
-          <div class="col u-mt">
-            <div class={`c-tag c-tag--pill ${size} ${color}`}>
+          <div className="col u-mt">
+            <div className={`c-tag c-tag--pill ${size} ${color}`}>
               {hasAvatar && (
                 <svg
-                  class="c-tag__avatar u-bg-grey-600 u-fg-white"
+                  className="c-tag__avatar u-bg-grey-600 u-fg-white"
                   xmlns="http://www.w3.org/2000/svg"
                   width="26"
                   height="26"
@@ -102,11 +102,11 @@ for displaying 10+ notifications. The tag may also contain a child
               </span>
             </div>
           </div>
-          <div class="col u-mt">
-            <div class={`c-tag c-tag--pill ${size} ${color}`}>T</div>
+          <div className="col u-mt">
+            <div className={`c-tag c-tag--pill ${size} ${color}`}>T</div>
           </div>
-          <div class="col u-mt">
-            <div class={`c-tag c-tag--round ${size} ${color}`}>
+          <div className="col u-mt">
+            <div className={`c-tag c-tag--round ${size} ${color}`}>
               {size === 'c-tag--lg' ? 100 : 8}
             </div>
           </div>


### PR DESCRIPTION
## Description

There seems to be local warnings about using camel cased DOM attributes in React. This PR migrates DOM attributes in React to be camel cased.

<img width="886" alt="Screen Shot 2021-04-05 at 2 58 16 PM" src="https://user-images.githubusercontent.com/1811365/113632692-7d492e80-9620-11eb-9f61-5cc97e3a49e7.png">

## Checklist

* [ ] ~:ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)~
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :arrow_left: renders as expected with reversed (RTL) direction
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
