### PR TITLE
feat(bedrock): add anchor focus styles

### DIFF
--- a/.postcssrc.js
+++ b/.postcssrc.js
@@ -9,7 +9,6 @@ module.exports = {
       features: {
         'color-mod-function': true,
         'custom-properties': { preserve: false },
-        'focus-visible-pseudo-class': { preserve: false },
         'system-ui-font-family': false
       }
     },

--- a/packages/bedrock/src/_base.css
+++ b/packages/bedrock/src/_base.css
@@ -50,10 +50,9 @@ u { text-decoration: none; }
 
 a:hover {
   text-decoration: underline;
-  color: var(--zd-anchor-color);
+  color: var(--zd-color-blue-700);
 }
 
-a:hover,
 a:active {
   color: var(--zd-color-blue-800);
 }

--- a/packages/bedrock/src/_base.css
+++ b/packages/bedrock/src/_base.css
@@ -34,24 +34,32 @@ html {
 *::before,
 *::after { box-sizing: inherit; }
 
-a { color: var(--zd-anchor-color); }
+a {
+  transition:
+    outline-color .1s ease-in-out,
+    color .25s ease-in-out;
+  outline: 2px solid transparent;
+  outline-offset: 1px;
+  border-radius: var(--zd-spacing-xxs);
+  color: var(--zd-anchor-color);
+}
 
 a,
 ins,
 u { text-decoration: none; }
 
-a:hover,
-a:focus {
+a:hover {
   text-decoration: underline;
   color: var(--zd-anchor-color);
 }
 
-a:focus { outline: none; }
+a:hover,
+a:active {
+  color: var(--zd-color-blue-800);
+}
 
 a:focus-visible {
-  outline: 2px solid var(--zd-anchor-color);
-  outline-offset: 1px;
-  border-radius: var(--zd-spacing-xxs);
+  outline-color: var(--zd-anchor-color);
   text-decoration: none;
 }
 

--- a/packages/bedrock/src/_base.css
+++ b/packages/bedrock/src/_base.css
@@ -49,7 +49,7 @@ a:focus {
 a:focus { outline: none; }
 
 a:focus-visible {
-  outline: calc(var(--zd-spacing-xxs) - 1px) solid var(--zd-color-blue-600);
+  outline: calc(var(--zd-spacing-xxs) - 2px) solid var(--zd-color-blue-600);
   outline-offset: calc(var(--zd-spacing-xxs) - 3px);
   border-radius: var(--zd-spacing-xxs);
   text-decoration: none;

--- a/packages/bedrock/src/_base.css
+++ b/packages/bedrock/src/_base.css
@@ -13,7 +13,7 @@
 }
 
 /* 1. Ensure the page always fills at least the entire viewport height.
- * 2. Force visible scrollbars to prevent awkard jumps when navigating between
+ * 2. Force visible scrollbars to prevent awkward jumps when navigating between
  * pages that do/don't have enough content to produce natural scrollbars. */
 html {
   background-color: var(--zd-html-background-color);
@@ -47,6 +47,17 @@ a:focus {
 }
 
 a:focus { outline: none; }
+
+a:focus-visible {
+  outline: calc(var(--zd-spacing-xxs) - 1px) solid var(--zd-color-blue-600);
+  outline-offset: calc(var(--zd-spacing-xxs) - 3px);
+  border-radius: var(--zd-spacing-xxs);
+  text-decoration: none;
+}
+
+a:focus-visible:hover {
+  text-decoration: underline;
+}
 
 b { font-weight: var(--zd-font-weight-semibold); }
 

--- a/packages/bedrock/src/_base.css
+++ b/packages/bedrock/src/_base.css
@@ -49,8 +49,8 @@ a:focus {
 a:focus { outline: none; }
 
 a:focus-visible {
-  outline: calc(var(--zd-spacing-xxs) - 2px) solid var(--zd-color-blue-600);
-  outline-offset: calc(var(--zd-spacing-xxs) - 3px);
+  outline: 2px solid var(--zd-anchor-color);
+  outline-offset: 1px;
   border-radius: var(--zd-spacing-xxs);
   text-decoration: none;
 }


### PR DESCRIPTION
## Description

Updating `css-bedrock` with new focus treatment for `<a>` tags.

## Detail

- Modifies the postcss configuration to use native `:focus-visible`
- Updates bedrock CSS to include focus styles for anchor with a `2px` `outline` (instead of `box-shadow`)
- Transition and color weights have parity with `react-components`

![focus-visible](https://github.com/zendeskgarden/css-components/assets/12474067/f7b5606e-cfb5-4564-99aa-a64027552bf8)

## Checklist

* [ ] :ok_hand: style updates are Garden Designer approved (add the
  designer as a reviewer)
* [ ] :globe_with_meridians: ~component demo is up-to-date (`yarn start`)~
* [ ] :white_check_mark: ~all component states are represented
  (`.is-hovered`, `.is-focused`, etc.)~
* [x] :metal: renders as expected sans Bedrock (`?bedrock=false`)
* [x] :memo: tested in Chrome, Firefox, Safari, Edge, and IE11
