### PR TITLE
chore: add cache version key for circle ci cache busting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
       - checkout
       - node/install-packages:
           pkg-manager: yarn
+          cache-version: '{{ .Environment.CACHE_VERSION }}'
       - run: yarn --frozen-lockfile --ignore-scripts
       - run: yarn lerna bootstrap
       - run: yarn lerna run build --concurrency=2 # prevent out-of-memory


### PR DESCRIPTION
## Description

This PR adds `CACHE_VERSION` as a mechanism to cache busting.

## Checklist

* [ ] :ok_hand: ~style updates are Garden Designer approved (add the
  designer as a reviewer)~
* [ ] :globe_with_meridians: ~component demo is up-to-date (`yarn start`)~
* [ ] :white_check_mark: ~all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)~
* [ ] :metal: ~renders as expected sans Bedrock (`?bedrock=false`)~
* [ ] :memo: ~tested in Chrome, Firefox, Safari, Edge, and IE11~
