### PR TITLE
chore(bedrock)!: update normalize

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,6 +24,5 @@
 * [ ] :globe_with_meridians: component demo is up-to-date (`yarn start`)
 * [ ] :white_check_mark: all component states are represented
   (`.is-hovered`, `.is-focused`, etc.)
-* [ ] :arrow_left: renders as expected with reversed (RTL) direction
 * [ ] :metal: renders as expected sans Bedrock (`?bedrock=false`)
 * [ ] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11

--- a/packages/bedrock/README.md
+++ b/packages/bedrock/README.md
@@ -4,7 +4,7 @@
 [npm version link]: https://www.npmjs.com/package/@zendeskgarden/css-bedrock
 
 This package provides a mostly reasonable CSS reset layered on top of
-[Normalize.css](http://necolas.github.io/normalize.css/).
+[modern-normalize](https://www.npmjs.com/package/modern-normalize).
 
 ## Installation
 

--- a/packages/bedrock/package.json
+++ b/packages/bedrock/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@zendeskgarden/css-variables": "^6.4.5",
-    "normalize.css": "^8.0.0"
+    "modern-normalize": "^1.0.0"
   },
   "keywords": [
     "components",

--- a/packages/bedrock/src/index.css
+++ b/packages/bedrock/src/index.css
@@ -5,5 +5,5 @@
  * found at http://www.apache.org/licenses/LICENSE-2.0.
  */
 
-@import 'normalize.css';
+@import 'modern-normalize';
 @import '_base';


### PR DESCRIPTION
- [x] **BREAKING CHANGE?** <!-- if so, indicate why under description -->

## Description

Move from `Normalize.css` to `modern-normalize' – a smaller, tested, and more consistent option. While there are no observable differences, this needs to be marked as a BREAKING CHANGE as there may be underlying properties/overrides that certain code depends on or is not expecting.

## Checklist

* [ ] :ok_hand: ~style updates are Garden Designer approved (add the
  designer as a reviewer)~
* [x] :globe_with_meridians: component demo is up-to-date (`yarn start`)
* [x] :white_check_mark: all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
